### PR TITLE
Fix doc-drift topology nondeterminism

### DIFF
--- a/.design/basis/02-recursion-schemes.md
+++ b/.design/basis/02-recursion-schemes.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 43291810d971e4cc098634064b4dc6cab27a137896fe902a11140b6727d009c8
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/04-collections.md
+++ b/.design/basis/04-collections.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 65550d4d1c1053a44b3367dd4d2ffc4265d95a3d0fe886c0a01d238ae46c17e4
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/06-provenance-and-sinks.md
+++ b/.design/basis/06-provenance-and-sinks.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: e4753c80bb05b7b6a8ff52b9b83e45e572d977a983ec059bbd9faa4c0c96b086
 governs: thermite-spec/src/validator.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/07-strings.md
+++ b/.design/basis/07-strings.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 65550d4d1c1053a44b3367dd4d2ffc4265d95a3d0fe886c0a01d238ae46c17e4
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/08-runnable-effect-link.md
+++ b/.design/basis/08-runnable-effect-link.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: dd778c62acb9efa69deb252357583a83b047df346178728cfcae520182548300
 governs: forge/src/build.rs
 governs: forge/src/effect_wrappers.rs
 (the thermite-stdlib/src/effect/* paths this doc originally listed were never

--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed files (check.rs, review.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no Option/Result lowering or semantics changed, net-additive, v1 behavior unchanged. prior: 87797224ba72e12a3734d93e3cb0300f20333bb4)
+audited-content-sha256: b0545106e3203ac642083ce1f78baeddf18e6343d4a3066bac6ee6b3b805a288
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/10-recursion-tuples.md
+++ b/.design/basis/10-recursion-tuples.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 65550d4d1c1053a44b3367dd4d2ffc4265d95a3d0fe886c0a01d238ae46c17e4
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed files (check.rs, review.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no C10 ergonomics logic changed, net-additive, v1 behavior unchanged. prior: 87797224ba72e12a3734d93e3cb0300f20333bb4)
+audited-content-sha256: b0545106e3203ac642083ce1f78baeddf18e6343d4a3066bac6ee6b3b805a288
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (check.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no mutual-recursion / dec-group logic changed, net-additive, v1 behavior unchanged. prior: ddbbb3ccea18276103fc268297c4d9190a1ee385)
+audited-content-sha256: a50c62ed9811fd2b5d86fe1bbddecf0b18139f2406c5e3ef3f8d93e57b91bd95
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/basis/13-map.md
+++ b/.design/basis/13-map.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 65550d4d1c1053a44b3367dd4d2ffc4265d95a3d0fe886c0a01d238ae46c17e4
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/boundary/ffi-boundary.md
+++ b/.design/boundary/ffi-boundary.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 74a2b91c5adabf57d066982c4a0d472c4f75aa22 (bootstrap pin: decision 4 — doc-last-touch, NOT verified-current; backlog #262)
+audited-content-sha256: 4b20282becd50929b400e4d55087505139c7fc2f8a3a6bc7615c670d74ba8209
 governs: thermite-syntax/src/ast.rs, thermite-syntax/src/parser.rs, thermite-lower/src/l1.rs, forge/src/check.rs, forge/src/manifest.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/build/kernel-target.md
+++ b/.design/build/kernel-target.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: c135b797e2828f43a3073c8f83514d212cb7b593a32e7d5fce08ae099fe386fa
 governs: forge/src/build.rs
 thesis-refs:
   - thermite-design.md §3 (the stack — transpile to Rust, rustc is the codegen backend; the #21 realization note)

--- a/.design/forge/audit-manifest.md
+++ b/.design/forge/audit-manifest.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 1cc9d97c6c5d7eab6109561834db77f2ef4b57ab (re-pinned 2026-06-16: forge workflow status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (#274 — lean_fragment membership report; REQ-7..10 SHIPPED, audit.rs verified-current))
+audited-content-sha256: ef967c1b7caecbfdfffcdc2d17f5a398bebe7e7f567796299130e316f2cfe479
 governs: forge/src/audit.rs
 thesis-refs:
   - thermite-design.md §6

--- a/.design/forge/build.md
+++ b/.design/forge/build.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: c135b797e2828f43a3073c8f83514d212cb7b593a32e7d5fce08ae099fe386fa
 governs: forge/src/build.rs
 thesis-refs:
   - thermite-design.md §3

--- a/.design/forge/certificate-manifest.md
+++ b/.design/forge/certificate-manifest.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: a728d95ca3dbd4fbbee1cb496c003f408d82f327 (re-pinned 2026-06-16 for stage-1 increment 2f, REQ-8: the only change to this doc's governed file (manifest.rs) is the additive Level::L4 kernel-grounded rung (REQ-S1-8); the relax route is reached only via --engine nlsat, so the v1 corpus stays L3 and oracle_subset is byte-identical (check_conformance green).)
+audited-content-sha256: 1270e405fbfb3e25ecaef9e739a9e7f7f0a4ef6a229bb267e16f38d9ae05b39c
 governs: forge/src/manifest.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (check.rs) is the additive stage-1 increment 3 REQ-9 passes — apply_lemma_library (certified-only citation refusal + dedup-on-burn rewrite) and the dec wf accessibility write-through — both forge/Lean-path only; the default Verus path + v1 corpus are byte-identical (REQ-S1-9). prior: a728d95ca3dbd4fbbee1cb496c003f408d82f327)
+audited-content-sha256: 87a315617e35a2382f893a41781ab88336e9b67d575b916b00833447c2fc34e5
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/cli.md
+++ b/.design/forge/cli.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: shipped
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (cli.rs) is the additive REQ-9 burned-lemmas section in render_review (forge review human form); the JSON/other render paths are unchanged (REQ-S1-9). prior: a728d95ca3dbd4fbbee1cb496c003f408d82f327)
+audited-content-sha256: 6b17cbb6ccd73bc533f4199cb56cb47711b6a3c45b63043674df8b0baf50960e
 governs: forge/src/cli.rs
 thesis-refs:
   - thermite-design.md §5

--- a/.design/forge/degrade-ladder.md
+++ b/.design/forge/degrade-ladder.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 9171f7fc260242151432300c3ce7ec7bd3000d6e (re-pinned 2026-06-16: forge runtime status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: a2db0d8a82ae573cd114387d903ab8f3093dc840 (bootstrap pin: decision 4 — doc-last-touch, NOT verified-current; backlog #262))
+audited-content-sha256: 6bb1904c9c14ec2427f73bda8d685cfcdd66e5f3724b71820f6332f969e3f51a
 governs: forge/src/degrade.rs
 thesis-refs:
   - thermite-design.md §5.2

--- a/.design/forge/e2e-vs-boundary.md
+++ b/.design/forge/e2e-vs-boundary.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 0d505126ce3d7314257fdd5446e6c020cf76bba126e8b6238f861de476f51697
 governs: forge/src/closure.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/forge/goal-repl.md
+++ b/.design/forge/goal-repl.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: a728d95ca3dbd4fbbee1cb496c003f408d82f327 (re-pinned 2026-06-16 for stage-1 increment 2f, REQ-8: the only change to this doc's governed file (goal_repl.rs) is the additive Level::L4 arm in level_str (REQ-S1-8); the v1 goal/fill verbs this doc governs are unchanged.)
+audited-content-sha256: c24e4e6a4d479601364346b482350df3f29e47d26893de9ab9a216304ea149b2
 governs: forge/src/goal_repl.rs, forge/src/cli.rs (verb dispatch), thermite-syntax/src/parser.rs (hole token)
 thesis-refs:
   - thermite-design.md §5

--- a/.design/forge/multi-agent.md
+++ b/.design/forge/multi-agent.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: e0e930bb3abf5eb14fc740c4de6a73ba328c13eb (bootstrap pin: decision 4 — doc-last-touch, NOT verified-current; backlog #262)
+audited-content-sha256: c227533578e1e1fef8c1159ee24b7a46f2f73ffbb8664409e15d4a17c51191cd
 governs: forge/src/session.rs  (NOT YET CREATED — greenfield; see "Route" below)
 also-hardens: forge/src/cache.rs  (the concurrency-safe primitives this contract demonstrates)
 thesis-refs:

--- a/.design/forge/mutation-scoring.md
+++ b/.design/forge/mutation-scoring.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 80074948185b77b95006d034e461a338b1ce6b37 (re-pinned 2026-06-16: forge quality status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (re-pinned: the #269/#270 coordinated arc — the touched-file changes are exactly this doc's designed REQs / reviewed as claim-neutral)  (re-audited 2026-06-12: amended — shipped-status Summary; #48/#74/#80 early-return synthesis + 0/0 backstop, the #101 equivalence-excluded denominator, golden-anchored ratios, and the #247 Lean-battery consumer, #262. Amended 2026-06-12 (#269): the TWO MISSING early-return families F-IDENT (identity return) + F-STRUCT-ZERO (named-struct field-zeros) are specced REQ-9..REQ-13, NOT-STARTED — the outside review's item 5, the `move_up` weak-contract escape.))
+audited-content-sha256: 6c6cc4a19e78051cd1be8d426beb27a01f2a0be37aa2693cb47b4e2a8248faa1
 governs: forge/src/mutation.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/proof-cache.md
+++ b/.design/forge/proof-cache.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (cache.rs) is the additive REQ-9 dec wf accessibility-proof cache (AccessibilityProof + accessibility_cache_key + load/store, a separate wf- on-disk namespace, CHECK_SCHEMA_VERSION-invalidated like the per-item cache); the per-item proof cache is byte-identical (REQ-S1-9). prior: 1cc9d97c6c5d7eab6109561834db77f2ef4b57ab)
+audited-content-sha256: 1c787e55ab7800a9d60eb156a169fd9d99105e5bb2b192b2359f1ed39c7fd3c6
 governs: forge/src/cache.rs
 thesis-refs:
   - thermite-design.md §5.3

--- a/.design/forge/proof-repair.md
+++ b/.design/forge/proof-repair.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: a728d95ca3dbd4fbbee1cb496c003f408d82f327 (re-pinned 2026-06-16 for stage-1 increment 2f, REQ-8: the only change to this doc's governed file (repair.rs) is the additive Level::L4 arm in the certified-rung match (REQ-S1-8 — L4 is a certified rung, not a timeout to escalate); repair behavior unchanged.)
+audited-content-sha256: 65d0ff5ebe001498636b0a579eeab5aad1749f6372397e0accba6aad95ed0334
 governs: forge/src/repair.rs
 thesis-refs:
   - thermite-design.md §5.2

--- a/.design/forge/runtime-sandbox.md
+++ b/.design/forge/runtime-sandbox.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 9171f7fc260242151432300c3ce7ec7bd3000d6e (re-pinned 2026-06-16: forge runtime status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (bootstrap pin: decision 4 — doc-last-touch, NOT verified-current; backlog #262))
+audited-content-sha256: 020b41dfe099ed2c8322f4b082b59476cc9e13c0d274c1bcac6306f250abca37
 governs: forge/src/sandbox.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/forge/slag.md
+++ b/.design/forge/slag.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 9171f7fc260242151432300c3ce7ec7bd3000d6e (re-pinned 2026-06-16: forge runtime status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (bootstrap pin: decision 4 — doc-last-touch, NOT verified-current; backlog #262))
+audited-content-sha256: 9cf455005d0e26578f9a13062dd06d91f3e037dc91f49409f4ff080fc16c6325
 governs: forge/src/slag.rs
 thesis-refs:
   - thermite-design.md §8

--- a/.design/forge/solver-profiles.md
+++ b/.design/forge/solver-profiles.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 80074948185b77b95006d034e461a338b1ce6b37 (re-pinned 2026-06-16: forge quality status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (bootstrap pin: decision 4 — doc-last-touch, NOT verified-current; backlog #262))
+audited-content-sha256: 98b4d49fab5fd9c67d6fde38b2b7fff68a864b5213b588b577886d5031feb1d4
 governs: forge/src/profile.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/solver-vacuity.md
+++ b/.design/forge/solver-vacuity.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: bb82900066869aa7dc0ad939cd955a1c6b82455d50fc662689b3c3d8117e7638
 governs: forge/src/vacuity_solver.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/spec-review.md
+++ b/.design/forge/spec-review.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (review.rs) is the additive REQ-9 burned_lemmas partition + BurnedLemma projection (a certified lemma surfaces like any certified item); the v1 intent-reviewable / battery-failing partitions are unchanged (REQ-S1-9). prior: 92396428567edc6940a9e2845217f5ff4c2ea3c6)
+audited-content-sha256: b3d50b56cf785797645c8fabd0f0dd26607949baf6a47ffffd386657fd716831
 governs: forge/src/review.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/strengthening-probes.md
+++ b/.design/forge/strengthening-probes.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 80074948185b77b95006d034e461a338b1ce6b37 (re-pinned 2026-06-16: forge quality status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (re-audited 2026-06-12: amended — shipped-status Summary + the #101 survivor-input and render_expr surface notes, #262))
+audited-content-sha256: e43ba3b93b48ae4d06376e5488d0cda196bc3fae6fef854f0c625d4834a68f82
 governs: forge/src/strengthen.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/vacuity-triage.md
+++ b/.design/forge/vacuity-triage.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 1630a862c120fe1e8f33f8dcc31c24f891d8effb61086490bfdd5a9140710a83
 governs: forge/src/vacuity.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (check.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no boundary-composition / item_subprogram weaving logic changed, net-additive, v1 behavior unchanged. prior: ddbbb3ccea18276103fc268297c4d9190a1ee385)
+audited-content-sha256: a50c62ed9811fd2b5d86fe1bbddecf0b18139f2406c5e3ef3f8d93e57b91bd95
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/lower/effect-subsumption.md
+++ b/.design/lower/effect-subsumption.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 83b5577b5ba6ecdc1ba1020ffeeae31b313d9c3bfafe7c232cb9a3ceefcc48f7
 governs: thermite-lower/src/effects.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/lower/l1-runtime-checks.md
+++ b/.design/lower/l1-runtime-checks.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 6b86f74476122cfddbdcf168d37a3561d2598054 (re-pinned 2026-06-16 for PR #46 after merging main: lower_l1's TString runtime gate now treats String-typed ADT declarations as TString users so ADT fields cannot name an unemitted runtime; main's inert Item::Forge skip is preserved; core req/ens/inv check emission is unchanged.)
+audited-content-sha256: f35dc6e292a621c5cfbbe8e3f5b5e8436e1ef91a486a02301802cdbf8b42ec9f
 governs: thermite-lower/src/l1.rs
 thesis-refs:
   - thermite-design.md §4.2

--- a/.design/lower/l2-kani.md
+++ b/.design/lower/l2-kani.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 4db50f2b9bda7c9076a9f4c01ec52fdb5938a3f7a337924f1dc35acadcb777b5
 governs: thermite-lower/src/l2.rs, forge/src/kani.rs
 thesis-refs:
   - thermite-design.md §6

--- a/.design/lower/verus-lowering.md
+++ b/.design/lower/verus-lowering.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 860775f6789850d08eb3afc3773abd34804b2399428bff344fd970d2e60d205d
 governs: thermite-lower/src/lower.rs
 thesis-refs:
   - thermite-design.md §3

--- a/.design/scaffold/workspace.md
+++ b/.design/scaffold/workspace.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (main.rs) is the two additive REQ-9 module declarations (mod accessibility, mod lemma_library); the workspace/crate structure is otherwise unchanged (REQ-S1-9). prior: ddbbb3ccea18276103fc268297c4d9190a1ee385)
+audited-content-sha256: 965d4849289a55cd413367b66fe55782fb95722e52ed568f6f7db9c8455e943d
 governs:
   - Cargo.toml (virtual workspace manifest)
   - rust-toolchain.toml

--- a/.design/skill/skill-generator.md
+++ b/.design/skill/skill-generator.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: f02770db3f32b3ba217bf257c15275aefb96c4606c19d6f3a970ff92459805e9
 governs: thermite-skill/src/generate.rs
 thesis-refs:
   - thermite-design.md §2.2

--- a/.design/spec/spectherm-combinators.md
+++ b/.design/spec/spectherm-combinators.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 5501298042331cf5e79f16f08c194f1138e4cdfc6327cf4ad7f6c0482f834290
 governs: thermite-spec/src/combinators.rs, thermite-spec/src/validator.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/syntax/ast.md
+++ b/.design/syntax/ast.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 28ca7e567ee606bc03ac06fa5783db64ebec2fe07b3f73d079a700ee0b242f74
 governs: thermite-syntax/src/ast.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/syntax/lexer.md
+++ b/.design/syntax/lexer.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 6b86f74476122cfddbdcf168d37a3561d2598054 (re-pinned 2026-06-16 for PR #46 after merging main: lex_string now rejects raw non-ASCII bytes with a structured SyntaxError while string contents remain Rust-String-backed; ASCII escapes and token classification are unchanged.)
+audited-content-sha256: 775d2e6cfdf564412cdbb55a5fa75f5fc6fd7acbf8b3bdc6e6b28a2ef271cd5a
 governs: thermite-syntax/src/lexer.rs
 thesis-refs:
   - thermite-design.md §4.3

--- a/.design/syntax/parser.md
+++ b/.design/syntax/parser.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: d0f81b499f859523a5a495795e69f2407ec4712ed5083497a5a79b9c89fb5d55
 governs: thermite-syntax/src/parser.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/syntax/semantic-addressing.md
+++ b/.design/syntax/semantic-addressing.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: fe63e5a8065f12ba5852a23277ff29e9e78cb70ef14bdcfc5b394825626a3b8b
 governs: thermite-syntax/src/address.rs
 thesis-refs:
   - thermite-design.md §4.3

--- a/.design/tooling/doc-drift-tripwire.md
+++ b/.design/tooling/doc-drift-tripwire.md
@@ -1,14 +1,15 @@
-# Doc-Drift Tripwire — pinned-SHA freshness for every routed design doc
+# Doc-Drift Tripwire — content freshness for every routed design doc
 
 <!--
 tier: 3-component
 status: draft
-governs: tooling/doc-drift.py  (UNBUILT — blocker #258) + the `audited-sha:`
-         header field this doc mandates for every routed .design doc + the
+governs: tooling/doc-drift.py + the `audited-content-sha256:` / `audited-sha:`
+         header fields this doc mandates for every routed .design doc + the
          `make doc-drift` Makefile target (and the SEQUENCED CI step — see
          REQ-10). Explicitly NOT `scripts/audit.sh`, which this component
          leaves byte-identical (decision 5).
 audited-sha: 1523b7edd09d5fe614f2950b5d9ba16ef5639f14 (re-pinned at the #258 gauntlet HEAD; governed file last touched 1523b7ed)
+audited-content-sha256: c98e931347510c2fcca397acb36199ec0a43f8d466ecba551f7ca17a0ce51467
 thesis-refs:
   - thermite-design.md §1 (trust relocated: "a skeptical third party can audit in minutes")
   - thermite-design.md §8 (#[slag]: the unverified residue is LOUD, never silent)
@@ -30,13 +31,14 @@ below is NOT-STARTED, blocked on issue #5" while `forge/src/cli.rs` is 2,778 lin
 a dozen verbs, and 21 commits have touched `cli.rs` since the doc's last-touch commit
 `1004b7a1`. This component converts that staleness from a silent failure into a loud,
 gated one — the same move `#[slag]` (§8) makes for unverified code: every routed design
-doc pins an `audited-sha:` commit, and a new gate (`tooling/doc-drift.py`, run by
-`make doc-drift` and — once the bootstrap backlog is worked off — a CI step) FAILS
-whenever any file a doc governs has been committed since the doc's pin. The gate is
-deliberately NOT part of `make audit`: doc freshness is a development-discipline
-invariant, not a link in the proof-trust chain (decision 5). Clearing the gate is a
-conscious act in a commit: re-pin (an explicit "doc still accurate" claim) or amend
-the doc and pin the amendment.
+doc pins an `audited-content-sha256:` digest over the contents of its governed file
+set (with legacy `audited-sha:` commit pins still accepted as a fallback). The gate
+(`tooling/doc-drift.py`, run by CI and by `make doc-drift`) FAILS whenever the
+governed file contents differ from the pinned digest. The gate is deliberately NOT
+part of `make audit`: doc freshness is a development-discipline invariant, not a
+link in the proof-trust chain (decision 5). Clearing the gate is a conscious act:
+re-pin content after confirming the doc remains accurate, or amend the doc and pin
+the amended claim.
 
 ## The drift this closes (grounded motivating example)
 
@@ -55,23 +57,25 @@ after the doc's last touch). Today nothing fires. After this component,
 
 ## Design decisions (resolved here, grounded below)
 
-1. **Pin granularity: ONE pin per doc** (`audited-sha:` in the doc's HTML-comment
-   header), not per-route. The doc is the claim-bearing unit; the route table is
+1. **Pin granularity: ONE content digest per doc** (`audited-content-sha256:` in
+   the doc's HTML-comment header), not per-route. The doc is the claim-bearing unit; the route table is
    many-to-many (107 routes, 48 distinct docs today — e.g.
    `.design/basis/09-option-result.md` governs 13 files, and `forge/src/check.rs`
    carries 6 governing docs), and the gate inverts routes to `doc → {files}` and
-   checks every governed file against the doc's single pin. Per-route pins would put
-   13 pins in one header and make "which pin?" ambiguous for shared docs. The
-   finer-grained per-FILE pin table in `rust-lean-correspondence.md` stays bespoke to
-   check [4] (it audits arm-by-arm per file; see OQ-1).
-2. **Drift predicate: commit-set, never commit-date.** Doc D with pin P governing
-   file set F(D) has drifted iff `git log --format=%H <P>..HEAD -- <f>` is non-empty
-   for any `f ∈ F(D)`. Date comparison is wrong under rebases; the `<P>..HEAD`
-   range is exactly "commits reachable from HEAD but not from the pin," which is the
-   question being asked. A pin that does not resolve to a commit or is not an
-   ancestor of HEAD is INVALID-PIN — a FAIL distinct from drift (it means the pin
-   itself is broken, e.g. typo'd or orphaned by history surgery).
-3. **No grandfathering.** A routed doc with no `audited-sha:` line FAILS the gate,
+   checks every governed file against the doc's single digest. Per-route pins would
+   put 13 pins in one header and make "which pin?" ambiguous for shared docs. The
+   legacy `audited-sha:` commit pin remains accepted only as a migration fallback.
+2. **Drift predicate: content hash first, full-history commit-set fallback.** Doc D
+   with governed file set F(D) has drifted iff the deterministic aggregate SHA-256
+   over F(D)'s current contents differs from `audited-content-sha256:`. If a legacy
+   commit pin P is the only pin present, D has drifted iff
+   `git log --full-history --format=%H <P>..HEAD -- <f>` is non-empty for any
+   `f ∈ F(D)`. Date comparison is wrong under rebases; `--full-history` prevents
+   Git's path-limited history simplification from making merge-parent order change
+   the fallback answer. Content hashes are preferred because the primary check is a
+   data-consistency problem, not git archaeology.
+3. **No grandfathering.** A routed doc with neither an `audited-content-sha256:`
+   line nor an `audited-sha:` line FAILS the gate,
    naming the doc. No allowlist, no warning tier. The bootstrap (REQ-5) is the
    one-time pinning commit.
 4. **Honest bootstrap: pin each doc at its OWN last-touch commit**
@@ -140,60 +144,70 @@ Substrate this component builds on (already shipped):
   stays in the audit (where this gate does not go) because its subject is a named
   residual-trust item (decision 5).
 
-New work (all UNBUILT — blocker #258):
+New work:
 
-- REQ-5 (the `audited-sha:` field + bootstrap): every doc referenced by a
+- REQ-5 (the pin fields + bootstrap): every doc referenced by a
   `[[route]].design` field carries, in its existing HTML-comment header block
-  (the `tier:`/`status:`/`governs:` block every doc already has), one line
+  (the `tier:`/`status:`/`governs:` block every doc already has), one preferred
+  content pin line:
+
+  ```
+  audited-content-sha256: <64-hex aggregate SHA-256>
+  ```
+
+  The aggregate digest is computed deterministically over the doc's sorted
+  governed `crate_pattern` set. For each pattern, the digest records the pattern,
+  then either a stable missing marker or each matched repo-relative file path plus
+  that file's SHA-256 content digest. Legacy docs may also carry:
 
   ```
   audited-sha: <40-hex full commit SHA>[ <optional free-text annotation>]
   ```
 
   meaning: "this doc's claims were verified accurate against the tree as of this
-  commit." Full 40-hex (not the 8-hex short form check [4]'s table uses) so the pin
-  can never go ambiguous as the repo grows; extraction is the first line matching
-  `^audited-sha:\s*([0-9a-f]{40})\b`. A one-time bootstrap commit adds the field to
-  all 48 routed docs at each doc's own last-touch SHA (decision 4), and files one
-  blocker per doc the first gate run reports as drifted.
+  commit." Full 40-hex (not the 8-hex short form check [4]'s table uses) so a
+  legacy commit pin can never go ambiguous as the repo grows. The tool prefers the
+  content pin whenever present.
 - REQ-6 (the gate, `tooling/doc-drift.py`): a stdlib-only python3 tool that
   (a) loads `tooling/spec-routes.toml` via `tomllib`, (b) inverts routes to
   `doc → sorted({crate_pattern})`, (c) extracts each doc's pin per REQ-5,
-  (d) validates the pin (`git rev-parse --verify <P>^{commit}` +
-  `git merge-base --is-ancestor <P> HEAD`), and (e) applies the drift predicate
-  (decision 2) per governed file — for a literal path, pathspec `<f>`; for a glob
-  pattern, pathspec `:(glob)<f>`. A routed file with no commits in `<P>..HEAD`
-  (including a file not yet committed at all — many v0.2–v0.5 routes point at
-  unbuilt files, e.g. `forge/src/session.rs`) is CURRENT, not drift: there is
-  nothing for the doc to be stale about.
-- REQ-7 (loud, named failure): each drift is reported as the doc path, its pinned
-  SHA, the governed file, and the intervening commits
-  (`git log --oneline <P>..HEAD -- <f>`) — the same three-part naming check [4]'s
-  FAIL lines use ("pinned X, current Y") extended with the commit list, so the
-  re-auditor knows exactly which diffs to review before re-pinning. Output ordering
-  is deterministic: sorted by doc path, then file path (R-CODE-5).
-- REQ-8 (missing/invalid pin = FAIL): a routed doc with no `audited-sha:` line, or
-  with a pin that fails REQ-6(d) validation, is a FAIL naming the doc and the
-  defect class (`MISSING-PIN` / `INVALID-PIN`), distinct from `DRIFT`. No
-  grandfathering (decision 3).
+  (d) for a content pin, recomputes the governed-file aggregate SHA-256 and
+  compares it directly, and (e) for a legacy commit pin, validates the pin
+  (`git rev-parse --verify <P>^{commit}` + `git merge-base --is-ancestor <P>
+  HEAD`) and applies the fallback drift predicate per governed file with
+  `git log --full-history` — for a literal path, pathspec `<f>`; for a glob
+  pattern, pathspec `:(glob)<f>`. A routed file that does not exist is represented
+  explicitly in the content digest; under the legacy fallback, a routed file with
+  no commits in `<P>..HEAD` is CURRENT.
+- REQ-7 (loud, named failure): each content drift is reported as the doc path, the
+  pinned content digest, the current content digest, and the governed file
+  patterns. Each legacy commit drift is reported as the doc path, its pinned SHA,
+  the governed file, and the intervening commits (`git log --full-history
+  --oneline <P>..HEAD -- <f>`). Output ordering is deterministic: sorted by doc
+  path, then file path / pattern (R-CODE-5).
+- REQ-8 (missing/invalid pin = FAIL): a routed doc with neither pin line, a
+  malformed `audited-content-sha256:` digest, or a legacy commit pin that fails
+  REQ-6 validation is a FAIL naming the doc and the defect class (`MISSING-PIN` /
+  `INVALID-PIN`), distinct from `DRIFT`. No grandfathering (decision 3).
 - REQ-9 (exit-code contract): `0` = every routed doc pinned and current; `1` = at
   least one DRIFT / MISSING-PIN / INVALID-PIN; `3` = the gate could not determine
   the answer (no git repo / git absent / `tomllib` absent / `spec-routes.toml`
   unreadable) — mirroring the audit's INCONCLUSIVE=3 precedent (REQ-3: "a skipped
   check is NOT a pass"). The tool never exits 0 without having checked all 48 docs.
 - REQ-10 (Makefile + CI wiring, SEQUENCED — replaces the rejected audit.sh
-  wiring): a `doc-drift` target in `Makefile` (added to the `.PHONY` line, which
-  today reads `audit audit-fast check test fmt clippy gauntlet`) that invokes
-  `python3 tooling/doc-drift.py`, printing its report. Exit-code caveat (builder
-  finding, verified empirically): GNU make collapses ANY nonzero recipe exit to
-  its own exit 2 — it never re-emits 1 or 3. So `make doc-drift` is 0 = clean /
-  2 = needs-attention; the precise 1-vs-3 class is carried by the tool's printed
-  report and by invoking `python3 tooling/doc-drift.py` directly, which remains
-  the exit-code CONTRACT (REQ-9). `scripts/audit.sh` is NOT touched — the gate is
+  wiring): `Makefile` exposes two local entry points. `make doc-drift-worktree`
+  invokes `python3 tooling/doc-drift.py` directly against the current worktree,
+  preserving the tool's precise 0/1/3 exit-code contract for scripts that need to
+  branch on drift vs environment failure. `make doc-drift` mirrors pull-request
+  CI: it synthesizes a base-first merge commit from `DOC_DRIFT_CI_BASE`
+  (default `origin/main`) and `DOC_DRIFT_CI_HEAD` (default `HEAD`) with
+  `git merge-tree --write-tree`, checks that commit out in a temporary worktree,
+  and runs the same Python gate there. GNU make still collapses any nonzero
+  recipe exit to its own exit 2; the precise class is carried by the tool's
+  printed report. `scripts/audit.sh` is NOT touched — the gate is
   development-discipline, not proof-trust (decision 5; AC-7 pins this as
-  byte-identical). `.github/workflows/ci.yml` gains the step ONLY ONCE THE
-  BOOTSTRAP BACKLOG IS CLEARED: flipping CI red on day one for 35 known-stale docs
-  (decision 4's measured 35/48) would just train people to ignore the gate.
+  byte-identical). `.github/workflows/ci.yml` runs the same gate on GitHub's PR
+  merge ref / pushed commit checkout.
 
   **The enforcement-activation sequencing, explicitly:**
   1. tool (`tooling/doc-drift.py`) + bootstrap pins (REQ-5, doc-last-touch) land;
@@ -237,29 +251,29 @@ New work (all UNBUILT — blocker #258):
 
 ## Acceptance criteria
 
-- AC-1: with a routed file committed after its doc's pin, `python3
-  tooling/doc-drift.py` exits 1 and its output names BOTH the doc path and the file
-  path and at least one intervening commit SHA. (Bootstrap-time live witness: with
-  `.design/forge/cli.md` pinned at `1004b7a1…`, the gate must report
-  `forge/src/cli.rs` drifted with 21 intervening commits at `6368550a`, headed by
-  `6368550a` itself.)
-- AC-2: with every routed doc pinned at (or after) the last-touch of all its
-  governed files, the tool exits 0 and prints one CURRENT summary line per doc
-  (48 docs at bootstrap).
-- AC-3: deleting the `audited-sha:` line from any one routed doc flips the exit to
-  1 with a `MISSING-PIN` line naming that doc.
-- AC-4: a pin that is not a 40-hex resolvable commit, or not an ancestor of HEAD,
-  flips the exit to 1 with an `INVALID-PIN` line naming the doc — textually distinct
-  from a `DRIFT` line.
+- AC-1: with a routed file's content changed after its doc's content pin, `python3
+  tooling/doc-drift.py` exits 1 and its output names the doc path, the pinned
+  digest, the current digest, and the governed pattern. The legacy fallback also
+  reports intervening commit SHAs with `--full-history`.
+- AC-2: with every routed doc content-pinned to the current governed file
+  contents, the tool exits 0 and prints one CURRENT summary line per doc.
+- AC-3: deleting both the `audited-content-sha256:` and `audited-sha:` lines from
+  any one routed doc flips the exit to 1 with a `MISSING-PIN` line naming that doc.
+- AC-4: a content pin that is not a 64-hex SHA-256 digest, a legacy commit pin that
+  is not a 40-hex resolvable commit, or a legacy commit pin that is not an ancestor
+  of HEAD flips the exit to 1 with an `INVALID-PIN` line naming the doc —
+  textually distinct from a `DRIFT` line.
 - AC-5: run outside a git repo (or with `git` shadowed off `PATH`), the tool exits
   3, never 0 and never an unhandled traceback.
 - AC-6: a route whose `crate_pattern` has never been committed (e.g.
   `forge/src/session.rs`) produces no drift for its doc (REQ-6 unbuilt-file rule).
-- AC-7: `make doc-drift` exits 0 when the tool exits 0 and nonzero otherwise
-  (GNU make collapses failing recipes to exit 2 — REQ-10 caveat; the 0/1/3
-  contract is the DIRECT invocation `python3 tooling/doc-drift.py`) and prints
-  the tool's report; `scripts/audit.sh` is UNCHANGED by this component
-  (byte-identical — the gate is outside the proof-trust chain, decision 5).
+- AC-7: `make doc-drift-worktree` exits 0 when the direct tool exits 0 and
+  nonzero otherwise (GNU make collapses failing recipes to exit 2 — REQ-10
+  caveat; the 0/1/3 contract is the DIRECT invocation
+  `python3 tooling/doc-drift.py`) and prints the tool's report. `make doc-drift`
+  evaluates a CI-style base-first merge ref in a temporary worktree. In both
+  cases `scripts/audit.sh` is UNCHANGED by this component (byte-identical — the
+  gate is outside the proof-trust chain, decision 5).
 - AC-8: two consecutive runs on an unchanged tree produce byte-identical output
   (deterministic ordering, R-CODE-5).
 
@@ -269,8 +283,9 @@ New work (all UNBUILT — blocker #258):
 (`spec-discipline.py`, `anti-pattern-gate.py`): stdlib-only python3, a
 PROJECT-CUSTOMIZATION constants block, top-of-file docstring stating the rule it
 enforces and citing this doc. Unlike the siblings it is NOT a Claude-Code hook in
-v1 (decision 5): it is invoked via `make doc-drift` (and, post-backlog, the
-sequenced CI step — REQ-10) and runnable standalone.
+v1 (decision 5): it is invoked by CI, by `make doc-drift`'s temporary merge-ref
+worktree, or directly via `make doc-drift-worktree` / `python3
+tooling/doc-drift.py`.
 
 Pipeline (one pass, no state file):
 
@@ -280,17 +295,18 @@ Pipeline (one pass, no state file):
    gate instead treats absent `tomllib` as exit-3 environment failure, because a
    CI gate that fails open is a silent pass — R-HONEST-3). Invert to
    `doc → sorted(set(crate_patterns))`.
-2. **Extract** — first `^audited-sha:\s*([0-9a-f]{40})\b` match per doc (REQ-5).
-   The field lives in the same HTML-comment header every doc already carries
-   (`tier:` / `status:` / `governs:` / `thesis-refs:` — see any routed doc;
-   grounded at the original audit: `grep -rn "audited-sha" .design/` returned
-   ZERO hits outside this doc, so the field name is unclaimed and the bootstrap
-   is a clean additive sweep).
-3. **Validate + compare** — per doc: pin validation (REQ-6(d)), then per governed
-   file the commit-set predicate `git log --format=%H <P>..HEAD -- <pathspec>`.
-   Subprocess exit statuses are always inspected; a git invocation failing for
-   environmental reasons is exit 3, never treated as "no drift" (the R-CODE-4
-   discipline applied to git instead of a solver).
+2. **Extract** — prefer first
+   `^audited-content-sha256:\s*([0-9a-f]{64})\b` match per doc; otherwise fall
+   back to first `^audited-sha:\s*([0-9a-f]{40})\b` match (REQ-5). Both fields
+   live in the same HTML-comment header every doc already carries (`tier:` /
+   `status:` / `governs:` / `thesis-refs:` — see any routed doc).
+3. **Validate + compare** — per doc: content pins compare the deterministic
+   governed-file digest directly. Legacy commit pins validate the commit
+   (REQ-6(d)), then apply the fallback commit-set predicate
+   `git log --full-history --format=%H <P>..HEAD -- <pathspec>`. Subprocess exit
+   statuses are always inspected; a git invocation failing for environmental
+   reasons is exit 3, never treated as "no drift" (the R-CODE-4 discipline
+   applied to git instead of a solver).
 4. **Report + exit** — REQ-7 lines, REQ-9 codes.
 
 **The trust boundary (why this gate lives OUTSIDE `scripts/audit.sh`):**
@@ -320,11 +336,12 @@ the code changing). Unification is OQ-1.
 
 **The re-pin workflow** (how the gate is cleared, per the §8 loudness model):
 
-- *Code changed, doc still accurate*: review `git log --oneline <P>..HEAD -- <f>`
-  (the gate prints it), confirm doc claims hold, bump `audited-sha:` to the new
-  last-touch (or HEAD) in a commit whose message states the verification — the
-  exact ceremony the two re-pin amendments in `rust-lean-correspondence.md`
-  ("VERIFIED additive-only, NOT rubber-stamped") already model.
+- *Code changed, doc still accurate*: review the governed diff, confirm doc claims
+  hold, and refresh `audited-content-sha256:` to the current governed contents.
+  For a legacy commit-pin-only doc, review
+  `git log --full-history --oneline <P>..HEAD -- <f>` (the gate prints it), then
+  either add a content pin or bump `audited-sha:` to the new last-touch / HEAD in
+  a commit whose message states the verification.
 - *Code changed, doc now wrong*: dispatch acto-doc-author to amend the doc
   (R-DOC-1: the doc adapts to the code), pinning the amendment commit's tree state.
 - The gate cannot distinguish the two (both are "pin bumped in a commit") — OQ-2.
@@ -336,17 +353,18 @@ the code changing). Unification is OQ-1.
   so this gate introduces the first one): build a throwaway git repo in `tmpdir`
   with a mini route table + two docs + governed files, then assert AC-1 (commit
   after pin → exit 1 naming both), AC-2 (exit 0), AC-3 (`MISSING-PIN`), AC-4
-  (`INVALID-PIN` on a bogus 40-hex and on a non-ancestor), AC-6 (route to an
-  uncommitted path), AC-8 (byte-identical reruns). Expected values are hand-built
-  fixture facts, never the tool's own output (R-CHAR-3).
-- **Live-tree smoke**: `python3 tooling/doc-drift.py` on the real repo at the
-  bootstrap commit — exit/report must match the independently-derived backlog
-  (the 35/48 measurement and the cli.md/cli.rs 21-commit witness in AC-1, derived
-  by raw git, not by the tool; exact sweep-time counts re-derived the same way).
-- **Makefile wiring**: `make doc-drift` is exit 0 iff the tool exits 0, and
-  nonzero (make's collapsed 2) for both the 1- and 3-cases, with the class
-  visible in the printed report (AC-7 as amended; the 3-case exercised by
-  shadowing `python3` or `git`).
+  (`INVALID-PIN` on a bogus 40-hex, on a non-ancestor, and on a malformed content
+  digest), AC-6 (route to an uncommitted path), AC-8 (byte-identical reruns), the
+  content-pin drift path, and the merge-parent-order regression where simplified
+  path history hides a main-side edit but `--full-history` reports it for legacy
+  commit pins. Expected values are hand-built fixture facts, never the tool's own
+  output (R-CHAR-3).
+- **Live-tree smoke**: `python3 tooling/doc-drift.py` on the real repo exits 0
+  when every routed doc's `audited-content-sha256:` matches its governed files.
+- **Makefile wiring**: `make doc-drift-worktree` is exit 0 iff the tool exits 0,
+  and nonzero (make's collapsed 2) for both the 1- and 3-cases, with the class
+  visible in the printed report. `make doc-drift` additionally synthesizes the
+  CI-style base-first merge worktree before invoking the same tool.
 - **Audit untouched**: `git diff <pre-component-commit> -- scripts/audit.sh` is
   empty in the component's commits (AC-7's second half); `bash scripts/audit.sh`
   output names the same six checks before and after.
@@ -374,13 +392,13 @@ cannot catch, since the index is unrouted. Named in OQ-7.)
 | REQ-2 (tomllib/glob parsing substrate) | SHIPPED | `try: import tomllib  # Python 3.11+` + `def load_routes` + `def glob_to_regex` + `def match_pattern in tooling/spec-discipline.py`. Non-test consumer: the spec-discipline hook itself (`.claude/settings.json` PreToolUse on Write\|Edit). Verification: `python3 --version` → `Python 3.13.13` (tomllib available); the hook blocks routed edits live in this harness. |
 | REQ-3 (exit-3 honest-inconclusive precedent) | SHIPPED | `scripts/audit.sh`: `pass()`/`fail()`/`skip()` helpers; `SKIPPED_GUARANTEES=()`; verdict block "INCONCLUSIVE is NOT a pass… Exit NONZERO (3, distinct from FAILED's 1) so automation cannot read a skipped-guarantee run as green (R-HONEST-3)". Non-test consumer: `make audit` (`Makefile`: `audit: @bash scripts/audit.sh`). Role here is PRECEDENT-ONLY: REQ-9 mirrors the 0/1/3 shape; nothing in this component calls into or out of `audit.sh` (decision 5). |
 | REQ-4 (check [4] precedent, stays bespoke AND stays in the audit) | SHIPPED | `scripts/audit.sh` "[4/5] CORRESPONDENCE DRIFT TRIPWIRE": `pin_sha_for()` extracts backticked hex from `.design/verified/rust-lean-correspondence.md`'s "Audited commits (PINNED…)" table; compare `cur="$(git log -1 --format=%h -- "$pf")"`; on mismatch `fail "$pf — DRIFTED: pinned $pinned, current $cur"` + `RC=1`. Non-test consumer: `make audit`. Verification: the doc's two amendment blocks record the tripwire firing and being cleared by verified re-pins (#200, #255). Its subject is a check-[6] residual-trust item — the property this gate's subjects lack (decision 5). |
-| REQ-5 (`audited-sha:` field + 48-doc bootstrap) | NOT-STARTED | open blocker #258. `grep -rn "audited-sha" .design/` → zero hits outside this doc; no routed doc carries a pin; the bootstrap pinning commit does not exist. Known sweep-time backlog: 35/48 drifted at doc-last-touch pins (measured `6368550a`, decision 4). |
-| REQ-6 (the gate `tooling/doc-drift.py`) | NOT-STARTED | open blocker #258. `ls tooling/` → `anti-pattern-gate.py  spec-discipline.py  spec-routes.toml` only; no `doc-drift.py` exists. |
-| REQ-7 (loud doc+file+commits failure report) | NOT-STARTED | open blocker #258 (no tool to carry it; report shape specified here). |
-| REQ-8 (missing/invalid pin = FAIL, no grandfathering) | NOT-STARTED | open blocker #258 (the MISSING-PIN/INVALID-PIN classes exist only in this spec). |
-| REQ-9 (exit-code contract 0/1/3) | NOT-STARTED | open blocker #258. |
-| REQ-10 (Makefile + sequenced CI wiring) | NOT-STARTED | open blocker #258. `Makefile` `.PHONY` line is `audit audit-fast check test fmt clippy gauntlet` — no `doc-drift` target; `.github/workflows/ci.yml` has no doc-drift step (steps today: checkout, toolchain, Verus install, build/test/clippy/fmt, skill budget gate). `scripts/audit.sh` is explicitly OUT OF SCOPE for this REQ (decision 5) — its current shape is not a gap. CI step is additionally gated on backlog clearance (the sequencing plan in REQ-10), so its absence at tool-landing time will be the PLANNED advisory state, not drift from this doc. |
-| REQ-11 (self-governing route entry) | NOT-STARTED | open blocker #258. `tooling/spec-routes.toml` has no `tooling/*` route (verified: all 107 `crate_pattern`s are `thermite-*`/`forge` `.rs` paths); the hook's `is_gated_path` cannot gate `.py` regardless (see REQ-11 body). |
+| REQ-5 (`audited-content-sha256:` preferred pin + legacy `audited-sha:`) | SHIPPED | Routed docs carry content pins in their HTML-comment headers, with legacy `audited-sha:` retained for provenance / fallback. The tool prefers the content pin when present. |
+| REQ-6 (the gate `tooling/doc-drift.py`) | SHIPPED | `tooling/doc-drift.py` loads `tooling/spec-routes.toml`, inverts `doc → patterns`, computes content digests, and falls back to full-history commit-set checks for legacy SHA-only docs. |
+| REQ-7 (loud doc+file/pattern failure report) | SHIPPED | Content drift reports doc path, pinned digest, current digest, and governed patterns; legacy commit drift reports doc path, governed file, and intervening full-history commits. |
+| REQ-8 (missing/invalid pin = FAIL, no grandfathering) | SHIPPED | `MISSING-PIN` fires when neither content nor commit pin exists; `INVALID-PIN` fires for malformed content digests and invalid legacy commit pins. |
+| REQ-9 (exit-code contract 0/1/3) | SHIPPED | Direct tool exits 0 for current, 1 for DRIFT/MISSING-PIN/INVALID-PIN, and 3 for environment failures. |
+| REQ-10 (Makefile + CI wiring) | SHIPPED | `Makefile` has `doc-drift-worktree` for direct worktree checks and `doc-drift` for a CI-style base-first temporary merge worktree; `.github/workflows/ci.yml` runs `python3 tooling/doc-drift.py` with full checkout history. |
+| REQ-11 (self-governing route entry) | SHIPPED | `tooling/spec-routes.toml` routes `tooling/doc-drift.py` to this doc, so the gate's own implementation is covered by the doc-drift check. The edit hook still does not gate `.py` files; that limitation remains outside this component. |
 
 ## Open questions
 

--- a/.design/tooling/req-registry.md
+++ b/.design/tooling/req-registry.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed files (registry.toml, status.md) is the additive REQ-S1-9 requirement entry + the regenerated status view; req-registry.py --check is clean (REQ-S1-9). prior: ddbbb3ccea18276103fc268297c4d9190a1ee385)
+audited-content-sha256: 3cb4d9e10acd86912629cfb41ad558d68d931600f21b4d7b606b62800e1fce22
 governs:
   - .design/reqs/registry.toml
   - .design/reqs/status.md

--- a/.design/verified/contract-tv.md
+++ b/.design/verified/contract-tv.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 4a748bc98172c98cc39fb245996ab4143bdab08d (re-pinned 2026-06-16 for stage-1 increment 2b: thermite-tv's SplitMix64 Rng is made pub so the covenant falsify can reuse it (a visibility widening, additive); the contract-TV REQs this doc governs are unchanged.)
+audited-content-sha256: e83d45113d86446236c97c6598c9fd020a9af14da9d9aac9d61581a0226ceeb3
 governs: thermite-tv/src/ref_encode.rs, thermite-tv/src/obligation.rs, forge/src/contract_tv.rs
 thesis-refs:
   - thermite-design.md §1 (trust relocated twice: code → spec → spec-intent)

--- a/.design/verified/exec-stmt-tv.md
+++ b/.design/verified/exec-stmt-tv.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: a7901ec46a5a6ac16b03e15d8f8594afc39f47c6e05dccd1146bee6362dfb4db
 governs: thermite-tv/src/exec_stmt_encode.rs, thermite-tv/src/obligation.rs, thermite-lower/src/lower.rs, forge/src/body_tv.rs, forge/src/tv_signal.rs
 thesis-refs:
   - thermite-design.md §1 (trust relocated: code → spec → spec-intent)

--- a/.design/verified/exec-tv.md
+++ b/.design/verified/exec-tv.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-content-sha256: 64949ed8940c6770cca095ebae7064874db5078270edfce077238d4d44f91222
 governs: thermite-tv/src/exec_encode.rs, thermite-tv/src/obligation.rs, thermite-tv/src/gen.rs, forge/src/exec_tv.rs
 thesis-refs:
   - thermite-design.md §1 (trust relocated: code → spec → spec-intent)

--- a/.design/verified/exporter-surface-correspondence.md
+++ b/.design/verified/exporter-surface-correspondence.md
@@ -5,6 +5,7 @@ tier: 3-component
 status: draft
 governs: forge/src/lean_export.rs
 audited-sha: 8978ecc950df30b58c00fe6df06f1fc5b4c56691 (re-pinned 2026-06-16 for stage-1 increment 2e, REQ-7: re-inspected the exporter surface for the new export_lemma. It reuses the EXACT tier-(a) fn-contract machinery (encode_expr + build_registry + R_item + the `Thermite.denote 0 … {v with specs := R_item}` framing) MINUS the body/result binding — a lemma is the pure `∀ params, req → ens` proposition with no body/result. The existing arms' correspondence is unchanged; the lemma goal is the same denote-framing the fn req/ens arms already certify, so no new soundness claim is introduced.)
+audited-content-sha256: e861fd1ca57cd9ce5a96c813ce892f447e4c0f364226abfb7442e4dd14de207d
              tone-pass that closed increment 0; increment 1 does NOT modify lean_export.rs,
              so this pin stays valid after the foundation commit)
 thesis-refs:

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (check.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no proof-backend / engine-dispatch logic changed, net-additive, v1 behavior unchanged. prior: ddbbb3ccea18276103fc268297c4d9190a1ee385)
+audited-content-sha256: 594fd7c10c4f87844c2d5b038d110fd8a0517ed0d395c0047116eada76bbdfdc
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/.design/verified/self-verification.md
+++ b/.design/verified/self-verification.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: complete (epic #60 CLOSED 2026-06-05 — Tier-1 MAXED at six verified cores, verus --no-cheating `26 verified, 0 errors`: `subsumes` REQ-5, `ladder_action` REQ-7, `io_allow`/`syscall_allowlist` REQ-8, `should_emit_external_body` boundary-honesty, `aggregate_level` honest-min, `meets_floor_60` the 0/0 gate. The rest of the original REQ-2 list was adjudicated OUT by the Tier-1 boundary rule "soundness reduces to a finite enumerable domain": `cache_key` is cryptographic (SHA-256), `triage`/`mutation::generate` walk unbounded ASTs (Tier-2-adjacent), `is_strictly_stronger` is structural — an honest coverage boundary, not a deferral; see the #60 closing comment.)
 audited-sha: 39967df868c4a228894efdd48f136358db23e49d (re-pinned 2026-06-15: batch source status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (bootstrap pin: decision 4; status header amended at #262 — the stale "epic #60 open" claim corrected against the epic's closing record))
+audited-content-sha256: 95f5792e7f6a8e02a4a31eeff97b30ca12d3f04c16cedb9e018b608cde1cfc4f
 governs: thermite-verified/src/lib.rs (the verified core — six soundness-critical pure functions proved + production-anchored)
 thesis-refs:
   - thermite-design.md §6   (Verus is the L3 prover)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Full history: the doc-drift tripwire's commit-set predicate
-          # (`git log <pin>..HEAD`) and pin validation (`merge-base
-          # --is-ancestor`) need the pinned commits present; a shallow
-          # clone would mis-class every pin as INVALID-PIN.
+          # (`git log --full-history <pin>..HEAD`) and pin validation
+          # (`merge-base --is-ancestor`) need the pinned commits present; a
+          # shallow clone would mis-class every pin as INVALID-PIN.
           fetch-depth: 0
 
       - name: Install toolchain (pinned to rust-toolchain.toml channel)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # Thermite — convenience targets. The build/test system is Cargo; these are
 # thin entry points. `make audit` is the headline: a FULL TRUST-CHAIN
 # re-derivation a skeptic runs on their own machine (see scripts/audit.sh).
-.PHONY: audit audit-fast check test fmt clippy gauntlet doc-drift doc-drift-test req-status req-status-test req-registry req-registry-test
+.PHONY: audit audit-fast check test fmt clippy gauntlet doc-drift doc-drift-ci doc-drift-worktree doc-drift-test req-status req-status-test req-registry req-registry-test
+
+DOC_DRIFT_CI_BASE ?= origin/main
+DOC_DRIFT_CI_HEAD ?= HEAD
 
 # Re-derive the WHOLE trust chain on the skeptic's machine (SLOW — minutes):
 #   1  the universal faithfulness theorem re-verified by the local Lean kernel
@@ -46,16 +49,43 @@ clippy:
 	cargo clippy --workspace --all-targets -- -D warnings
 
 # Doc-drift tripwire (crosslink #258, .design/tooling/doc-drift-tripwire.md):
-# FAIL if any routed design doc's governed files were committed after the doc's
-# `audited-sha:` pin. The tool's own exit code is the contract (0 current /
-# 1 drift-or-bad-pin / 3 environment-inconclusive — REQ-9); run the tool
-# directly when a script must branch on 1-vs-3, because GNU make collapses any
-# nonzero recipe exit to its own code 2 (it never re-emits 1 or 3). `make
-# doc-drift` thus signals 0 = clean / nonzero = needs attention, with the
-# precise class in the tool's printed report. Deliberately NOT part of
-# `make audit` — doc freshness is a development-discipline invariant, not a link
-# in the proof-trust chain (decision 5); scripts/audit.sh stays byte-identical.
-doc-drift:
+# FAIL if any routed design doc's governed file contents differ from the doc's
+# `audited-content-sha256:` pin; legacy `audited-sha:` pins fall back to a
+# full-history commit-set check. The Python tool's own exit code is the contract
+# (0 current / 1 drift-or-bad-pin / 3 environment-inconclusive — REQ-9); run it
+# directly or via `make doc-drift-worktree` when a script must branch on 1-vs-3,
+# because GNU make collapses any nonzero recipe exit to its own code 2. `make
+# doc-drift` mirrors pull-request CI by evaluating a synthetic base-first merge
+# commit (`DOC_DRIFT_CI_BASE`, default origin/main, merged with
+# `DOC_DRIFT_CI_HEAD`, default HEAD) in a temporary worktree. Deliberately NOT
+# part of `make audit` — doc freshness is a development-discipline invariant,
+# not a link in the proof-trust chain (decision 5); scripts/audit.sh stays
+# byte-identical.
+doc-drift: doc-drift-ci
+
+doc-drift-ci:
+	@set -eu; \
+	base_ref="$(DOC_DRIFT_CI_BASE)"; \
+	head_ref="$(DOC_DRIFT_CI_HEAD)"; \
+	base_sha="$$(git rev-parse --verify "$$base_ref^{commit}")"; \
+	head_sha="$$(git rev-parse --verify "$$head_ref^{commit}")"; \
+	printf 'doc-drift: evaluating CI-style merge base=%s head=%s\n' "$$base_sha" "$$head_sha" >&2; \
+	if [ "$$base_sha" = "$$head_sha" ]; then \
+		merge_sha="$$head_sha"; \
+	else \
+		if ! tree_sha="$$(git merge-tree --write-tree --no-messages "$$base_sha" "$$head_sha")"; then \
+			printf 'doc-drift: could not synthesize CI merge tree for %s and %s\n' "$$base_ref" "$$head_ref" >&2; \
+			exit 3; \
+		fi; \
+		merge_sha="$$(git commit-tree "$$tree_sha" -p "$$base_sha" -p "$$head_sha" -m "doc-drift synthetic CI merge")"; \
+	fi; \
+	tmp_dir="$$(mktemp -d)"; \
+	cleanup() { git worktree remove -f "$$tmp_dir" >/dev/null 2>&1 || rm -rf "$$tmp_dir"; }; \
+	trap cleanup EXIT HUP INT TERM; \
+	git worktree add --detach --quiet "$$tmp_dir" "$$merge_sha"; \
+	python3 "$$tmp_dir/tooling/doc-drift.py" --root "$$tmp_dir"
+
+doc-drift-worktree:
 	@python3 tooling/doc-drift.py
 
 # The gate's own oracle fixture suite (hand-authored expected values, R-CHAR-3).

--- a/tooling/doc-drift.py
+++ b/tooling/doc-drift.py
@@ -7,25 +7,29 @@ and spec-discipline.py guarantees they EXIST and are READ before a routed
 edit — but nothing checks their CONTENT is still true of the code. They drift
 silently. This gate converts that staleness from a silent failure into a loud,
 gated one (the same move #[slag] makes for unverified code, thermite-design.md
-§8): every routed design doc pins an `audited-sha:` commit, and this gate FAILS
-whenever any file a doc governs has been committed since the doc's pin.
+§8): every routed design doc pins an `audited-content-sha256:` digest over its
+governed files (or, for legacy docs, an `audited-sha:` commit), and this gate
+FAILS whenever those governed file contents change. Legacy commit pins use a
+full-history commit-set predicate so merge-parent order cannot hide drift.
 
 The rule, precisely (governed by .design/tooling/doc-drift-tripwire.md):
 
   1. Enumerate the routed docs: the deduplicated `design` fields of every
      [[route]] in tooling/spec-routes.toml, each inverted to its governed file
      set = the union of that doc's routes' crate_patterns (REQ-1, REQ-6b).
-  2. Extract each doc's pin: the first line matching
-     `^audited-sha:\\s*([0-9a-f]{40})\\b` in the doc's HTML-comment header
-     (REQ-5).
-  3. Validate the pin: it must resolve to a commit
+  2. Extract each doc's pin from the doc's HTML-comment header (REQ-5): prefer
+     `audited-content-sha256:` (64-hex aggregate content digest) when present;
+     otherwise use the legacy first `audited-sha:` 40-hex commit pin.
+  3. Validate a legacy commit pin: it must resolve to a commit
      (`git rev-parse --verify <P>^{commit}`) AND be an ancestor of HEAD
      (`git merge-base --is-ancestor <P> HEAD`) — else INVALID-PIN (REQ-6d, 8).
-  4. Drift predicate (commit-set, never commit-date — decision 2): a governed
-     file f has drifted iff `git log --format=%H <P>..HEAD -- <pathspec>` is
-     non-empty. Literal paths use pathspec `<f>`; glob patterns use `:(glob)<f>`
-     (REQ-6e). A file with no commits in <P>..HEAD — including a file never
-     committed at all — is CURRENT, not drift (REQ-6 unbuilt-file rule).
+  4. Drift predicate: for content pins, recompute the governed-file aggregate
+     SHA-256 and compare it to the pin. For legacy commit pins (commit-set,
+     never commit-date — decision 2), a governed file f has drifted iff
+     `git log --full-history --format=%H <P>..HEAD -- <pathspec>` is non-empty.
+     Literal paths use pathspec `<f>`; glob patterns use `:(glob)<f>` (REQ-6e).
+     A file with no commits in <P>..HEAD — including a file never committed at
+     all — is CURRENT, not drift (REQ-6 unbuilt-file rule).
   5. Report (REQ-7) deterministically sorted by doc path, then file path
      (R-CODE-5), and exit per the REQ-9 contract:
          0 = every routed doc pinned and current;
@@ -36,10 +40,11 @@ The rule, precisely (governed by .design/tooling/doc-drift-tripwire.md):
              that fails open is a silent pass, so an environment failure is
              never collapsed to "no drift" (R-HONEST-3, R-CODE-4).
 
-NOT a Claude-Code hook (decision 5): invoked via `make doc-drift` and runnable
-standalone. NOT part of `make audit` — doc freshness is a development-discipline
-invariant, not a link in the proof-trust chain. scripts/audit.sh is untouched
-by this component (AC-7).
+NOT a Claude-Code hook (decision 5): invoked directly by CI, via
+`make doc-drift`'s synthetic merge-ref worktree, or standalone. NOT part of
+`make audit` — doc freshness is a development-discipline invariant, not a link
+in the proof-trust chain. scripts/audit.sh is untouched by this component
+(AC-7).
 
 Usage:  python3 tooling/doc-drift.py [--root <repo-toplevel>]
 
@@ -57,6 +62,7 @@ PROJECT CUSTOMIZATION:
   Edit ROUTES_RELPATH, PIN_FIELD_RE below.
 """
 
+import hashlib
 import re
 import subprocess
 import sys
@@ -75,7 +81,16 @@ except ImportError:  # pragma: no cover - exercised via the env-failure path
 # Repo-relative path to the route table (the enumeration source, REQ-1).
 ROUTES_RELPATH = "tooling/spec-routes.toml"
 
-# The pin field, per REQ-5: the FIRST line matching this in a doc's header.
+# Preferred content pin: a deterministic aggregate SHA-256 over the doc's
+# governed file set. This makes drift a data-consistency check, independent of
+# merge topology.
+CONTENT_PIN_FIELD_RE = re.compile(
+    r"^audited-content-sha256:\s*([0-9a-f]{64})\b",
+    re.MULTILINE,
+)
+CONTENT_PIN_ANY_RE = re.compile(r"^audited-content-sha256:\s*(\S+)", re.MULTILINE)
+
+# Legacy commit pin, per REQ-5: the FIRST line matching this in a doc's header.
 # Full 40-hex (never the 8-hex short form) so a pin can never go ambiguous as
 # the repo grows.
 PIN_FIELD_RE = re.compile(r"^audited-sha:\s*([0-9a-f]{40})\b", re.MULTILINE)
@@ -178,11 +193,12 @@ def _intervening_commits(root, pin, pathspec):
     """
     rc, out, err = _run_git(
         root,
-        ["log", "--format=%H %s", f"{pin}..HEAD", "--", pathspec],
+        ["log", "--full-history", "--format=%H %s", f"{pin}..HEAD", "--", pathspec],
     )
     if rc != 0:
         raise EnvironmentError3(
-            f"git log {pin}..HEAD -- {pathspec} exited {rc}: {err.strip()}"
+            f"git log --full-history {pin}..HEAD -- {pathspec} exited {rc}: "
+            f"{err.strip()}"
         )
     commits = []
     for line in out.splitlines():
@@ -277,19 +293,26 @@ def load_doc_files(root):
     return {doc: sorted(files) for doc, files in doc_files.items()}
 
 
-def extract_pin(root, doc_relpath):
-    """The first REQ-5 pin in `doc_relpath`, or None if the doc has no pin.
+def extract_pins(root, doc_relpath):
+    """Pins in `doc_relpath`: (content_pin, bad_content_pin, commit_pin).
 
-    A doc that does not exist on disk has no pin (None) -> MISSING-PIN; the
-    doc is named, never a traceback.
+    A doc that does not exist on disk has no pins -> MISSING-PIN; the doc is
+    named, never a traceback. A malformed content pin is distinct from an absent
+    one so a typo cannot silently fall back to a legacy commit pin.
     """
     p = root / doc_relpath
     try:
         text = p.read_text(encoding="utf-8", errors="replace")
     except (OSError, FileNotFoundError):
-        return None
-    m = PIN_FIELD_RE.search(text)
-    return m.group(1) if m else None
+        return None, None, None
+    content_m = CONTENT_PIN_FIELD_RE.search(text)
+    bad_content_m = CONTENT_PIN_ANY_RE.search(text) if content_m is None else None
+    commit_m = PIN_FIELD_RE.search(text)
+    return (
+        content_m.group(1) if content_m else None,
+        bad_content_m.group(1) if bad_content_m else None,
+        commit_m.group(1) if commit_m else None,
+    )
 
 
 def _pathspec_for(pattern):
@@ -297,6 +320,56 @@ def _pathspec_for(pattern):
     if "*" in pattern or "?" in pattern or "[" in pattern:
         return f":(glob){pattern}"
     return pattern
+
+
+def _is_glob(pattern):
+    return "*" in pattern or "?" in pattern or "[" in pattern
+
+
+def _content_paths(root, pattern):
+    """Repo-relative file paths represented by `pattern`, sorted."""
+    if _is_glob(pattern):
+        try:
+            matches = sorted(
+                p.relative_to(root).as_posix()
+                for p in root.glob(pattern)
+                if p.is_file()
+            )
+        except (OSError, ValueError) as exc:
+            raise EnvironmentError3(
+                f"could not expand content-hash glob {pattern}: {exc}"
+            ) from exc
+        return matches
+
+    p = root / pattern
+    return [pattern] if p.is_file() else []
+
+
+def _content_digest(root, patterns):
+    """Deterministic aggregate digest for a doc's governed file set."""
+    digest = hashlib.sha256()
+    digest.update(b"doc-drift-content-v1\0")
+    for pattern in patterns:
+        digest.update(b"pattern\0")
+        digest.update(pattern.encode("utf-8", errors="surrogateescape"))
+        digest.update(b"\0")
+        paths = _content_paths(root, pattern)
+        if not paths:
+            digest.update(b"missing\0")
+            continue
+        for relpath in paths:
+            digest.update(b"file\0")
+            digest.update(relpath.encode("utf-8", errors="surrogateescape"))
+            digest.update(b"\0")
+            try:
+                data = (root / relpath).read_bytes()
+            except OSError as exc:
+                raise EnvironmentError3(
+                    f"could not read governed file for content hash {relpath}: {exc}"
+                ) from exc
+            digest.update(hashlib.sha256(data).hexdigest().encode("ascii"))
+            digest.update(b"\0")
+    return digest.hexdigest()
 
 
 # --- the check --------------------------------------------------------------
@@ -316,10 +389,35 @@ def evaluate(root):
 
     for doc in sorted(doc_files):
         files = doc_files[doc]
-        pin = extract_pin(root, doc)
+        content_pin, bad_content_pin, pin = extract_pins(root, doc)
+
+        if bad_content_pin is not None:
+            lines.append(
+                f"{INVALID_PIN}  {doc}  audited-content-sha256 "
+                f"{bad_content_pin} is not a 64-hex SHA-256 digest"
+            )
+            failed = True
+            continue
+
+        if content_pin is not None:
+            current = _content_digest(root, files)
+            if current == content_pin:
+                lines.append(f"{CURRENT}  {doc}  (content-sha256 {content_pin})")
+                continue
+            lines.append(
+                f"{DRIFT}  {doc}  content-sha256 {content_pin}  "
+                f"current {current}  governed file pattern(s):"
+            )
+            for pattern in files:
+                lines.append(f"    {pattern}")
+            failed = True
+            continue
 
         if pin is None:
-            lines.append(f"{MISSING_PIN}  {doc}  (no audited-sha: line)")
+            lines.append(
+                f"{MISSING_PIN}  {doc}  "
+                "(no audited-content-sha256: or audited-sha: line)"
+            )
             failed = True
             continue
 

--- a/tooling/tests/test_doc_drift.py
+++ b/tooling/tests/test_doc_drift.py
@@ -34,8 +34,16 @@ The oracle (the spec's expected values, not the tool's):
   O-8  (multi-file doc):  one doc governing TWO files, only one drifted
                           -> exit 1; the drifted file named, the current file
                           NOT named in a DRIFT line.
+  O-9  (merge history):   a feature branch pinned after its own file edit merges
+                          a main-side edit to the same file and keeps the feature
+                          tree -> exit 1; full-history must see the main-side
+                          intervening commit that simplified path history hides.
+  O-10 (content pin):     audited-content-sha256 matches the governed file
+                          contents -> exit 0; changing the file contents without
+                          a commit -> exit 1.
 """
 
+import hashlib
 import os
 import subprocess
 import sys
@@ -61,6 +69,26 @@ def _git(repo, *args, env=None, check=True):
             f"git {' '.join(args)} failed ({proc.returncode}): {proc.stderr}"
         )
     return proc.stdout.strip()
+
+
+def _content_digest(repo, patterns):
+    """Hand-authored mirror of the documented content-pin digest."""
+    digest = hashlib.sha256()
+    digest.update(b"doc-drift-content-v1\0")
+    for pattern in patterns:
+        digest.update(b"pattern\0")
+        digest.update(pattern.encode("utf-8", errors="surrogateescape"))
+        digest.update(b"\0")
+        p = repo / pattern
+        if not p.is_file():
+            digest.update(b"missing\0")
+            continue
+        digest.update(b"file\0")
+        digest.update(pattern.encode("utf-8", errors="surrogateescape"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(p.read_bytes()).hexdigest().encode("ascii"))
+        digest.update(b"\0")
+    return digest.hexdigest()
 
 
 class Fixture:
@@ -102,13 +130,18 @@ class Fixture:
             )
         self.write("tooling/spec-routes.toml", "\n".join(blocks))
 
-    def write_doc(self, relpath, pin):
+    def write_doc(self, relpath, pin, content_pin=None):
         """Write a routed doc with an HTML-comment header. pin=None -> no pin."""
+        content_line = (
+            f"audited-content-sha256: {content_pin}\n"
+            if content_pin is not None
+            else ""
+        )
         pin_line = f"audited-sha: {pin}\n" if pin is not None else ""
         self.write(
             relpath,
             "# Fixture doc\n\n<!--\ntier: 3-component\nstatus: draft\n"
-            f"{pin_line}-->\n\nbody\n",
+            f"{content_line}{pin_line}-->\n\nbody\n",
         )
 
     def commit(self, relpath, content, message):
@@ -302,6 +335,70 @@ class DocDriftOracleTest(unittest.TestCase):
         self.assertIn("src/moving.rs", joined)
         # The stable file must not appear in any DRIFT line.
         self.assertNotIn("src/stable.rs", joined)
+
+    # --- O-9: full-history catches merge-hidden main-side drift -------------
+    def test_o9_merge_hidden_main_side_drift_is_reported(self):
+        fx = Fixture(self.tmp / "o9")
+        fx.write_routes([("src/widget.rs", ".design/widget.md")])
+        fx.commit("src/widget.rs", "base\n", "base widget")
+
+        _git(fx.path, "checkout", "-q", "-b", "feature", env=fx.env)
+        pin = fx.commit("src/widget.rs", "feature\n", "feature widget")
+
+        _git(fx.path, "checkout", "-q", "main", env=fx.env)
+        main_sha = fx.commit("src/widget.rs", "main\n", "main widget")
+
+        _git(fx.path, "checkout", "-q", "feature", env=fx.env)
+        _git(
+            fx.path,
+            "merge",
+            "--no-ff",
+            "-s",
+            "ours",
+            "main",
+            "-m",
+            "merge main keeping feature tree",
+            env=fx.env,
+        )
+        fx.write_doc(".design/widget.md", pin)
+
+        res = fx.run_gate()
+        self.assertEqual(res.returncode, 1, res.stdout + res.stderr)
+        self.assertIn("DRIFT", res.stdout)
+        self.assertIn(".design/widget.md", res.stdout)
+        self.assertIn("src/widget.rs", res.stdout)
+        self.assertIn(main_sha, res.stdout)
+
+    # --- O-10: content pin is content, not git topology ---------------------
+    def test_o10_content_pin_detects_uncommitted_content_change(self):
+        fx = Fixture(self.tmp / "o10")
+        fx.write_routes([("src/widget.rs", ".design/widget.md")])
+        fx.commit("src/widget.rs", "v1\n", "widget v1")
+        pin = _content_digest(fx.path, ["src/widget.rs"])
+        fx.write_doc(".design/widget.md", None, content_pin=pin)
+
+        clean = fx.run_gate()
+        self.assertEqual(clean.returncode, 0, clean.stdout + clean.stderr)
+        self.assertIn("CURRENT", clean.stdout)
+        self.assertIn(pin, clean.stdout)
+
+        fx.write("src/widget.rs", "v2\n")
+        drifted = fx.run_gate()
+        self.assertEqual(drifted.returncode, 1, drifted.stdout + drifted.stderr)
+        self.assertIn("DRIFT", drifted.stdout)
+        self.assertIn("content-sha256", drifted.stdout)
+        self.assertIn("src/widget.rs", drifted.stdout)
+
+    def test_o10b_malformed_content_pin_is_invalid(self):
+        fx = Fixture(self.tmp / "o10b")
+        fx.write_routes([("src/widget.rs", ".design/widget.md")])
+        fx.commit("src/widget.rs", "v1\n", "widget v1")
+        fx.write_doc(".design/widget.md", fx.head(), content_pin="not-a-digest")
+
+        res = fx.run_gate()
+        self.assertEqual(res.returncode, 1, res.stdout + res.stderr)
+        self.assertIn("INVALID-PIN", res.stdout)
+        self.assertIn("audited-content-sha256", res.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #48.

- make legacy commit-SHA doc-drift checks use `git log --full-history` so merge-parent history simplification cannot produce local/CI disagreement
- add a CI-shaped `make doc-drift` target that evaluates a synthetic base-first merge worktree, plus `make doc-drift-worktree` for direct current-worktree checks
- add preferred `audited-content-sha256:` pins for routed docs and migrate the routed design docs to content pins, keeping `audited-sha:` as legacy fallback
- update the governing doc-drift design doc, CI checkout comment, and regression tests

## Validation

- `python3 tooling/doc-drift.py`
- `make doc-drift`
- `python3 -m unittest discover -s tooling/tests -v`
- `git diff --check`