### PR TITLE
docs: bake tone-and-voice into the build workflow + comment-pass plan

### DIFF
--- a/.claude/agents/acto-builder.md
+++ b/.claude/agents/acto-builder.md
@@ -40,6 +40,8 @@ Write production code AND tests in the same change set. Discipline:
 ### Step 4 — Update the design-doc REQ status
 In the module's `//!` doc-comment, add/update the `## REQ status` table — every REQ SHIPPED (impl symbol + non-test consumer symbol + verification) or NOT-STARTED (open blocker #). Two states only. Mirror it in the governing `.design/<doc>.md`.
 
+Comments and doc-comments follow **R-TONE-1** / `.design/tone-and-voice.md`: plain technical prose, no emphatic ALL-CAPS or virtue adverbs, `exactly`/`precisely` only where they disambiguate. Tonal residue in comments is what later agents drift on.
+
 ### Step 5 — Gauntlet (MUST pass before commit)
 ```bash
 cargo test -p <crate>

--- a/.claude/agents/acto-doc-author.md
+++ b/.claude/agents/acto-doc-author.md
@@ -75,6 +75,7 @@ thesis-refs:
 - **Stay on the current git branch.** Never `git switch` / `git checkout -b` / `git branch`; write/commit your design docs on the branch you were dispatched on (normally `main`). Branching is the orchestrator's job.
 - **Clean up scratch.** Remove any throwaway files before finishing (or keep them under `/tmp`). No stray files left in the tree.
 - **No CHANGELOG pollution.** If you ever `crosslink issue close <id>`, pass `--no-changelog`. If a `CHANGELOG.md` appears, delete it.
+- **Tone (R-TONE-1).** Prose follows `.design/tone-and-voice.md`: affirmative not defensive, plain not emphatic, narrative only in intros/conclusions. No antithesis pairs ("not X — Y"), virtue adverbs ("honestly"/"loudly"), rhetorical bold/ALL-CAPS for emphasis, or `exactly`/`precisely` as emphasis (only where they disambiguate). Credibility comes from the content.
 
 ## Report (max 400 words)
 Doc path, LOC, REQ breakdown (N SHIPPED / M NOT-STARTED), route added/updated, new blockers filed, surprises, and an honest note on which SHIPPED claims you are LEAST confident about.

--- a/.design/tone-and-voice.md
+++ b/.design/tone-and-voice.md
@@ -27,6 +27,15 @@ with an imagined skeptic. Remove that register.
   countermodel on failure" beats "every failure is a concrete counterexample,
   the property the whole ladder ranks by."
 
+`exactly` deserves a claim-by-claim check rather than blanket removal. It is
+technical when it disambiguates — "passes exactly when no out-of-domain bit is
+set" is an iff — and tonal otherwise: "computes exactly the relation," "exactly
+the IO-membership projection." Strip the tonal use; often the precise verb or
+noun was the real claim all along ("the IO-membership projection"). In code
+comments this matters twice over — residual emphasis is what a downstream agent
+anchors on and drifts toward, so removing it keeps later work from reading
+meaning into tone.
+
 ## Narrative stays localized
 
 - A brief metaphor or narrative is welcome in introductions and conclusions —

--- a/.design/tone-comment-pass-plan.md
+++ b/.design/tone-comment-pass-plan.md
@@ -1,0 +1,101 @@
+# Plan: deep tone pass over all source comments
+
+A handoff plan for a fresh session. The work is a deep, judgment-based tone pass
+over **every source comment** in the repo (Rust + Lean), applying
+`.design/tone-and-voice.md`. It is a register change only — no code, no
+identifiers, no semantics move.
+
+This is the gated base: other work pauses until this lands, then rebases onto
+it. So edit freely across all crates on one branch; there is no concurrent-churn
+constraint while this is the active slice.
+
+## The standard
+
+`.design/tone-and-voice.md` is authoritative. In one line: affirmative not
+defensive, plain not emphatic, narrative only in intros/conclusions, substance
+preserved. For comments specifically, the targets are:
+
+- **Emphatic ALL-CAPS** used for emphasis (`ACTUALLY RUNS`, `THE TRUST
+  BOUNDARY`, `NEVER`, `MUST`) → normal case. Keep ALL-CAPS only for real
+  acronyms (SMT, JSON, EPR) and established status labels the schema depends on
+  (e.g. `SHIPPED`/`NOT-STARTED` in REQ tables, enum variants).
+- **Virtue adverbs** (`honestly`, `loudly`, `cleanly`) → cut; describe the
+  behavior.
+- **Antithesis pairs** (`not X — Y`, `X, not Y`, `not just X but Y`) → state the
+  positive claim directly, unless the contrast is a genuine technical
+  disambiguation.
+- **Rhetorical bold** and **cute asides** → cut.
+- **`exactly` / `precisely`** → claim-by-claim judgment, not blanket removal.
+  Keep where it disambiguates (`passes exactly when no out-of-domain bit is
+  set` is an iff). Strip where it is tonal (`computes exactly the relation`,
+  `exactly the IO-membership projection`) — often the precise verb or noun was
+  the real claim. This matters twice over in comments: residual emphasis is what
+  a downstream agent anchors on and drifts toward.
+
+## Hard constraints
+
+- **Comments only.** No change to code, identifiers, string literals, test
+  expectations, or behavior. Doc-comments (`///`, `//!`), line comments (`//`),
+  block comments, and Lean `--`/`/- -/` are in scope.
+- **No semantic change.** "The certificate honestly says PARTIAL" → "says
+  PARTIAL" is fine; never alter what a comment asserts about the code.
+- **Status labels and schema-bearing text stay.** REQ-status tables, enum
+  names, the `## REQ status` doc-comment tables, and any text other tooling
+  parses (doc-drift `audited-sha:` blocks, etc.) are untouched.
+- **Verify per file/crate:** `git diff` shows only comment-line changes; the
+  crate still builds and tests pass (`cargo test -p <crate>`); Lean edits leave
+  `lake build` unaffected (comments do not affect proofs).
+
+## Scope and rough sizing
+
+Raw "tic" greps overstate, because precise `exactly`/`deliberately` uses are
+legitimate. Treat these as upper bounds, not work units:
+
+| crate / tree | ~tic-marked comment lines |
+|---|---|
+| `thermite-verified` | ~5 (mostly precise; little to do) |
+| `thermite-spec` | ~28 |
+| `thermite-syntax` | ~41 |
+| `thermite-tv` | ~55 |
+| `lean/` | ~83 |
+| `thermite-lower` | ~116 |
+| `forge` | ~212 |
+
+The genuinely performative comments concentrate in `forge`, `thermite-lower`,
+`lean/` (ALL-CAPS-heavy module banners, "ACTUALLY RUNS"-style emphasis).
+
+## Recommended execution: a workflow
+
+Merge-hell is gated away, so parallelism is safe. Suggested shape:
+
+- One agent per crate (or per large module for `forge`), instructed to apply
+  `.design/tone-and-voice.md` to comments with the `exactly` judgment above.
+- Each paired with an **adversarial verifier** that checks the diff is
+  comments-only and asserts no semantic/identifier change — the one real risk.
+- All on one branch; PR when the tree is covered. Commit per crate so review and
+  any revert are crate-scoped.
+
+Inline crate-by-crate is the fallback (slower, serial). Either way: one branch,
+gated, rebased onto by everything else after it lands.
+
+## Order
+
+Smallest/cleanest first to set the pattern, then the heavy crates:
+`thermite-verified` → `thermite-spec` → `thermite-syntax` → `thermite-tv` →
+`lean/` → `thermite-lower` → `forge`.
+
+## Done when
+
+Every crate's comments read as plain technical prose under the standard; the
+full workspace builds and tests green; `lake build` green; the branch is one
+coherent PR (or per-crate PRs) for review, ready to be the rebase base.
+
+## Context already done (do not redo)
+
+- Public docs (README, RATIONALE, thermite-design) — tone-passed and merged (#9).
+- Root `.design/` thermite-2 docs + the standard — merged (#10).
+- `docs/` external tree foundation — merged (#11).
+- `.design/` **subdir** docs — left as historical artifacts; **out of scope**.
+- The build workflow now carries **R-TONE-1** (`goal.md`) and tone references in
+  the `acto-doc-author` / `acto-builder` agents, so new/rewritten prose follows
+  the standard going forward.

--- a/goal.md
+++ b/goal.md
@@ -144,6 +144,9 @@ Close the crosslink issue (`--kind result` comment first).
 - **R-CODE-4**: no swallowing of solver/subprocess failures. Verus/Kani/Z3 invocations check exit status and surface structured errors; a timeout degrades the ladder (L3→L2→L1) and is reported, never silently treated as success.
 - **R-CODE-5**: determinism is a contract — no `Date`/wall-clock/un-seeded randomness in build, format, codegen, or check paths. Solver seeds are pinned in the lockfile (design §5.3).
 
+### Prose & tone
+- **R-TONE-1**: prose — doc comments, design docs, and module/header comments — follows [`.design/tone-and-voice.md`](.design/tone-and-voice.md): affirmative not defensive, plain not emphatic, narrative only in intros/conclusions. No antithesis pairs ("not X — Y"), virtue adverbs ("honestly"/"loudly"), rhetorical bold/ALL-CAPS for emphasis, or cute asides. `exactly`/`precisely` only where they disambiguate (e.g. an iff), not as emphasis. This is a register rule; it never changes a claim, identifier, or guarantee.
+
 ### Spec-mirror (default = match the design contract; deviate only for these)
 - **R-SPEC-1 (MATCH — surface semantics)**: the surface grammar, mandatory `req`/`ens`/`fx` and `inv`/`dec`, the SpecTherm combinator set and their frozen triggers, and the ladder semantics match `thermite-design.md` §4/§6 exactly. "One way to do everything" (pillar §2.3) — no alternate syntaxes, no config knobs the design doesn't sanction.
 - **R-SPEC-2 (MATCH — certificate contract)**: certificate/manifest fields, assurance levels (L0–L3), vacuity-battery outputs, and `#[slag]` metadata match the design (§6, §7, §8, Appendix A). The certificate IS the deliverable; its shape is a contract.


### PR DESCRIPTION
Two things ahead of the all-crate comment tone pass (#287).

## 1. Bake the standard into the build workflow

So new and rewritten prose follows `.design/tone-and-voice.md` automatically:

- **`goal.md`** — adds **R-TONE-1** (prose follows the standard; the specific tics named; `exactly`/`precisely` only where they disambiguate; register-only, never changes a claim).
- **`acto-doc-author` / `acto-builder`** agents — tone references pointing at R-TONE-1, so the doc-writer and code/comment-writer produce clean prose.
- **`tone-and-voice.md`** — folds in the claim-by-claim `exactly` judgment (strip tonal "exactly the X"; keep disambiguating "exactly when …"). Stripping the tonal residue keeps downstream agents from anchoring on emphasis that isn't semantically there.

## 2. The comment-pass handoff plan

`.design/tone-comment-pass-plan.md` — self-contained so a fresh session can run the deep all-crate source-comment pass without this session's context: the standard, the hard constraints (comments-only, no semantic/identifier change, verify diffs), per-crate sizing, the recommended workflow shape (one agent per crate + an adversarial verifier that confirms comments-only and no semantics moved), the crate order, and what's already done. The pass is the gated base everything rebases onto once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)