### PR TITLE
docs: de-hype slice 1 — technicalize body prose (README + RFC-1 program docs)

### DIFF
--- a/.design/m0-spikes.md
+++ b/.design/m0-spikes.md
@@ -182,15 +182,14 @@ emission conventions, the reference-style mimics
 `lean/Thermite/RefEncode.lean`'s — the two real columns the stage-2 TV
 will eventually compare. The hand-work is bounded *per combinator
 shape* (≤8 shapes), then instantiated across the 4 corpus clauses plus
-generator-drawn instances (read out of the existing `gen_combinator` —
+generator-drawn instances (read out of the existing `gen_combinator`;
 no new generator productions, those are stage-2 binder work) so the
-threshold-bearing denominator is meaningful rather than n=4. This is the
-plan analysis's most material correction: a 90% bar over 4 clauses is
-4/4, which the corpus alone cannot support. This mimicry is the probe's known
-approximation, and it biases the measured hit rate *downward* if
-anything (real stage-2 emitters can be nudged toward convergence,
-fallback F-C step 1), so a high measured rate is trustworthy evidence
-and a low one triggers the design issue — the asymmetry is safe.
+threshold-bearing denominator is larger than n=4. A 90% bar over 4
+corpus clauses is effectively 4/4, which is why the generator-drawn
+instances are needed. The mimicry is an approximation: it biases the
+measured hit rate downward (real stage-2 emitters can be converged
+toward each other, fallback F-C step 1), so a high measured rate is
+trustworthy and a low one triggers the design issue.
 
 **What the spikes deliberately do not do:** no soundness lemmas for the
 normalizer passes, no `Strat/` modules, no classifier, no changes to

--- a/.design/stage1-forge-tier.md
+++ b/.design/stage1-forge-tier.md
@@ -6,9 +6,9 @@ Stage 1 of the RFC-1 program: the kernel proof tier (RFC-1 §5 — covenant,
 frozen battery, anti-Goodhart at L3, the `Stuck`/`KernelBudget`/
 `CovenantRefuted` verdicts) plus nlsat real-relaxation routing with
 `RealWitness` (RFC-1 §4). No spine change beyond the small Mathlib-island
-relax lemmas; the cage remains the v1 combinator menu. The headline that
-lands at gate G1: out-of-cage no longer degrades down the ladder — it
-escalates up to the forge. This doc covers the program plan §2's nine work
+relax lemmas; the cage remains the v1 combinator menu. The behavioral
+change at G1: out-of-cage clauses escalate up to the forge instead of
+degrading down the ladder. This doc covers the program plan §2's nine work
 items as REQ clusters, grounded against the tree at `c46da3ac`, with the
 Q-register defaults (Q1–Q4, Q6–Q8) adopted inline. Umbrella:
 `.design/thermite2-program.md` (REQ-3); predecessor gate: M0

--- a/.design/stage3-bv-reconstruction.md
+++ b/.design/stage3-bv-reconstruction.md
@@ -30,7 +30,7 @@ where the fragment supports it, migrating cage clauses' trust base from
 solver to kernel without touching their rung — the C4 grid honesty,
 delivered through the `trust:` field. The bv half is the program's one
 permanent semantic fork and its one new gaming vector; it is staged
-last for exactly that reason, and fallback F-F's whole ladder remains
+last for that reason, and fallback F-F's ladder remains
 open until the re-pass. Umbrella: `.design/thermite2-program.md`
 (REQ-10).
 

--- a/.design/thermite2-program.md
+++ b/.design/thermite2-program.md
@@ -189,11 +189,10 @@ The v1 toolchain this program extends is shipped and audited in-tree:
 - **Doc-drift tooling** — the tripwire gate landed post-baseline
   (#258–#262, governed by `.design/tooling/doc-drift-tripwire.md`). Audit
   check [4′] (drift rows for the three new mirrored Rust files) extends
-  this existing mechanism instead of inventing one — a delta in the
-  program's favor.
+  this existing mechanism rather than inventing one.
 - **CI** — `.github/workflows/ci.yml` has no Lean job today; the Lean
-  build is currently un-CI'd, which is exactly why debt item (a) is a
-  pre-M1 blocker: from M1 the Lean build is load-bearing per-certificate.
+  build is currently un-CI'd, which is why debt item (a) is a
+  pre-M1 blocker: from M1 the Lean build is checked per-certificate.
 
 ### Stage → surface map
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## The problem
 
-When an AI writes code for you, how do you know it's right? Today the answer is "read it yourself" or "trust the vibes." Neither scales. Code review by humans is exactly the bottleneck AI was supposed to remove — and "the tests pass" only tells you about the cases somebody thought to test.
+When an AI writes code for you, how do you know it's right? Today the answer is "read it yourself" or "trust the vibes." Neither scales. Code review by humans is the bottleneck AI was supposed to remove — and "the tests pass" only tells you about the cases somebody thought to test.
 
 Formal verification — *mathematically proving* code correct — has existed for decades. It never caught on, because writing the proofs is miserable for humans. But AI agents don't get bored, don't get tired, and pay for effort in cheap compute instead of expensive attention. **Thermite's bet: agents flip the economics of proof.** Burn the cheap resource (tokens) to buy the expensive one (trust).
 
@@ -39,7 +39,7 @@ It always aims for L3 and only slides down honestly. One thing never slides: if 
 
 **How an agent actually writes it.** Like a conversation. Declare the contract first with a hole where the body goes (literally `?0` — a [typed hole](RATIONALE.md#typed-holes-n--the-goal-repl), the Agda/Idris/Lean-`sorry` idea). `forge goal` shows what's given and what must be achieved. `forge fill` drops code into the hole and immediately re-checks — failures come back as concrete counterexamples, not vibes. Repeat until: `ALL GOALS DISCHARGED ✓ certified L3`. A program with an unfilled hole physically cannot be built or certified.
 
-Under the hood, Thermite translates to Rust (annotated for the [Verus](https://github.com/verus-lang/verus) prover, which uses the Z3 logic engine), so it inherits Rust's compiler, optimizer, and ecosystem. The specification language is a deliberately small [caged quantifier fragment](RATIONALE.md#the-combinator-cage) — a fixed set of bounded combinators with frozen SMT triggers, no raw `forall` — and that small, [frozen subset](RATIONALE.md#the-frozen-subset-the-central-design-why) is precisely what makes the machine-checked soundness proof below feasible. The full design rationale lives in [`thermite-design.md`](./thermite-design.md).
+Under the hood, Thermite translates to Rust (annotated for the [Verus](https://github.com/verus-lang/verus) prover, which uses the Z3 logic engine), so it inherits Rust's compiler, optimizer, and ecosystem. The specification language is a deliberately small [caged quantifier fragment](RATIONALE.md#the-combinator-cage) — a fixed set of bounded combinators with frozen SMT triggers, no raw `forall` — and that small, [frozen subset](RATIONALE.md#the-frozen-subset-the-central-design-why) is what makes the machine-checked soundness proof below feasible. The full design rationale lives in [`thermite-design.md`](./thermite-design.md).
 
 ## The proof it isn't a toy
 
@@ -96,7 +96,7 @@ A run with a skipped guarantee prints **INCONCLUSIVE** and exits nonzero — it 
 
 ## "But how do you know the *translation* is honest?"
 
-The sharpest possible objection: Thermite translates your code into the prover's language — so a buggy translator could prove the wrong statement. Promise `=`, prove `≤`, certificate says L3, everyone goes home happy and wrong.
+The hardest objection: Thermite translates your code into the prover's language — so a buggy translator could prove the wrong statement. Promise `=`, prove `≤`, certificate says L3, everyone goes home happy and wrong.
 
 Two answers, both machine-checked:
 


### PR DESCRIPTION
First slice of the de-hype pass (#287, umbrella issue on GitHub: #6).

## Standard applied

Default to precise technical claims; keep narrative flair only in **localized intro/conclusion sections**. The README's opening thermite metaphor stays (it's the project's identity); body and mechanism prose gets technicalized. **No change to any claim, requirement, acceptance criterion, identifier, or structure** — tone only.

## Changes (5 files)

- **README.md** — "exactly the bottleneck" → "the bottleneck"; "The sharpest possible objection" → "The hardest objection"; "precisely what makes … feasible" → "what makes … feasible". (Metaphor and overall pitch intact.)
- **.design/thermite2-program.md** — dropped "— a delta in the program's favor" and "which is exactly why".
- **.design/m0-spikes.md** — dropped "the plan analysis's most material correction" and "the asymmetry is safe" framing; kept the engineering rationale (why n=4 is insufficient, the downward bias).
- **.design/stage1-forge-tier.md** — "The headline that lands at gate G1" → "The behavioral change at G1".
- **.design/stage3-bv-reconstruction.md** — dropped "for exactly that reason" / "whole ladder".

(stage2-stratified-cage.md was already technical — no change.)

## Scope / next slices

Sampling found the docs more disciplined than a broad "hype" sweep implies — `RATIONALE.md` actively hedges its claims. So this is a measured dial-down, not a rewrite. Remaining slices:
- **Slice 2**: body prose in the public docs (`RATIONALE.md`, `thermite-design.md`) and the other `.design/` areas — more judgment-heavy, public-facing.
- **Slice 3**: source comments (`*.rs`/`*.lean`) — emphatic ALL-CAPS and editorializing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)