### PR TITLE
docs: external-facing docs/ tree (foundation)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Thermite documentation
+
+Thermite is a programming language for AI agents. Every function carries an
+enforced contract, every contract clause is checked, and the result ships as a
+certificate a third party can re-derive.
+
+- [Overview](overview.md) — the problem Thermite addresses and how the
+  assurance ladder works.
+- [Language](language.md) — the three contract promises (`req`/`ens`/`fx`), the
+  surface syntax, and how an agent writes a function.
+- [Verification](verification.md) — the proof ladder, translation validation,
+  and the two proof engines.
+- [Trust](trust.md) — what remains trusted, and how `make audit` re-derives the
+  rest on your machine.

--- a/docs/language.md
+++ b/docs/language.md
@@ -1,0 +1,51 @@
+# Language
+
+## Three promises
+
+Every function carries three promises, enforced as syntax. Leaving one out is a
+compile error:
+
+- `req` — what must hold before the function is called (e.g. "the list is sorted").
+- `ens` — what the result guarantees (e.g. "if it returns an index, the element is there").
+- `fx` — what the function may touch (e.g. "nothing — pure", or "may read this file").
+
+Loops add `inv` (the loop invariant) and `dec` (the termination measure).
+
+```thermite
+fn sum(xs: &[u32]) -> u64
+  req xs.len() <= 1_000_000
+  ens result == spec_sum(xs)
+  fx  pure
+{
+  let mut acc: u64 = 0;
+  let mut i: usize = 0;
+  while i < xs.len()
+    inv acc == spec_sum(&xs[..i])
+    dec xs.len() - i
+  {
+    acc = acc + xs[i] as u64;
+    i = i + 1;
+  }
+  acc
+}
+```
+
+## The specification language
+
+Contract-position expressions stay inside a small fragment: a fixed set of
+bounded quantifier combinators with frozen SMT triggers, and no raw `forall`.
+The fragment is small enough to make the machine-checked soundness proof
+([Verification](verification.md)) feasible, and to keep the whole surface
+teachable to a model within a fixed token budget. `THERMITE.skill.md` is the
+generated, budget-checked language reference.
+
+## How a function is written
+
+The workflow is incremental. Declare the contract with a hole where the body
+goes (`?0`, a typed hole). `forge goal` shows what is given and what must hold;
+`forge fill` puts code in the hole and re-checks, returning a counterexample on
+failure. Repeat until `forge check` reports `ALL GOALS DISCHARGED ✓ certified
+L3`. An item with an unfilled hole cannot be built or certified.
+
+`forge build` compiles a certified program to a native binary, with the
+`fx`-derived syscall cage enabled ([Trust](trust.md)).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,38 @@
+# Overview
+
+## The problem
+
+When an AI writes code, the question is whether it is correct. The usual
+answers are "read it yourself" or "trust that the tests pass." Reading does not
+scale — human review is the bottleneck AI was supposed to remove — and passing
+tests only cover the cases someone thought to test.
+
+Formal verification — mathematically proving code correct — has existed for
+decades. It never caught on because writing the proofs is expensive for humans,
+who pay for it in attention. Agents pay in compute, which is cheap and parallel.
+Thermite's premise is that this changes the economics of proof: spend the cheap
+resource (tokens) to buy the expensive one (trust).
+
+Thermite is therefore strict in a way no human would tolerate, because humans
+are not the intended author. People decide what the software should do and read
+the resulting certificates; the agent writes the proofs.
+
+## The assurance ladder
+
+Each contract clause is graded on a four-rung ladder. `forge`, the toolchain,
+aims for the top rung and records where each clause landed.
+
+| Rung | Meaning |
+|---|---|
+| **L3** | A machine-checked proof that the clause holds for every input. (SMT-backed deductive verification via the Verus prover and the Z3 solver.) |
+| **L2** | Proven for all inputs up to a stated size. (Bounded model checking, via Kani/CBMC.) |
+| **L1** | Checked while the program runs; a violation stops it. (Runtime contract monitoring.) |
+| **L0** | Trusted by fiat — the `#[slag]` escape hatch, greppable so the trusted lines are enumerable. |
+
+A function's level is the minimum over its clauses. A counterexample — a
+concrete input where a clause fails — is a hard failure; it is never recorded
+as a lower grade.
+
+The rungs correspond to four established verification techniques. [Verification](verification.md)
+covers how L3 is discharged and re-checked; [Trust](trust.md) covers what
+remains trusted after a clean run.

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -1,0 +1,45 @@
+# Trust
+
+## The runtime cage
+
+`fx` is enforced at runtime as well as statically. When you build a binary,
+Thermite derives a syscall filter (seccomp-BPF, the kernel mechanism Docker and
+Chrome use) from the declared effects. A function that declared `pure` and then
+opens a network connection is killed by the OS mid-syscall. The static effect
+check and the runtime cage come from the same `fx` declaration.
+
+## Re-deriving the trust chain
+
+`make audit` re-derives the chain on your machine:
+
+```sh
+make audit        # the full re-derivation (minutes)
+make audit-fast   # a 60-second demonstration (one program, one injected bug)
+```
+
+The fast version: a correct program certifies; the same program with one
+injected bug is refused with a counterexample; and the emitted proof re-verifies
+under an independent copy of the prover with the Thermite tooling excluded.
+
+The full version re-checks every link: your own Lean proof checker re-verifies
+the central theorem, the translation cross-checks re-run over the test corpus
+(thousands of live proof obligations), and the sabotage tests re-run to confirm
+the prover catches each known class of translation bug. It then prints the list
+of what remains trusted. A run with a skipped check prints `INCONCLUSIVE` and
+exits nonzero.
+
+## What remains trusted
+
+After a clean run, five items remain trusted:
+
+1. The Lean kernel and its three standard axioms (`propext`, `Classical.choice`,
+   `Quot.sound`).
+2. Z3/Verus soundness (a kernel-replay proof-of-concept already covers the
+   scalar-linear fragment).
+3. The gap between the formal specification and the author's intent — answered
+   by reading the declarative spec layer, not closed by machine.
+4. The pinned Rust↔Lean correspondence inspection.
+5. rustc and LLVM.
+
+Everything else is re-derived on your machine. A trust statement is only useful
+if it enumerates its assumptions, which is what this list is.

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,48 @@
+# Verification
+
+## What the ladder rungs mean
+
+L3, the top rung, is a machine-checked proof that a clause holds for every
+input, discharged by the Verus prover emitting verification conditions to the
+Z3 solver. L2 is bounded model checking (Kani/CBMC) up to a stated size. L1 is
+runtime contract monitoring. L0 is a trusted-by-fiat `#[slag]` annotation.
+[Overview](overview.md) has the full table.
+
+## Grading the contract, not only the proof
+
+A clause that asserts nothing (`ens true`) would pass trivially. Every contract
+therefore goes through an anti-Goodhart battery: it is checked for emptiness
+(vacuity detection), then run against mutant copies of the code that introduce
+bugs (mutation testing). A contract that fails to catch the mutants is rejected.
+Mandatory contracts are the precondition for this: a tool that grades contract
+strength is meaningless if a function can score by declaring no contract.
+
+## Translation validation
+
+Thermite translates source into the prover's language, so a faulty translator
+could prove the wrong statement. Two mechanisms check the translation, both
+machine-checked:
+
+1. **Per run.** A second, independent translator (kept from sharing code with
+   the first by the build system) re-translates the contracts and bodies, and
+   Z3 must prove the two translations equivalent on your program.
+2. **Across all programs.** That independent translator is small enough to prove
+   correct in Lean. The theorem (`lean/`, `Thermite.lowering_faithful`) states
+   that every program passing the cross-check is translated meaning-for-meaning;
+   it is quantified over all programs and re-checkable by your own Lean kernel
+   (audit check [1] in [Trust](trust.md)). Each translation bug previously found
+   by testing is refuted by that theorem.
+
+This is the verified-validator architecture from the compiler-verification
+literature (the CompCert lineage). Thermite's meaning is defined by the Lean
+semantics; Verus is the first proof engine against it, proven faithful.
+
+## Two proof engines
+
+L3 obligations are discharged by Verus by default, or by Lean under
+`forge check --engine lean|auto`. The Lean path is kernel-checked, with a replay
+that rejects `sorry` and non-standard axioms. Each certificate records which
+engine proved each obligation and under which trust assumptions. If the two
+engines disagree on the same obligation — one proves it, the other produces a
+counterexample — `forge` halts with a soundness alarm rather than resolving the
+disagreement by preference.


### PR DESCRIPTION
Slice 3a of the docs work (#287). A structured, tone-controlled `docs/` tree for external readers, decoupled from `.design/` (which stays internal/historical). Content restructured from the already-tone-passed README — no claims/mechanisms changed, just reorganized into a reader's path.

## Adds
- `docs/index.md` — entry + map
- `docs/overview.md` — the problem, the premise, the assurance ladder
- `docs/language.md` — `req`/`ens`/`fx`, the spec fragment, the hole workflow
- `docs/verification.md` — the ladder, anti-Goodhart battery, translation validation, two engines
- `docs/trust.md` — the runtime cage, `make audit`, the residual-trust list

All five are free of `.design/` references; internal links resolve within `docs/`.

## Follow-up (next slice)
- `docs/rationale.md`: move RATIONALE in and strip its ~38 woven-in `.design` pointers — a careful content pass, deliberately not rushed here.
- Trim `README.md` to a short entry that points into `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)