### PR TITLE
fix(forge): solver-vacuity no longer silently no-ops on ADT-returning fns (#275)

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed files (check.rs, review.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no Option/Result lowering or semantics changed, net-additive, v1 behavior unchanged. prior: 87797224ba72e12a3734d93e3cb0300f20333bb4)
+audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no Option/Result lowering or semantics changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no Option/Result lowering or semantics changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
+audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no C10 ergonomics logic changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
+audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed files (check.rs, review.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no C10 ergonomics logic changed, net-additive, v1 behavior unchanged. prior: 87797224ba72e12a3734d93e3cb0300f20333bb4)
+audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no C10 ergonomics logic changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no mutual-recursion / dec-group logic changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
+audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (check.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no mutual-recursion / dec-group logic changed, net-additive, v1 behavior unchanged. prior: ddbbb3ccea18276103fc268297c4d9190a1ee385)
+audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no mutual-recursion / dec-group logic changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (check.rs) is the additive stage-1 increment 3 REQ-9 passes — apply_lemma_library (certified-only citation refusal + dedup-on-burn rewrite) and the dec wf accessibility write-through — both forge/Lean-path only; the default Verus path + v1 corpus are byte-identical (REQ-S1-9). prior: a728d95ca3dbd4fbbee1cb496c003f408d82f327)
+audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program at this same per-item loop point) threaded into the solver-vacuity gate call; the per-item check pipeline structure is otherwise unchanged, net-additive, the default Verus path + v1 corpus are byte-identical. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program at this same per-item loop point) threaded into the solver-vacuity gate call; the per-item check pipeline structure is otherwise unchanged, net-additive, the default Verus path + v1 corpus are byte-identical. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
+audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/solver-vacuity.md
+++ b/.design/forge/solver-vacuity.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix to vacuity_solver.rs: REQ-1/REQ-2's harness builder now weaves the reachable struct/enum decls (reachable_adt_deps) so an ADT-returning/taking harness compiles, and reconstructs the requires/ensures regions verbatim so a multi-line match ens stays valid Verus; REQ-3's interpreter now maps the !success && errors==0 compile non-verdict (E0425) to a ForgeError instead of the clean Failed (the silent no-op that bypassed both anti-Goodhart checks on every ADT fn). The doc's REQ-1/REQ-3/REQ-11 prose was updated in this same commit to describe the shipped behavior; #275 is RESOLVED. prior: 92396428567edc6940a9e2845217f5ff4c2ea3c6)
+audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
 governs: forge/src/vacuity_solver.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/solver-vacuity.md
+++ b/.design/forge/solver-vacuity.md
@@ -94,7 +94,15 @@ below; all NOT-STARTED, blocker #271.
   the same `requires`/`ensures` text `lower_fn` emits) so the harness's contract
   text is byte-identical to the real item's. Spec-fn dependencies the contract
   references (`spec_sum`) plus combinator defs are woven in exactly as `check.rs`'s
-  `item_subprogram` does. Source: `thermite-design.md` §7 step 2 ("is `ens`
+  `item_subprogram` does — and (the #275 fix) the reachable `struct`/`enum`
+  declarations the signature + contract reference, via the `reachable_adt_deps`
+  set `check::check_file` already computes for the L3 sub-program, so an
+  ADT-returning / ADT-taking harness (`result: Account`, `a: Shape`) compiles
+  instead of hitting `E0425` (without the decls the harness failed to elaborate
+  and its compile error was silently read as a clean verdict — the #275 hole).
+  A multi-line `ens` (a `match result { … }`) is spliced back VERBATIM, not
+  re-emitted per physical line, so it reconstructs as valid Verus. Source:
+  `thermite-design.md` §7 step 2 ("is `ens`
   provable from `req` + types **without the function body**? If yes, the contract
   says nothing about the implementation → reject with the proof as the
   explanation").
@@ -111,14 +119,21 @@ below; all NOT-STARTED, blocker #271.
   each harness is run through `run_verus`-style invocation and its verus outcome
   is interpreted as: **PROVED** (`success && errors == 0`) → the property holds
   → VACUOUS DETECTED (`tautology`/`vacuous_precondition` = `true` → reject);
-  **FAILED** (a `postcondition not satisfied` / `assertion failed`
-  counterexample) → the property does not hold → CLEAN (the check passes, the
+  **FAILED** (`!success && errors >= 1` — a `postcondition not satisfied` /
+  `assertion failed` counterexample, or an rlimit-exhaustion, each a checked-and-
+  unproved obligation) → the property does not hold → CLEAN (the check passes, the
   field is asserted `false`); **ENVIRONMENT / INTERNAL** (verus absent,
-  unparseable output, VIR error, timeout) → a handled outcome, NEVER silently
-  treated as a clean pass (R-CODE-4). A timeout on a vacuity query degrades /
-  reports (it does not assert clean); the surface form (degrade to "undetermined"
-  vs. a `ForgeError`) is OQ-3. The polarity is deliberate: verus PROVING the
-  harness is the *bad* news (the contract is degenerate). Source:
+  unparseable output, VIR error) → a handled outcome, NEVER silently treated as a
+  clean pass (R-CODE-4). The discriminator between FAILED and a NON-VERDICT is the
+  verification-error count: a `!success && errors == 0` run NEVER reached
+  verification — the harness failed to COMPILE / elaborate (an `E0425` unresolved
+  name, a parse / type error) — so it is a HARNESS-CONSTRUCTION `ForgeError`, NOT
+  the clean `Failed` (the #275 hole was reading this non-verdict as clean, which
+  silently no-op'd both checks on every ADT fn whose harness lacked its woven
+  decls; see REQ-1). A timeout on a vacuity query is reported as a verification
+  error (`errors >= 1`), so it maps to FAILED (the conservative OQ-3 polarity: an
+  inconclusive query does not reject). The polarity is deliberate: verus PROVING
+  the harness is the *bad* news (the contract is degenerate). Source:
   `thermite-design.md` §7; `goal.md` R-CODE-4.
 - **REQ-4 (the value-add over #6 — semantic detection #6 cannot reach):** a
   contract that PASSES #6's syntactic triage but IS a semantic tautology / has an
@@ -255,11 +270,13 @@ bounds-shaped contracts).
   `String`/`Vec`/slice-valued returns (the view-equality encoding `r1@ =~= r2@`
   is OQ-6). The struct path REQUIRES weaving the reachable ADT decls
   (`reachable_adt_deps`, as `check::check_file` already computes for the L3
-  sub-program) into the harness — the shipped #13 extraction weaves SpecFns ONLY,
-  and the grounded consequence is blocker **#275** (an ADT-returning harness hits
-  `E0425` and its compile error reads as a verdict); the tightness builder MUST
-  NOT inherit that gap (its AC-7 fixture is a struct return, so the AC
-  mechanically forces the weave). Source: grounded probes below; #275.
+  sub-program) into the harness. Blocker **#275** (an ADT-returning harness hit
+  `E0425` and its compile error read as a verdict) is now FIXED in the shipped #13
+  gate: REQ-1/REQ-2's extraction weaves the reachable ADT decls (not SpecFns only)
+  and REQ-3 maps the `!success && errors == 0` compile non-verdict to a
+  `ForgeError`, never a clean pass. The tightness builder inherits the working
+  weave (its AC-7 fixture is a struct return, so the AC mechanically exercises it).
+  Source: grounded probes below; #275 (resolved).
 - **REQ-12 (wiring + cost + cache — rides the existing pass):** the tightness
   query runs INSIDE the proof-cache MISS branch of `check::check_file`'s
   per-item loop, immediately after `solver_vacuity_check` returns `Clean` (so it

--- a/.design/forge/solver-vacuity.md
+++ b/.design/forge/solver-vacuity.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
+audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix to vacuity_solver.rs: REQ-1/REQ-2's harness builder now weaves the reachable struct/enum decls (reachable_adt_deps) so an ADT-returning/taking harness compiles, and reconstructs the requires/ensures regions verbatim so a multi-line match ens stays valid Verus; REQ-3's interpreter now maps the !success && errors==0 compile non-verdict (E0425) to a ForgeError instead of the clean Failed (the silent no-op that bypassed both anti-Goodhart checks on every ADT fn). The doc's REQ-1/REQ-3/REQ-11 prose was updated in this same commit to describe the shipped behavior; #275 is RESOLVED. prior: 92396428567edc6940a9e2845217f5ff4c2ea3c6)
 governs: forge/src/vacuity_solver.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no boundary-composition / item_subprogram weaving logic changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
+audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (check.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no boundary-composition / item_subprogram weaving logic changed, net-additive, v1 behavior unchanged. prior: ddbbb3ccea18276103fc268297c4d9190a1ee385)
+audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no boundary-composition / item_subprogram weaving logic changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no proof-backend / engine-dispatch / obligation-minting logic changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
+audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (check.rs) is the additive stage-1 increment 3 REQ-9 lemma library mechanics (REQ-S1-9); no proof-backend / engine-dispatch logic changed, net-additive, v1 behavior unchanged. prior: ddbbb3ccea18276103fc268297c4d9190a1ee385)
+audited-sha: 8617c2b5d52a4f6cf606d2501dd3bf898a422bc3 (re-pinned 2026-06-17 for the #275 solver-vacuity fix: the only change to this doc's governed file (check.rs) is a single added argument (&adt_deps, already computed for the L3 sub-program) threaded into the solver-vacuity gate call; no proof-backend / engine-dispatch / obligation-minting logic changed, net-additive, v1 behavior unchanged. prior: 8b4d2580b472d04fca2b14de5b6be52533a2d258)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -699,8 +699,20 @@ pub fn check_file_with_options(
         // (OQ-2): a later hit serves the cached reject / clean cert without a verus
         // spawn (the cache-hit verus-free invariant, proof-cache.md AC-1).
         if let Item::Fn(f) = item {
+            // #275: thread the reachable `struct`/`enum` decls (the same `adt_deps`
+            // woven into this item's L3 sub-program above) into the vacuity
+            // harnesses. Without them an ADT-returning / ADT-taking fn's harness
+            // failed to compile (E0425), which the pre-#275 interpreter read as a
+            // clean pass — so both anti-Goodhart checks silently no-op'd on every
+            // ADT fn. The harness now compiles, so the verdict is real.
             if let crate::vacuity_solver::SolverVacuityVerdict::Detected { cause } =
-                crate::vacuity_solver::solver_vacuity_check(f, &spec_items, seed, rlimit)?
+                crate::vacuity_solver::solver_vacuity_check(
+                    f,
+                    &spec_items,
+                    &adt_deps,
+                    seed,
+                    rlimit,
+                )?
             {
                 let (taut, vac) = match cause {
                     crate::vacuity_solver::SolverVacuityCause::SemanticTautology => (true, false),

--- a/forge/src/vacuity_solver.rs
+++ b/forge/src/vacuity_solver.rs
@@ -161,13 +161,14 @@ struct HarnessSummary {
 pub fn solver_vacuity_check(
     f: &FnItem,
     spec_items: &[Item],
+    adt_items: &[Item],
     seed: u64,
     rlimit: f64,
 ) -> Result<SolverVacuityVerdict, ForgeError> {
     // §7 step 3 first (soundness precedence above): vacuity (assume req / assert
     // false). An unsat `req` is the root cause that would also make the tautology
     // harness spuriously prove, so it is reported as `VacuousPrecondition`.
-    let vac = build_vacuity_harness(f, spec_items)?;
+    let vac = build_vacuity_harness(f, spec_items, adt_items)?;
     if matches!(
         run_harness(&vac, "vac", seed, rlimit)?,
         HarnessOutcome::Proved
@@ -180,7 +181,7 @@ pub fn solver_vacuity_check(
     // §7 step 2: tautology (assume req / arbitrary result / assert ens). Reached
     // only when the `req` is satisfiable, so a proved `ens` for an arbitrary result
     // is a genuine semantic tautology rather than an artifact of a false premise.
-    let taut = build_tautology_harness(f, spec_items)?;
+    let taut = build_tautology_harness(f, spec_items, adt_items)?;
     if matches!(
         run_harness(&taut, "taut", seed, rlimit)?,
         HarnessOutcome::Proved
@@ -213,13 +214,22 @@ struct LoweredFn {
     /// The lowered return type from `-> (result: <RET>)` (e.g. `u64`,
     /// `Option<usize>`). The arbitrary-result binder type (OQ-4).
     ret: String,
-    /// The verbatim `requires <expr>,` line(s) the lowerer emitted (omitted by the
-    /// lowerer when `req` is literally `true`, so the harness simply has no
-    /// `requires` — a `true` precondition is trivially satisfiable, never vacuous).
-    requires: Vec<String>,
-    /// The verbatim lowered `ensures` clause line(s) (the bodies of the `ensures`
-    /// block, each a `<expr>,` line). Used only by the tautology harness.
-    ensures: Vec<String>,
+    /// The lowered `requires` region's lines, captured VERBATIM (each line with its
+    /// own indentation and trailing comma exactly as the lowerer emitted it),
+    /// including the `requires` keyword line. Empty when the lowerer omitted the
+    /// clause (`req` literally `true`, a trivially-satisfiable precondition that is
+    /// never vacuous), so the harness simply has no `requires`. Verbatim capture
+    /// (rather than per-clause re-emission) is what makes a MULTI-LINE clause — a
+    /// `match`/`forall` `req` — splice back as valid Verus instead of having a comma
+    /// appended after every physical line (crosslink #275: the per-line
+    /// reconstruction produced `match result {,` and the harness failed to compile).
+    requires_lines: Vec<String>,
+    /// The lowered `ensures` region's lines, captured VERBATIM (including the
+    /// `ensures` keyword line and every clause line, each as the lowerer emitted
+    /// it). Used only by the tautology harness. Verbatim capture preserves a
+    /// multi-line `match result { … }` ens as valid Verus (the #275 fix; the prior
+    /// per-line re-emission mangled it into a non-compiling harness).
+    ensures_lines: Vec<String>,
 }
 
 /// Build the §7 step-2 tautology harness for `f` (REQ-1). Lowers the real item via
@@ -238,8 +248,12 @@ struct LoweredFn {
 /// meaningful `result`) is not a tautology candidate: its `ens` cannot constrain a
 /// `()` output, so #6's (b) already governs it; here a `()` return simply produces
 /// a `result: ()` binder verus treats as the single inhabitant.
-fn build_tautology_harness(f: &FnItem, spec_items: &[Item]) -> Result<String, ForgeError> {
-    let lf = extract_lowered_fn(f, spec_items)?;
+fn build_tautology_harness(
+    f: &FnItem,
+    spec_items: &[Item],
+    adt_items: &[Item],
+) -> Result<String, ForgeError> {
+    let lf = extract_lowered_fn(f, spec_items, adt_items)?;
     let mut out = String::new();
     out.push_str("use vstd::prelude::*;\n");
     out.push_str("verus! {\n");
@@ -248,12 +262,16 @@ fn build_tautology_harness(f: &FnItem, spec_items: &[Item]) -> Result<String, Fo
     // The harness signature: real params plus the arbitrary `result` binder.
     let params = append_result_param(&lf.params, &lf.ret);
     out.push_str(&format!("proof fn taut_check({params})\n"));
-    for req in &lf.requires {
-        out.push_str(&format!("    requires {req},\n"));
+    // Splice the lowered `requires` + `ensures` regions VERBATIM (each line as the
+    // lowerer emitted it, including the keyword lines and original commas), so a
+    // multi-line `match`/`forall` clause reconstructs as valid Verus (#275).
+    for line in &lf.requires_lines {
+        out.push_str(line);
+        out.push('\n');
     }
-    out.push_str("    ensures\n");
-    for ens in &lf.ensures {
-        out.push_str(&format!("        {ens},\n"));
+    for line in &lf.ensures_lines {
+        out.push_str(line);
+        out.push('\n');
     }
     out.push_str("{\n}\n");
     out.push_str("\n}\nfn main() {}\n");
@@ -275,16 +293,24 @@ fn build_tautology_harness(f: &FnItem, spec_items: &[Item]) -> Result<String, Fo
 /// precondition), so the harness omits them. A `fn` whose `req` lowered to nothing
 /// (literal `true`) yields a harness with no `requires`: `assert(false)` under no
 /// assumption fails, so a trivially-satisfiable precondition is clean.
-fn build_vacuity_harness(f: &FnItem, spec_items: &[Item]) -> Result<String, ForgeError> {
-    let lf = extract_lowered_fn(f, spec_items)?;
+fn build_vacuity_harness(
+    f: &FnItem,
+    spec_items: &[Item],
+    adt_items: &[Item],
+) -> Result<String, ForgeError> {
+    let lf = extract_lowered_fn(f, spec_items, adt_items)?;
     let mut out = String::new();
     out.push_str("use vstd::prelude::*;\n");
     out.push_str("verus! {\n");
     out.push_str(&lf.preamble);
     out.push('\n');
     out.push_str(&format!("proof fn vac_check({})\n", lf.params));
-    for req in &lf.requires {
-        out.push_str(&format!("    requires {req},\n"));
+    // Only the lowered `requires` region (verbatim), then `assert(false)`. The
+    // `ens`/`result` binder is irrelevant to vacuity. Verbatim splice keeps a
+    // multi-line `req` valid (#275).
+    for line in &lf.requires_lines {
+        out.push_str(line);
+        out.push('\n');
     }
     out.push_str("{\n    assert(false);\n}\n");
     out.push_str("\n}\nfn main() {}\n");
@@ -302,17 +328,38 @@ fn append_result_param(params: &str, ret: &str) -> String {
     }
 }
 
-/// Lower the real `FnItem` (woven with the file's `spec fn`s, as
-/// `check::item_subprogram` builds the L3 sub-program) and extract the lowered
-/// preamble + signature + verbatim `requires`/`ensures` lines (REQ-1/REQ-2). This
-/// is the reuse the harness rests on: the harness's contract text is the same bytes the
-/// real L3 proof sees, so a tautology/vacuity verdict reflects the real contract
-/// rather than a re-derivation.
-fn extract_lowered_fn(f: &FnItem, spec_items: &[Item]) -> Result<LoweredFn, ForgeError> {
-    // The same sub-program shape `check::item_subprogram` builds for the L3 path:
-    // the file's `spec fn`s (pure shared deps a contract may reference) plus the
-    // target `fn`, in source order (spec fns first so a forward reference resolves).
-    let mut items = spec_items.to_vec();
+/// Lower the real `FnItem` (woven with the file's `spec fn`s and the `struct`/
+/// `enum` declarations the fn reaches, as `check::item_subprogram` builds the L3
+/// sub-program) and extract the lowered preamble + signature + verbatim
+/// `requires`/`ensures` lines (REQ-1/REQ-2). This is the reuse the harness rests
+/// on: the harness's contract text is the same bytes the real L3 proof sees, so a
+/// tautology/vacuity verdict reflects the real contract rather than a
+/// re-derivation.
+///
+/// `adt_items` are the reachable `Item::Struct`/`Item::Enum` declarations the
+/// caller resolved (`check::reachable_adt_deps`, the same set woven into the L3
+/// sub-program). An ADT-returning / ADT-taking `fn` (`-> Account`, `a: Shape`)
+/// whose harness omitted these decls failed to COMPILE (`error[E0425]: cannot
+/// find type`), and a non-compiling harness was silently read as "not a tautology
+/// / not vacuous" — both anti-Goodhart checks then no-op'd on every ADT fn
+/// (crosslink #275). Weaving the ADT decls first (so the synthetic `proof fn`'s
+/// `result: Account` binder + any `result.field` in the `ens` resolve) makes the
+/// harness compile, so the verdict is real. Empty `adt_items` for the pure scalar
+/// corpus (`sum`/`binary_search`) — the lowered frame is then byte-identical to
+/// before (no regression).
+fn extract_lowered_fn(
+    f: &FnItem,
+    spec_items: &[Item],
+    adt_items: &[Item],
+) -> Result<LoweredFn, ForgeError> {
+    // The same sub-program shape `check::item_subprogram` builds for the L3 `Fn`
+    // path: the reachable `struct`/`enum` decls FIRST (#68 — so the type decls +
+    // their `well_formed` invariants are in scope before any fn that references
+    // them), then the file's `spec fn`s (pure shared deps a contract may
+    // reference), then the target `fn` last (so a forward reference resolves; the
+    // lowerer dedups combinator defs regardless of order).
+    let mut items = adt_items.to_vec();
+    items.extend(spec_items.iter().cloned());
     items.push(Item::Fn(f.clone()));
     let program = Program { items };
     let lowered = thermite_lower::lower(&program).map_err(ForgeError::Lower)?;
@@ -375,13 +422,25 @@ fn parse_lowered_fn(lowered: &str, name: &str) -> Result<LoweredFn, ForgeError> 
         .to_string();
 
     // The `requires` / `ensures` lines between the signature and the body's `{`.
-    // The lowerer emits `    requires <expr>,` (zero or one line, omitted when
-    // `req` is literally `true`) then `    ensures\n        <expr>,\n ...`, then the
-    // body opener `{`. Collect verbatim until the first line whose trimmed form is
-    // `{` (the body block opener `lower_fn` emits, via `lower_fn_body`).
-    let mut requires = Vec::new();
-    let mut ensures = Vec::new();
-    let mut in_ensures = false;
+    // The lowerer emits `    requires <expr>,` (omitted when `req` is literally
+    // `true`) then `    ensures\n        <expr>,\n ...`, then the body opener `{`.
+    // Capture each region's lines VERBATIM (with the lowerer's own indentation and
+    // trailing commas, keyword lines included) up to the first line whose trimmed
+    // form is `{` (the body block opener `lower_fn` emits). Verbatim capture — not
+    // per-clause re-emission — is the #275 fix: a multi-line `ens` (the
+    // `match result { … }` of `binary_search`) splices back as valid Verus instead
+    // of having a comma appended after the `match result {` opener (which produced
+    // `match result {,` → the harness failed to compile → the verdict silently
+    // no-op'd to clean).
+    #[derive(PartialEq)]
+    enum Region {
+        None,
+        Requires,
+        Ensures,
+    }
+    let mut requires_lines: Vec<String> = Vec::new();
+    let mut ensures_lines: Vec<String> = Vec::new();
+    let mut region = Region::None;
     let mut found_body = false;
     for line in &lines[sig_idx + 1..] {
         let t = line.trim();
@@ -389,16 +448,22 @@ fn parse_lowered_fn(lowered: &str, name: &str) -> Result<LoweredFn, ForgeError> 
             found_body = true;
             break;
         }
-        if let Some(rest) = t.strip_prefix("requires ") {
-            requires.push(rest.trim_end_matches(',').to_string());
+        if t == "requires" || t.starts_with("requires ") {
+            region = Region::Requires;
+            requires_lines.push((*line).to_string());
             continue;
         }
-        if t == "ensures" {
-            in_ensures = true;
+        if t == "ensures" || t.starts_with("ensures ") {
+            region = Region::Ensures;
+            ensures_lines.push((*line).to_string());
             continue;
         }
-        if in_ensures && !t.is_empty() {
-            ensures.push(t.trim_end_matches(',').to_string());
+        match region {
+            Region::Requires => requires_lines.push((*line).to_string()),
+            Region::Ensures => ensures_lines.push((*line).to_string()),
+            // A stray/blank line between the signature and the first clause keyword
+            // — not part of either region, skip it (the harness re-derives spacing).
+            Region::None => {}
         }
     }
     if !found_body {
@@ -406,18 +471,20 @@ fn parse_lowered_fn(lowered: &str, name: &str) -> Result<LoweredFn, ForgeError> 
             "signature not followed by a `{` body opener",
         ));
     }
-    if ensures.is_empty() {
+    if ensures_lines.is_empty() {
         // Every `fn` has ≥1 `ens` clause (ast.rs `Contract.ens` is non-empty), so
-        // an empty `ensures` set means the frame shape changed — surface it.
-        return Err(lowering_shape_error("no `ensures` clauses extracted"));
+        // the lowerer always emits an `ensures` keyword line — an empty capture
+        // means the frame shape changed; surface it rather than emit a harness with
+        // no `ensures` (which would prove vacuously and spuriously detect).
+        return Err(lowering_shape_error("no `ensures` region extracted"));
     }
 
     Ok(LoweredFn {
         preamble,
         params,
         ret,
-        requires,
-        ensures,
+        requires_lines,
+        ensures_lines,
     })
 }
 
@@ -483,14 +550,18 @@ fn lowering_shape_error(what: &str) -> ForgeError {
 /// - unparseable `--output-json` (no `verification-results`) → `ForgeError::VerusOutput`;
 /// - a VIR / internal verus error → `ForgeError::VerusOutput`.
 ///
-/// A verus timeout (rlimit exhausted) is an undetermined query: its summary is a
-/// non-success without a VIR error, which [`interpret_summary`] maps to `Failed`
-/// (clean). This is the conservative reading (OQ-3): an inconclusive vacuity query
-/// does not reject the contract (it is not proven degenerate), and a timeout is
-/// not read as "tautology". These harnesses are tiny single queries, so a
-/// timeout at the generous pinned rlimit is unlikely; the polarity is sound (a
-/// hard-to-disprove tautology stays unrejected, a missed detection and the
-/// documented completeness gap, never an unsound false reject).
+/// A verus timeout (rlimit exhausted) is an undetermined query that verus still
+/// reports as a per-obligation verification error (`errors >= 1`), so
+/// [`interpret_summary`] maps it to `Failed` (clean). This is the conservative
+/// reading (OQ-3): an inconclusive vacuity query does not reject the contract (it
+/// is not proven degenerate), and a timeout is not read as "tautology". (A
+/// `!success` run with `errors == 0` is a different beast — a harness that never
+/// reached verification, i.e. a compile/elaborate failure — which
+/// [`interpret_summary`] surfaces as a `ForgeError`, not `Failed`; see there.)
+/// These harnesses are tiny single queries, so a timeout at the generous pinned
+/// rlimit is unlikely; the polarity is sound (a hard-to-disprove tautology stays
+/// unrejected, a missed detection and the documented completeness gap, never an
+/// unsound false reject).
 fn run_harness(
     harness: &str,
     label: &str,
@@ -572,15 +643,35 @@ fn invoke_verus_on_harness(
 }
 
 /// Map a parsed harness summary to a [`HarnessOutcome`] (REQ-3, R-CODE-4). The
-/// solver-vacuity polarity:
+/// solver-vacuity polarity, with the COMPILE-vs-VERIFY distinction the #275 fix
+/// makes load-bearing:
 ///
 /// - a VIR / internal verus error → `ForgeError::VerusOutput` (an environment
 ///   condition, not a verdict, never a silent clean `false`);
 /// - PROVED (`success && errors == 0`) → `Proved`: the harness property holds,
 ///   which is the bad news (the contract is degenerate, so the caller rejects);
-/// - otherwise (`success == false`, a counterexample / failed assert / timeout) →
-///   `Failed`: verus could not prove the harness, the good news (the contract is
-///   non-degenerate, so clean).
+/// - a genuine NON-PROOF (`!success && errors >= 1`) → `Failed`: the harness
+///   COMPILED and verus checked its obligation (the empty-body `ens`, or the
+///   `assert(false)`) and could not prove it — the good news, the contract is
+///   non-degenerate, so clean. A counterexample, a failed assert, and an
+///   rlimit-exhaustion all report `errors >= 1` (each is a per-obligation
+///   verification error), so a timeout still reads as `Failed` (the conservative
+///   OQ-3 polarity: an inconclusive query does not reject);
+/// - a NON-VERDICT (`!success && errors == 0`) → `ForgeError::VerusOutput`: a
+///   `!success` run that reported ZERO verification errors never reached the
+///   verification phase — the harness failed to COMPILE / elaborate (an `E0425`
+///   unresolved name, a parse / type error). That is a HARNESS CONSTRUCTION
+///   failure, NOT "verus checked the obligation and it failed" (R-CODE-4: a
+///   non-verdict must never be read as a clean `Failed`). Before #275, this case
+///   mapped to `Failed` → clean, so every ADT-returning / ADT-taking `fn` whose
+///   harness lacked the `struct`/`enum` decls (the now-fixed weave above) silently
+///   bypassed BOTH anti-Goodhart checks. The discriminator is `errors`: verus's
+///   `verification-results.errors` counts only VERIFICATION failures, so a
+///   compiled harness with an obligation is either `success` (proved) or
+///   `errors >= 1` (checked-and-failed) — `errors == 0` with `!success` is
+///   exclusively the never-verified (compile) case (confirmed against verus
+///   `--output-json`: `E0425` → `success:false, errors:0`; a real non-proof and
+///   an rlimit hit → `errors:1`).
 ///
 /// Split out from the spawn so it is unit-testable over synthetic summaries (AC-6).
 fn interpret_summary(summary: HarnessSummary, stderr: &str) -> Result<HarnessOutcome, ForgeError> {
@@ -593,10 +684,26 @@ fn interpret_summary(summary: HarnessSummary, stderr: &str) -> Result<HarnessOut
         });
     }
     if summary.success && summary.errors == 0 {
-        Ok(HarnessOutcome::Proved)
-    } else {
-        Ok(HarnessOutcome::Failed)
+        return Ok(HarnessOutcome::Proved);
     }
+    if summary.errors == 0 {
+        // `!success` with zero verification errors: the harness never reached the
+        // verification phase, so verus rendered no verdict on the obligation — it
+        // failed to COMPILE / elaborate (E0425 unresolved name, parse / type
+        // error). Surface it as a harness-construction error (R-CODE-4), never the
+        // clean `Failed` the #275 bug produced.
+        return Err(ForgeError::VerusOutput {
+            detail: format!(
+                "a solver-vacuity harness failed to compile/elaborate before verification \
+                 (verus reported success=false with zero verification errors — a name/type/parse \
+                 error, e.g. E0425, not a checked-and-unproved obligation); the harness \
+                 construction is wrong (a missing woven decl), so the vacuity verdict is \
+                 undetermined and must not be read as clean. stderr:\n{}",
+                first_lines(stderr, 12)
+            ),
+        });
+    }
+    Ok(HarnessOutcome::Failed)
 }
 
 /// Parse the `verification-results` object out of verus's `--output-json` stdout
@@ -688,7 +795,7 @@ mod tests {
     fn tautology_harness_reuses_lowered_contract() {
         let (f, specs) =
             fn_and_specs("fn f(x: u32) -> u32 req x > 0 ens result >= 0 fx pure { x }");
-        let h = build_tautology_harness(&f, &specs).expect("build taut harness");
+        let h = build_tautology_harness(&f, &specs, &[]).expect("build taut harness");
         assert!(
             h.contains("proof fn taut_check(x: u32, result: u32)"),
             "harness:\n{h}"
@@ -707,7 +814,7 @@ mod tests {
     fn vacuity_harness_assumes_req_asserts_false() {
         let (f, specs) =
             fn_and_specs("fn f(x: u32) -> u32 req x > 5 && x < 3 ens result == x fx pure { x }");
-        let h = build_vacuity_harness(&f, &specs).expect("build vac harness");
+        let h = build_vacuity_harness(&f, &specs, &[]).expect("build vac harness");
         assert!(h.contains("proof fn vac_check(x: u32)"), "harness:\n{h}");
         assert!(h.contains("requires x > 5 && x < 3,"), "harness:\n{h}");
         assert!(h.contains("assert(false);"), "harness:\n{h}");
@@ -732,7 +839,7 @@ mod tests {
         )
         .expect("read sum.th");
         let (f, specs) = fn_and_specs(&src);
-        let h = build_tautology_harness(&f, &specs).expect("build sum taut harness");
+        let h = build_tautology_harness(&f, &specs, &[]).expect("build sum taut harness");
         // The spec fn def is woven into the preamble (so `spec_sum` resolves).
         assert!(h.contains("spec fn spec_sum("), "harness:\n{h}");
         // The slice param is exec `&[u32]`; the ens uses the `xs@` view + `as nat`
@@ -759,7 +866,7 @@ mod tests {
         )
         .expect("read binary_search.th");
         let (f, specs) = fn_and_specs(&src);
-        let h = build_tautology_harness(&f, &specs).expect("build bs taut harness");
+        let h = build_tautology_harness(&f, &specs, &[]).expect("build bs taut harness");
         assert!(
             h.contains("proof fn taut_check(haystack: &[u32], needle: u32, result: Option<usize>)"),
             "harness:\n{h}"
@@ -767,6 +874,67 @@ mod tests {
         // The match-ens is reused verbatim (the combinator `forall_in` woven in).
         assert!(h.contains("match result {"), "harness:\n{h}");
         assert!(h.contains("spec fn forall_in("), "harness:\n{h}");
+    }
+
+    /// The `Item::Struct`/`Item::Enum` decls in a program (the harness's
+    /// `adt_items` set, mirroring what `check::reachable_adt_deps` resolves for the
+    /// L3 sub-program). The fixtures here are small, so weaving every ADT decl is
+    /// the reachable set.
+    fn adt_items(program: &str) -> Vec<Item> {
+        thermite_syntax::parse(program)
+            .program
+            .items
+            .into_iter()
+            .filter(|i| matches!(i, Item::Struct(_) | Item::Enum(_)))
+            .collect()
+    }
+
+    // REQ-1 (crosslink #275): an ADT-returning fn's tautology harness weaves the
+    // reachable `struct` decl into the preamble, so the arbitrary `result: <ADT>`
+    // binder + the `result.field` in the `ens` resolve. Without the weave the
+    // harness referenced an undeclared type (`error[E0425]: cannot find type`), did
+    // not compile, and the verdict silently no-op'd. This is the pure-string pin (no
+    // verus): the decl is present and the binder carries the ADT type.
+    #[test]
+    fn tautology_harness_weaves_reachable_adt_decl() {
+        let src = "struct Pair { a: u32, b: u32 } \
+                   fn mk(x: u32) -> Pair req x > 0 ens result.a >= 0 fx pure { Pair { a: x, b: x } }";
+        let (f, specs) = fn_and_specs(src);
+        let adts = adt_items(src);
+        let h = build_tautology_harness(&f, &specs, &adts).expect("build adt taut harness");
+        // The struct decl is woven into the preamble (so `Pair` resolves).
+        assert!(
+            h.contains("struct Pair"),
+            "harness must weave the struct decl:\n{h}"
+        );
+        // The arbitrary-result binder carries the ADT return type.
+        assert!(
+            h.contains("result: Pair)"),
+            "harness must bind an arbitrary `result: Pair`:\n{h}"
+        );
+    }
+
+    // REQ-2 (crosslink #275): an ADT-TAKING fn's vacuity harness weaves the
+    // reachable `struct` decl, so the `a: <ADT>` proof-fn param resolves and the
+    // `assert(false)`-under-`req` harness compiles. Without the weave the
+    // `vac_check(a: Acct)` param referenced an undeclared type and the unsat-`req`
+    // check silently no-op'd.
+    #[test]
+    fn vacuity_harness_weaves_reachable_adt_decl() {
+        let src = "struct Acct { bal: u32 } \
+                   fn f(a: Acct, x: u32) -> u32 req x > 100 && x < 10 ens result == x fx pure { x }";
+        let (f, specs) = fn_and_specs(src);
+        let adts = adt_items(src);
+        let h = build_vacuity_harness(&f, &specs, &adts).expect("build adt vac harness");
+        assert!(
+            h.contains("struct Acct"),
+            "harness must weave the struct decl:\n{h}"
+        );
+        assert!(
+            h.contains("a: Acct"),
+            "harness must bind the ADT param `a: Acct`:\n{h}"
+        );
+        assert!(h.contains("assert(false);"), "harness:\n{h}");
     }
 
     // REQ-3 / AC-6: a synthetic PROVED summary → Proved (vacuity detected). The
@@ -796,6 +964,33 @@ mod tests {
         assert_eq!(
             interpret_summary(summary, "error: postcondition not satisfied").expect("interpret"),
             HarnessOutcome::Failed
+        );
+    }
+
+    // REQ-3 / R-CODE-4 (crosslink #275): a `!success` summary with ZERO
+    // verification errors is the COMPILE/elaborate-failure signal — verus never
+    // reached verification (an `E0425` unresolved name, a parse/type error), so it
+    // rendered no verdict on the obligation. It must surface a `ForgeError`, NEVER
+    // the clean `Failed` the pre-#275 code produced (the silent no-op that let
+    // every ADT-returning fn bypass both anti-Goodhart checks). The discriminator
+    // is `errors == 0`: a compiled harness with an obligation is either proved
+    // (`success`) or checked-and-failed (`errors >= 1`); `errors == 0 && !success`
+    // is exclusively the never-verified case (confirmed against verus
+    // `--output-json`: `E0425` → `success:false, errors:0`).
+    #[test]
+    fn compile_error_summary_is_forge_error_not_clean() {
+        let summary = HarnessSummary {
+            success: false,
+            errors: 0,
+            encountered_vir_error: false,
+        };
+        let r = interpret_summary(
+            summary,
+            "error[E0425]: cannot find type `Account` in this scope",
+        );
+        assert!(
+            matches!(r, Err(ForgeError::VerusOutput { .. })),
+            "a non-compiling harness (success:false, errors:0) must be a ForgeError, not clean: {r:?}"
         );
     }
 

--- a/forge/tests/divergence_solver_vacuity.rs
+++ b/forge/tests/divergence_solver_vacuity.rs
@@ -106,6 +106,40 @@ fn check(name: &str, program: &str) -> Value {
         .unwrap_or_else(|| panic!("no certificate emitted for `{name}`: {value}"))
 }
 
+/// Run `forge check <program> --json` and return the certificate for the named
+/// item. A program that declares an ADT emits a cert for the `struct`/`enum`
+/// before the `fn`, so the fn's cert is NOT the first one — these ADT probes must
+/// look the cert up by item name (`check` returns only the first cert).
+fn check_item(name: &str, program: &str, item: &str) -> Value {
+    let path = write_temp(name, program);
+    let cache_dir = unique_cache_dir();
+    let _ = std::fs::remove_dir_all(&cache_dir);
+    let out = Command::new(forge_bin())
+        .arg("check")
+        .arg(&path)
+        .arg("--json")
+        .env("FORGE_CACHE_DIR", &cache_dir)
+        .output()
+        .unwrap_or_else(|e| panic!("spawn forge: {e}"));
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "forge --json must emit one JSON document: {e}\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    value
+        .as_array()
+        .and_then(|a| {
+            a.iter()
+                .find(|c| c.get("item").and_then(|i| i.as_str()) == Some(item))
+        })
+        .cloned()
+        .unwrap_or_else(|| panic!("no `{item}` certificate in output for `{name}`: {value}"))
+}
+
 fn level(c: &Value) -> &str {
     c["level"].as_str().unwrap_or("<no level>")
 }
@@ -350,5 +384,116 @@ fn tautology_with_satisfiable_req_is_reported_as_tautology() {
     assert!(
         taut(&c) && !vac(&c),
         "the tautology bool is set, the vacuous bool is NOT (the req is satisfiable): {c}"
+    );
+}
+
+// ===========================================================================
+// crosslink #275 — the ADT soundness hole. Before the fix, the harness builder
+// omitted the reachable `struct`/`enum` decls, so an ADT-returning / ADT-taking
+// fn's harness referenced an undeclared type and failed to COMPILE (E0425); the
+// interpreter mapped that compile failure (`success:false, errors:0`) to the
+// clean `Failed`, so BOTH anti-Goodhart checks silently no-op'd on every ADT fn
+// (R-CODE-4 "non-verdict read as clean"). The fix weaves the reachable ADT decls
+// into the harness AND treats a `!success && errors == 0` (never-verified)
+// summary as a loud `ForgeError`, not clean. These probes pin the soundness
+// direction: a DEGENERATE ADT contract must now be CAUGHT, not silently certified.
+// Authority: `.design/forge/solver-vacuity.md` §7 steps 2-3 + AC-2/AC-3.
+// ===========================================================================
+
+/// A struct-RETURNING fn with a body-ignoring (tautological) `ens`
+/// (`result.a >= 0` holds for any `u32` field) must be DETECTED as a tautology,
+/// not silently certified. Pre-#275 the `result: Pair` binder referenced an
+/// undeclared `Pair` (E0425) → the harness never compiled → silent clean L3. The
+/// ADT-weave makes the harness compile and verus proves the tautology → reject.
+#[test]
+fn adt_returning_fn_tautology_is_detected() {
+    if !verus_present() {
+        eprintln!("SKIP: verus absent — the ADT tautology harness needs the proof.");
+        return;
+    }
+    let c = check_item(
+        "adt_taut",
+        "struct Pair { a: u32, b: u32 }\n\
+         fn mk(x: u32) -> Pair\n  req x > 0\n  ens result.a >= 0\n  fx pure\n{ Pair { a: x, b: x } }\n",
+        "mk",
+    );
+    assert_ne!(
+        level(&c),
+        "L3",
+        "a struct-returning tautology MUST NOT silently certify (the #275 hole): {c}"
+    );
+    assert_eq!(
+        cause(&c),
+        Some("SemanticTautology"),
+        "the body-ignoring `ens result.a >= 0` must be caught as SemanticTautology: {c}"
+    );
+    assert!(
+        taut(&c) && !vac(&c),
+        "the tautology bool is solver-confirmed true on the ADT-returning fn: {c}"
+    );
+}
+
+/// A struct-TAKING fn with an unsatisfiable `req` (`x > 100 && x < 10`) must be
+/// DETECTED as a vacuous precondition. Pre-#275 the `vac_check(a: Acct)` param
+/// referenced an undeclared `Acct` (E0425) → silent clean. The ADT-weave makes
+/// the `assert(false)`-under-unsat-`req` harness compile and prove → reject.
+#[test]
+fn adt_taking_fn_unsat_req_is_detected() {
+    if !verus_present() {
+        eprintln!("SKIP: verus absent — the ADT vacuity harness needs the proof.");
+        return;
+    }
+    let c = check_item(
+        "adt_vac",
+        "struct Acct { bal: u32 }\n\
+         fn f(a: Acct, x: u32) -> u32\n  req x > 100 && x < 10\n  ens result == x\n  fx pure\n{ x }\n",
+        "f",
+    );
+    assert_ne!(
+        level(&c),
+        "L3",
+        "an ADT-taking unsat-req contract MUST NOT silently certify (the #275 hole): {c}"
+    );
+    assert_eq!(
+        cause(&c),
+        Some("VacuousPrecondition"),
+        "the unsat `req x > 100 && x < 10` must be caught as VacuousPrecondition: {c}"
+    );
+    assert!(
+        vac(&c) && !taut(&c),
+        "the vacuous bool is solver-confirmed true on the ADT-taking fn: {c}"
+    );
+}
+
+/// The false-positive guard on the ADT path: a struct-returning fn with a GOOD,
+/// result-constraining `ens` (`result.v == x`) and a satisfiable `req` must still
+/// reach L3 with both `contract_quality` bools `false`. The ADT-weave must not
+/// over-constrain the arbitrary `result` binder into a spurious tautology
+/// detection (the dangerous direction — rejecting valid code). Authority:
+/// `.design/forge/solver-vacuity.md` AC-1.
+#[test]
+fn adt_returning_fn_good_contract_is_clean_l3() {
+    if !verus_present() {
+        eprintln!("SKIP: verus absent — the ADT false-positive guard needs the proof.");
+        return;
+    }
+    let c = check_item(
+        "adt_good",
+        "struct Box1 { v: u32 }\n\
+         fn wrap(x: u32) -> Box1\n  req x < 100\n  ens result.v == x\n  fx pure\n{ Box1 { v: x } }\n",
+        "wrap",
+    );
+    assert_eq!(
+        level(&c),
+        "L3",
+        "a good struct-returning contract must certify L3, not be flagged: {c}"
+    );
+    assert!(
+        !taut(&c),
+        "a result-constraining `ens result.v == x` MUST NOT be flagged tautology: {c}"
+    );
+    assert!(
+        !vac(&c),
+        "a satisfiable `req x < 100` MUST NOT be flagged vacuous: {c}"
     );
 }


### PR DESCRIPTION
Fixes crosslink **#275** (HIGH, anti-Goodhart soundness hole). The two solver-vacuity checks (tautology + vacuous-precondition) **silently no-op'd on every struct/enum-returning fn**: the harness omitted the reachable ADT decls → `E0425` compile error → `interpret_summary` mapped `success:false / errors:0` to `Failed`, read as a **clean pass**. An R-CODE-4 "non-verdict read as clean" sitting under the anti-Goodhart claim.

## Fix (`forge/src/vacuity_solver.rs`)
- **Weave ADT deps**: thread the reachable `adt_deps` (already computed for the L3 sub-program) into `solver_vacuity_check → build_{tautology,vacuity}_harness → extract_lowered_fn`, emitting the struct/enum decls first (mirroring `item_subprogram`'s `Fn` arm). The ADT-fn harness now **compiles**.
- **Compile-error ≠ verification-failed**: `!success && errors==0` (verification never ran — compile/elaborate failure) is now a **loud `ForgeError`**, never `Failed`→clean; only `!success && errors>=1` (checked-and-unproved, incl. rlimit) stays the Failed/clean signal. Verified empirically against `verus --output-json` (E0425 → `errors:0`; genuine non-proof + rlimit → `errors>=1`).
- **Latent bug also fixed**: reconstruct the `requires`/`ensures` regions verbatim (not per-line) so a multi-line `match` ens (binary_search) splices back as valid Verus — a harness-construction bug the new compile-error detection correctly surfaced.

## Tests (verus-guarded)
ADT tautology → `SemanticTautology` rejected; ADT unsat-req → `VacuousPrecondition` rejected; good ADT fn → clean L3; `interpret_summary(errors:0)` → `ForgeError`; + ADT-weave preamble unit tests.

## Gauntlet
`cargo test -p forge` 398/0 bin + all integration binaries (after building the spine); clippy `-D warnings` clean; fmt clean; doc-drift 0 (7 docs re-pinned); req-registry clean (440); no corpus cert flips (sum/binary_search goldens match). Scope: #275 only; README untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)