### PR TITLE
[codex] Add arm64 seccomp sandbox support

### DIFF
--- a/.design/basis/08-runnable-effect-link.md
+++ b/.design/basis/08-runnable-effect-link.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: dd778c62acb9efa69deb252357583a83b047df346178728cfcae520182548300
+audited-content-sha256: df347aac593e3f751d671d91af8a5bdd5c5d0ec1007017e86664c40b4f9c6ca2
 governs: forge/src/build.rs
 governs: forge/src/effect_wrappers.rs
 (the thermite-stdlib/src/effect/* paths this doc originally listed were never
@@ -349,8 +349,10 @@ forge audit <same program>  →  tcb: now -> os::now (…)   [UNCHANGED by the l
 Boundaries (what Stage 8 is NOT):
 - It does NOT change `forge check` (verification), the lowering of the boundary crossing,
   or the #57 allowlist derivation — those ship.
-- It is x86_64-Linux only (the #57 seccomp filter + the `os::` wrappers target
-  x86_64-Linux; cross-platform is future work, as `runtime-sandbox.md` / OQ-4 scope).
+- It is native Linux only for the confined-run guarantee: the #57 seccomp filter
+  supports x86_64 and aarch64 generated runners, while non-Linux remains future work
+  (`runtime-sandbox.md` / OQ-4 scope). The `os::` wrappers themselves use portable
+  `std` bodies.
 - `Net`/`Rand` wrappers are v1.1 (identical emit shape); `Alloc` needs no `os::`
   wrapper (the Rust allocator under the baseline allowlist).
 - The generated `main`'s input convention stays v0.1 fixed-literal (`build.md` OQ-1);
@@ -470,11 +472,12 @@ the repo tree (#53 — compiled binaries are large).
   (`03-effect-stdlib.md` OQ-5) still applies — use `Option`/`Result` or the sentinel,
   not a user enum, until that lowering is fixed.
 
-- **OQ-4 (cross-platform — x86_64-Linux only, as #57 scopes):** the `os::` wrappers use
-  `std` (portable) but the #57 seccomp filter is x86_64-Linux-specific, so the
-  confined-run guarantee (REQ-4) is x86_64-Linux only in v1. A non-Linux `forge build`
-  could emit the `mod os` + compile + run but without the seccomp confinement — out of
-  v1 scope (matches `runtime-sandbox.md`'s platform scope).
+- **OQ-4 (cross-platform — native Linux only, as #57 scopes):** the `os::` wrappers use
+  `std` (portable) but the #57 seccomp filter is Linux-specific and currently supports
+  x86_64/aarch64 generated runners, so the confined-run guarantee (REQ-4) is native
+  Linux only in v1. A non-Linux `forge build` could emit the `mod os` + compile + run
+  but without the seccomp confinement — out of v1 scope (matches
+  `runtime-sandbox.md`'s platform scope).
 
 ## Routes to add (orchestrator)
 
@@ -524,6 +527,6 @@ does NOT author the oracle, the golden, the routes, or the wrappers (R-DOC-1).
 | REQ-1 (the `os::<name>` wrapper stdlib — real `std` syscall bodies) | SHIPPED | the `WRAPPERS` table in `forge/src/effect_wrappers.rs` holds a real `std` body for each v1 target: `os::now` (`std::time::SystemTime::now().duration_since(UNIX_EPOCH).map(\|d\| d.as_secs())`), `os::read_byte`/`os::read_line` (`std::io::stdin().read`/`read_line`, the latter → `TString`), `os::write`/`os::print` (`std::io::stdout().write_all` over `TString`). Each handles its error arm honestly (the EOF sentinel 256 / a status code, no `unwrap`-panic). The table has since GROWN with the editor's wrappers (same shape, same TCB discipline): `os::read_key`/`os::key_str` (#87), `os::raw_mode_on`/`os::raw_mode_off`/`os::read_key_raw`/`os::write_frame` (#90), `os::read_file`/`os::write_file` (#125 — total, empty-`TString`/status-arm on error). Consumer: `effect_wrappers::emit_mod_os` (emitted by `build::emit_source`). Verified by `effect_link_conformance::elapsed_ok_builds_and_runs` (the linked `os::now` runs a real `clock_gettime`) + `read_byte_links_and_runs_both_arms` (`A`→130, EOF→0) + the `effect_wrappers::tests` unit battery (11 tests, incl. `read_key_wrapper_mirrors_read_byte_eof_sentinel`/`key_str_wrapper_is_bounded_one_byte_string`/`read_file_wrapper_is_total_empty_on_error`/`write_file_wrapper_is_total_status_arm`) + the runnable editor `forge/tests/editor_runs.rs`. The OQ-2 packaging is the INLINE `forge/src/` table (the orchestrator's settled decision), NOT a `thermite-stdlib` crate. |
 | REQ-2 (`forge build` LINKS via emit-`mod os` keyed off boundary targets) | SHIPPED | `build::reachable_boundary_targets` collects the distinct `BoundaryAttr.target` over the program's `#[boundary]` `Item::Fn`s (every one is lowered with an `os::<name>(args)` crossing by `lower_l1`); `effect_wrappers::emit_mod_os` assembles a sorted, deterministic `mod os { … }` carrying EXACTLY those wrappers; `build::emit_source` PREPENDS it to `lower_l1`'s output, closing the GROUNDED `E0433`. Consumer: `build::emit_source` → `build::build_file` → `cli::run_build`. Verified by `effect_link_conformance::elapsed_ok_builds_and_runs` (rustc exit 0, no `E0433`) + `effect_wrappers::tests::{emits_only_named_wrappers,emission_is_sorted_deterministic}` (minimal-TCB keying + R-CODE-5 determinism). |
 | REQ-3 (a verified program COMPILES + RUNS + does real I/O) | SHIPPED | `forge build effect_link_demo.th --entry elapsed_ok` compiles + the binary RUNS the linked `os::now`'s real `clock_gettime` → prints `elapsed_ok() = <live Unix timestamp>` (e.g. `1780780684`), exit 0; `os::read_byte` over stdin → `doubled() = 130` (byte `A`) / `0` (EOF, the handled arm). Verified by `effect_link_conformance::elapsed_ok_builds_and_runs` (run exit 0, output a u64 in `(0, 4_000_000_000)`) + `read_byte_links_and_runs_both_arms`. THE UNLOCK: a verified Thermite program runs + does real I/O. |
-| REQ-4 (the linked wrapper is #57-seccomp-CONFINED) | SHIPPED | the linked `os::now` runs UNDER the SHIPPED #57 `sandbox::emit_sandbox_prelude` (installed FIRST in `synthesize_entry_main`'s `main`, UNCHANGED): the `time` allowlist INCLUDES `clock_gettime` (228) → the live `os::now` runs clean (exit 0), and EXCLUDES `openat` (257) → the `--sandbox-self-test` probe under the SAME `time` filter is `SIGSYS`-KILLED (exit 159). Verified by `effect_link_conformance::sandbox_confines_the_linked_wrapper` (the live-foreign-body confinement OQ-4 deferred, now real). The #57 allowlist derivation is verbatim. |
+| REQ-4 (the linked wrapper is #57-seccomp-CONFINED) | SHIPPED | the linked `os::now` runs UNDER the SHIPPED #57 `sandbox::emit_sandbox_prelude` (installed FIRST in `synthesize_entry_main`'s `main`, UNCHANGED): the `time` allowlist INCLUDES host-native `clock_gettime` (x86_64 228 / aarch64 113) → the live `os::now` runs clean (exit 0), and EXCLUDES host-native `openat` (x86_64 257 / aarch64 56) → the `--sandbox-self-test` probe under the SAME `time` filter is `SIGSYS`-KILLED (exit 159). Verified by `effect_link_conformance::sandbox_confines_the_linked_wrapper` (the live-foreign-body confinement OQ-4 deferred, now real). The #57 allowlist derivation is verbatim. |
 | REQ-5 (verification UNCHANGED — link is build-only) | SHIPPED | `forge check effect_link_demo.th --mutation-floor 0` certifies `now` at `L1` + `boundary` + `boundary_target os::now` + `fx time`, and `elapsed_ok` at `L3` + `assurance_scope to_boundary { via: now }` — IDENTICAL to the pre-link cert (the link lives in `build::emit_source` codegen + rustc; `forge check` never emits `mod os` or invokes rustc). Verified by `effect_link_conformance::verify_unchanged` (the before/after invariance now PINNED by the Stage-8 oracle). `forge check`/lowering-for-check is untouched. |
 | REQ-6 (the wrappers are the TRUSTED-by-fiat TCB — enumerated + confined) | SHIPPED | the linked `os::now` IS exactly the boundary the SHIPPED #15 `AuditManifest.tcb` enumerates (`boundary: now -> os::now (req=… ens=[result < 4000000000] fx=[time])`, the `forge check` cert's `boundary`/`boundary_target`/`effects` fields, PINNED by `verify_unchanged`) made RUNNABLE under the #57 confinement (REQ-4). `emit_mod_os` emits ONLY the wrappers the program names (minimal TCB), so the link does not enlarge the TCB beyond the enumerated boundaries. Verified by `effect_link_conformance::{verify_unchanged,sandbox_confines_the_linked_wrapper}` + `effect_wrappers::tests::emits_only_named_wrappers`. |

--- a/.design/build/kernel-target.md
+++ b/.design/build/kernel-target.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: c135b797e2828f43a3073c8f83514d212cb7b593a32e7d5fce08ae099fe386fa
+audited-content-sha256: 7904c45b72a131cbb9e0da48849f593bcc5a93dfcd4d2acf49452f8beea1670f
 governs: forge/src/build.rs
 thesis-refs:
   - thermite-design.md §3 (the stack — transpile to Rust, rustc is the codegen backend; the #21 realization note)

--- a/.design/forge/build.md
+++ b/.design/forge/build.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: c135b797e2828f43a3073c8f83514d212cb7b593a32e7d5fce08ae099fe386fa
+audited-content-sha256: 7904c45b72a131cbb9e0da48849f593bcc5a93dfcd4d2acf49452f8beea1670f
 governs: forge/src/build.rs
 thesis-refs:
   - thermite-design.md §3
@@ -123,9 +123,10 @@ not this doc); see the Amendment below.
   in the build manifest (REQ-5) the syscall filter is derived from. SUPERSEDED IN
   PART by #57 shipping (`56c23565`, pre-pin — Amendment 2026-06-12): `forge build
   --entry` now also INSTALLS the sandbox itself. `fn synthesize_entry_main in
-  build.rs` injects `sandbox::emit_sandbox_prelude(&allowlist)` — allowlist =
-  `sandbox::syscall_allowlist(&sandbox::transitive_fx(program, &f.name))` — as the
-  FIRST statements of the generated `main`, ON BY DEFAULT (`SandboxConfig::default()`
+  build.rs` injects `sandbox::emit_sandbox_prelude(&transitive_fx)` — the emitter
+  derives cfg-gated native x86_64/aarch64 syscall allowlists from
+  `sandbox::transitive_fx(program, &f.name)` — as the FIRST statements of the generated
+  `main`, ON BY DEFAULT (`SandboxConfig::default()`
   → `SandboxMode::On`; `--no-sandbox` opts out), and records the result as
   `pub sandbox: SandboxRecord` on the `BuildManifest` (`installed` +
   `transitive_fx` + `syscall_allowlist`). The sandbox MECHANISM (`sandbox.rs`) is

--- a/.design/forge/runtime-sandbox.md
+++ b/.design/forge/runtime-sandbox.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 9171f7fc260242151432300c3ce7ec7bd3000d6e (re-pinned 2026-06-16: forge runtime status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (bootstrap pin: decision 4 — doc-last-touch, NOT verified-current; backlog #262))
-audited-content-sha256: 020b41dfe099ed2c8322f4b082b59476cc9e13c0d274c1bcac6306f250abca37
+audited-content-sha256: 41538b2db294602e23ef5079c9e3742029194ae020bb6766c6b6be83ed94c650
 governs: forge/src/sandbox.rs
 thesis-refs:
   - thermite-design.md §4.1
@@ -58,7 +58,8 @@ implements against; the seccomp mechanism is empirically grounded against real
   cycle-safe, source-order DFS `closure::classify` uses — never a duplicate walker.
 
 - **REQ-3 (`fx` → syscall allowlist mapping, pinned):** each `fx` token maps to a
-  fixed set of x86_64 syscall numbers (the [mapping table](#fx--syscall-allowlist-mapping)).
+  fixed set of target-architecture syscall numbers (the
+  [mapping table](#fx--syscall-allowlist-mapping)).
   `pure` → the minimal baseline a Rust binary needs to run, print, and exit (NO
   `openat`/`socket`). `read(_)`, `write(_)`, `net(_)`, `time`, `rand` ADD their
   syscalls; `alloc` is already in the baseline. The mapping is deterministic: the same
@@ -84,10 +85,11 @@ implements against; the seccomp mechanism is empirically grounded against real
 
 - **REQ-7 (the `term` terminal-control effect + the `ioctl` grant — issue #106):**
   the §4.1 effect lattice gains a DEDICATED terminal-control atom, surfaced as the
-  `fx term` token, whose syscall-allowlist widening is `{ioctl:16}` (the
+  `fx term` token, whose syscall-allowlist widening is the host-native `ioctl`
+  number (`16` on x86_64, `29` on aarch64; the
   [mapping table](#fx--syscall-allowlist-mapping) `TERM_SYSCALLS` row). A fn that
   reaches the terminal (the editor's `os::raw_mode_on`/`os::raw_mode_off`
-  `tcgetattr`/`tcsetattr` boundary, which issue the x86_64 `ioctl` syscall #16 with
+  `tcgetattr`/`tcsetattr` boundary, which issue the native `ioctl` syscall with
   the termios `TCGETS`/`TCSETS` cmds) declares `fx term`; its transitive caller's
   allowlist then INCLUDES `ioctl`, so the binary runs CONFINED (raw mode allowed,
   everything else still killed). A program WITHOUT `term` in its transitive `fx`
@@ -138,9 +140,9 @@ Tied to a `conformance/sandbox/cases.json` oracle the orchestrator authors (the 
 
 - **AC-6 (the `term` fx grants `ioctl`; a non-`term` program's `ioctl` → SIGSYS;
   the editor runs FULLY sandboxed — issue #106):** an entry whose transitive `fx`
-  includes `term` → the installed allowlist INCLUDES `ioctl`:16 (so a `tcgetattr`
+  includes `term` → the installed allowlist INCLUDES host-native `ioctl` (so a `tcgetattr`
   ioctl is ALLOWED); the SAME program with a `pure`/`read(_)`/`write(_)` (no `term`)
-  filter EXCLUDES `ioctl`:16 (so the editor's raw-mode `ioctl` is `SIGSYS`-killed,
+  filter EXCLUDES host-native `ioctl` (so the editor's raw-mode `ioctl` is `SIGSYS`-killed,
   exit 159 — the #106 bug as it stands TODAY). With `term` granted, the
   `examples/editor/editor.th` `run` entry builds WITH the sandbox (NOT
   `--no-sandbox`) and RUNS clean end-to-end on piped keystrokes: raw mode enters
@@ -171,10 +173,12 @@ must subsume every callee's row" — the union IS the entry's effective row).
 
 **2. The BPF filter (raw `libc`, no seccomp crate).** No `seccompiler`/`libseccomp`
 crate is cached offline; `libc` (cached, `0.2.x`) is. The prelude hand-builds a classic
-`sock_filter[]` program: load `seccomp_data.arch`, guard `AUDIT_ARCH_X86_64`, load
-`seccomp_data.nr`, then a `BPF_JEQ` per allowlisted syscall number → `SECCOMP_RET_ALLOW`,
-defaulting to `SECCOMP_RET_KILL_PROCESS`. Installed via `prctl(PR_SET_NO_NEW_PRIVS,1)`
-then `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &sock_fprog)`. This is grounded below.
+`sock_filter[]` program selected by Rust `#[cfg(target_arch = "...")]`: x86_64 guards
+`AUDIT_ARCH_X86_64`; aarch64 guards `AUDIT_ARCH_AARCH64`. Both branches then load
+`seccomp_data.nr`, emit a `BPF_JEQ` per allowlisted syscall number →
+`SECCOMP_RET_ALLOW`, and default to `SECCOMP_RET_KILL_PROCESS`. Installed via
+`prctl(PR_SET_NO_NEW_PRIVS,1)` then
+`prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &sock_fprog)`. This is grounded below.
 
 **3. Injection point (the generated `main`).** `build::synthesize_entry_main` (in
 `build.rs`) already emits `fn main() { let r = entry(args); println!(…); }` for
@@ -186,21 +190,24 @@ between the prelude and the entry call only under `--sandbox-self-test`.
 
 ### `fx` → syscall allowlist mapping
 
-x86_64 syscall numbers. The baseline was derived empirically (a trivial Rust binary
-ran CLEAN under a kill-default filter with exactly this set; see Verification).
+x86_64 and aarch64 syscall numbers. The x86_64 baseline was derived empirically (a
+trivial Rust binary ran CLEAN under a kill-default filter with exactly this set; see
+Verification). The aarch64 numbers are the Linux `asm-generic/unistd.h` ABI values;
+the arm64 runtime baseline is deliberately called provisional until a native arm64
+executor runs the same conformance suite under `SECCOMP_RET_LOG`/kill.
 
-| `fx` token | adds (x86_64 syscall : nr) |
-|---|---|
-| **baseline** (always, incl. `pure`, `alloc`) | `read`:0, `write`:1, `close`:3, `mmap`:9, `mprotect`:10, `munmap`:11, `brk`:12, `rt_sigaction`:13, `rt_sigprocmask`:14, `rt_sigreturn`:15, `madvise`:28, `poll`:7, `sigaltstack`:131, `arch_prctl`:158, `gettid`:186, `futex`:202, `sched_getaffinity`:204, `set_tid_address`:218, `exit`:60, `exit_group`:231, `set_robust_list`:273, `prlimit64`:302, `rseq`:334 |
-| `read(_)` | `openat`:257, (`read`:0 already in baseline), `close`:3, `lseek`:8, `statx`:332, `newfstatat`:262 |
-| `write(_)` | `openat`:257, (`write`:1 already), `fsync`:74, `newfstatat`:262 |
-| `net(_)` | `socket`:41, `connect`:42, `sendto`:44, `recvfrom`:45, `setsockopt`:54, `getsockopt`:55 |
-| `alloc` | (already baseline: `mmap`/`munmap`/`brk`/`mprotect`) |
-| `time` | `clock_gettime`:228, `clock_nanosleep`:230 |
-| `rand` | `getrandom`:318 |
-| `term` (NEW, #106) | `ioctl`:16 (termios `TCGETS`/`TCSETS` — but seccomp can't filter the cmd; the whole `ioctl` is granted under `term`, OQ-5) |
-| `panic` | (baseline `write`+`exit_group`; panic unwinds + prints to stderr) |
-| `diverge` | (no added syscall; divergence is a non-termination effect) |
+| `fx` token | x86_64 adds | aarch64 adds |
+|---|---|---|
+| **baseline** (always, incl. `pure`, `alloc`) | `read`:0, `write`:1, `close`:3, `poll`:7, `mmap`:9, `mprotect`:10, `munmap`:11, `brk`:12, `rt_sigaction`:13, `rt_sigprocmask`:14, `rt_sigreturn`:15, `madvise`:28, `exit`:60, `sigaltstack`:131, `arch_prctl`:158, `gettid`:186, `futex`:202, `sched_getaffinity`:204, `set_tid_address`:218, `exit_group`:231, `set_robust_list`:273, `prlimit64`:302, `rseq`:334 | `close`:57, `read`:63, `write`:64, `exit`:93, `exit_group`:94, `set_tid_address`:96, `futex`:98, `set_robust_list`:99, `sched_getaffinity`:123, `sigaltstack`:132, `rt_sigaction`:134, `rt_sigprocmask`:135, `rt_sigreturn`:139, `gettid`:178, `brk`:214, `munmap`:215, `mmap`:222, `mprotect`:226, `madvise`:233, `prlimit64`:261, `rseq`:293 |
+| `read(_)` | `openat`:257, (`read`:0 already in baseline), `close`:3, `lseek`:8, `statx`:332, `newfstatat`:262 | `openat`:56, (`read`:63 already), `close`:57, `lseek`:62, `newfstatat`:79, `statx`:291 |
+| `write(_)` | `openat`:257, (`write`:1 already), `fsync`:74, `newfstatat`:262 | `openat`:56, (`write`:64 already), `newfstatat`:79, `fsync`:82 |
+| `net(_)` | `socket`:41, `connect`:42, `sendto`:44, `recvfrom`:45, `setsockopt`:54, `getsockopt`:55 | `socket`:198, `connect`:203, `sendto`:206, `recvfrom`:207, `setsockopt`:208, `getsockopt`:209 |
+| `alloc` | (already baseline: `mmap`/`munmap`/`brk`/`mprotect`) | (already baseline: `mmap`/`munmap`/`brk`/`mprotect`) |
+| `time` | `clock_gettime`:228, `clock_nanosleep`:230 | `clock_gettime`:113, `clock_nanosleep`:115 |
+| `rand` | `getrandom`:318 | `getrandom`:278 |
+| `term` (NEW, #106) | `ioctl`:16 (termios `TCGETS`/`TCSETS` — but seccomp can't filter the cmd; the whole `ioctl` is granted under `term`, OQ-5) | `ioctl`:29 (same scope caveat) |
+| `panic` | (baseline `write`+`exit_group`; panic unwinds + prints to stderr) | (baseline `write`+`exit_group`; panic unwinds + prints to stderr) |
+| `diverge` | (no added syscall; divergence is a non-termination effect) | (no added syscall; divergence is a non-termination effect) |
 
 > The baseline is a SUPERSET-of-minimum: it allows the syscalls the Rust runtime
 > startup/teardown + `println!` + the L1 `thermite_check!` panic path need. It pointedly
@@ -266,19 +273,19 @@ TCGETS-only filter would need an arg-inspecting filter (a future refinement, OQ-
 
 ## Grounding the #106 fix (real `forge`/`rustc`)
 
-Grounded on this Linux host (`rustc 1.95.0`, kernel `6.6.87.2-microsoft-WSL2`,
+Grounded on this x86_64 Linux host (`rustc 1.95.0`, kernel `6.6.87.2-microsoft-WSL2`,
 `/proc/sys/kernel/seccomp/actions_avail` ⊇ `kill_process`) against `forge` built from
 this tree. The atom is not yet implemented (no `Effect::Term`), so the grant was
-grounded by a PROBE — temporarily adding `16 // ioctl` to `WRITE_SYSCALLS` to prove
-`ioctl` is the EXACT missing syscall — then REVERTED (the tree is clean; the probe
-edit lived only during grounding). The PRINCIPLED landing is the dedicated `term`
-atom above (#132), but the grant's SHAPE (the one syscall, the kill→clean flip) is
-identical.
+grounded by a PROBE — temporarily adding the x86_64 `16 // ioctl` to
+`WRITE_SYSCALLS` to prove `ioctl` is the EXACT missing syscall — then REVERTED (the
+tree is clean; the probe edit lived only during grounding). The PRINCIPLED landing is
+the dedicated `term` atom above (#132), but the grant's SHAPE (the one syscall, the
+kill→clean flip) is identical.
 
 **(1) The editor SIGSYS-dies sandboxed TODAY (the #106 bug).** `forge build
 examples/editor/editor.th --entry run` (default sandbox) → transitive
 `fx = [alloc, diverge, pure, read(input), write(output)]`, allowlist EXCLUDES
-`ioctl`:16. Run with piped keystrokes (`printf 'ab\x11'`, Ctrl-Q):
+x86_64 `ioctl`:16. Run with piped keystrokes (`printf 'ab\x11'`, Ctrl-Q):
 
 ```
 Bad system call (core dumped)
@@ -290,9 +297,9 @@ before any frame is written. This is why `forge/tests/editor_runs.rs` builds the
 editor `--no-sandbox` today (the honest seam it documents).
 
 **(2) With `ioctl` granted, the editor runs FULLY sandboxed (exit 0).** The probe
-adds `ioctl`:16; rebuild + `forge build … --entry run` (default sandbox) → allowlist
-INCLUDES 16. Run `printf 'XY\x13\x11'` (insert X, Y; Ctrl-S save; Ctrl-Q quit) over
-the demo file `hello world`:
+adds x86_64 `ioctl`:16; rebuild + `forge build … --entry run` (default sandbox) →
+allowlist INCLUDES 16. Run `printf 'XY\x13\x11'` (insert X, Y; Ctrl-S save; Ctrl-Q
+quit) over the demo file `hello world`:
 
 ```
 === SANDBOXED run exit: 0 ===
@@ -309,7 +316,8 @@ the baseline). NO residual syscall gap (see the file-syscall note below).
 
 **(3) The grant is SCOPED — a non-`term` program's `ioctl` is still killed.** Under
 the probe (folded into `write` for grounding), a `pure` program's allowlist
-EXCLUDES `ioctl`:16, and a `read(src)` program's allowlist EXCLUDES `ioctl`:16:
+EXCLUDES x86_64 `ioctl`:16, and a `read(src)` program's allowlist EXCLUDES x86_64
+`ioctl`:16:
 
 ```
 pure:     ioctl(16) in allowlist: False   | fx: ['pure']
@@ -325,13 +333,13 @@ sandboxed editor run exits 159 again, confirming `ioctl` is the lone gating sysc
 
 **The file-open/write syscalls (read_file/write_file) are COVERED — no residual gap.**
 The editor's `os::read_file` declares `fx read(input)` and `os::write_file` declares
-`fx write(output)`. `read(_)` widens with `openat`:257 (+`read`:0 baseline) and
-`write(_)` widens with `openat`:257 (+`write`:1 baseline) — so the Ctrl-S save's
-`std::fs::write` (`openat` + `write`) and the initial `std::fs::read` load (`openat` +
-`read`) are ALREADY granted by the editor's existing `read`/`write` fx. GROUNDED in
-(2): the Ctrl-S save wrote `XYhello world` to the file under the sandbox with NO extra
-syscall gap. The ONLY missing syscall was `ioctl` (the termios boundary); no separate
-"file effect" is needed.
+`fx write(output)`. On the x86_64 grounding host, `read(_)` widens with `openat`:257
+(+`read`:0 baseline) and `write(_)` widens with `openat`:257 (+`write`:1 baseline) —
+so the Ctrl-S save's `std::fs::write` (`openat` + `write`) and the initial
+`std::fs::read` load (`openat` + `read`) are ALREADY granted by the editor's existing
+`read`/`write` fx. GROUNDED in (2): the Ctrl-S save wrote `XYhello world` to the file
+under the sandbox with NO extra syscall gap. The ONLY missing syscall was `ioctl` (the
+termios boundary); no separate "file effect" is needed.
 
 ## Verification
 
@@ -377,11 +385,13 @@ The discharging checks (post-implementation):
   a SIGSYS handler (the DISCOVER mode) could print the offending syscall for a crisper
   §5 message, at the cost of a handler in every binary. Decision deferred to the
   builder; the doc pins KILL_PROCESS as the default (simplest, matches §4.1 "killed").
-- **OQ-3 (architecture portability):** the filter pins `AUDIT_ARCH_X86_64`. A non-x86_64
-  Linux host (or non-Linux) needs a different table / a no-op `--no-sandbox` fallback.
-  v0.1 is x86_64-Linux only (documented limitation), `--no-sandbox` is the escape.
+- **OQ-3 (architecture portability):** shipped support covers native x86_64-Linux and
+  aarch64-Linux generated runners. Other Linux architectures and non-Linux hosts still
+  need a different table / a no-op `--no-sandbox` fallback. The aarch64 syscall
+  numbers are ABI-grounded, but the baseline membership still needs native arm64
+  runtime conformance before it is considered as empirically grounded as x86_64.
 - **OQ-5 (`ioctl`-broad vs `TCGETS`/`TCSETS`-only — #106):** the `term` grant is the
-  WHOLE `ioctl` syscall (#16, any cmd), because classic seccomp-bpf compares only
+  WHOLE native `ioctl` syscall (any cmd), because classic seccomp-bpf compares only
   `seccomp_data.nr` — it cannot gate `ioctl` by its `cmd` register without an
   arg-inspecting filter (a `BPF_JEQ` on the second arg, a v1.1 refinement). The honest
   v1 scope is therefore "`term` ⇒ any `ioctl`," DOCUMENTED in REQ-7 + the manifest's
@@ -411,8 +421,8 @@ cite) and the route above. This doc does NOT author the oracle or the route (R-D
 |---|---|---|
 | REQ-1 (seccomp prelude install via raw `libc` `prctl`) | SHIPPED | `sandbox::emit_sandbox_prelude` emits a `sock_filter[]` program (arch-guard + per-syscall `BPF_JEQ` → `SECCOMP_RET_ALLOW`, default `SECCOMP_RET_KILL_PROCESS`) installed via `prctl(PR_SET_NO_NEW_PRIVS)` + `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER)`, raw `extern "C"` (no libc crate). Consumer: `build::synthesize_entry_main`. Verified by `sandbox_conformance::pure_runs_clean` + `probe_killed` (real seccomp kill, exit 159). |
 | REQ-2 (transitive-`fx` derivation via `closure.rs`) | SHIPPED | `sandbox::transitive_fx` unions `manifest::effects_of` over `{entry} ∪ closure::reachable_in_file_fns(program, entry)` (the #17 walker, never duplicated). Consumer: `build::synthesize_entry_main` + `build::build_file`. Verified by `sandbox_conformance::probe_allowed_when_fx_widens` (the `read` fx widens the allowlist → openat permitted). |
-| REQ-3 (`fx` → syscall allowlist mapping) | SHIPPED | `sandbox::syscall_allowlist` maps each token's leading verb to the pinned x86_64 set (the [mapping table](#fx--syscall-allowlist-mapping)); `pure` baseline excludes `openat`, `read(_)` adds it; sorted + deduped (deterministic). Verified by `probe_killed` (pure, no openat → kill) vs `probe_allowed_when_fx_widens` (read, openat → allowed). |
+| REQ-3 (`fx` → syscall allowlist mapping) | SHIPPED | `sandbox::syscall_allowlist_for_arch` maps each token's leading verb to the pinned x86_64 or aarch64 set (the [mapping table](#fx--syscall-allowlist-mapping)); `pure` baseline excludes `openat`, `read(_)` adds it; sorted + deduped (deterministic). The legacy `syscall_allowlist` remains the x86_64 wrapper for the Verus anchor. Verified by `probe_killed` (pure, no openat → kill) vs `probe_allowed_when_fx_widens` (read, openat → allowed) and `sandbox::tests::aarch64_allowlist_uses_native_syscall_numbers`. |
 | REQ-4 (sandbox-on-by-default for `--entry`, `--no-sandbox` opt-out) | SHIPPED | `build::SandboxConfig::default` is `SandboxMode::On`; `synthesize_entry_main` injects the prelude FIRST when on; `--no-sandbox` → `SandboxMode::Off` (no prelude); a library build emits no `main`. Consumer: `cli::run_build` (the `--sandbox`/`--no-sandbox` flags). Verified by `sandbox_conformance::no_sandbox_omits_prelude`. |
 | REQ-5 (reproducible prelude + manifest record) | SHIPPED | `emit_sandbox_prelude` is byte-deterministic (sorted allowlist); `build::BuildManifest::sandbox` (`SandboxRecord`) records the installed allowlist (the §9 audit surface). Verified by `sandbox::tests::prelude_installs_and_is_deterministic` + `sandbox_conformance::pure_runs_clean`. |
 | REQ-6 (demonstrable enforcement — probe + clean pure run) | SHIPPED | `sandbox::emit_probe` injects (under `--sandbox-self-test`, AFTER the filter) a raw `syscall(SYS_openat, ...)`. Consumer: `build::synthesize_entry_main`. Verified by `probe_killed` (exit 159 under pure) vs `probe_allowed_when_fx_widens` (exit 0 under read). The critical interaction — a contract violation still PANICS `[ens]` (exit 101), NOT seccomp-killed — is verified by `contract_violation_panics_not_killed` (the baseline allows the panic/abort path). |
-| REQ-7 (the `term` terminal-control atom + the `ioctl` grant, #106) | SHIPPED | blocker **#132** closed. `Effect::Term` in `thermite_syntax::ast::Effect` (parsed as `fx term` by `parser::parse_effect`); `EffectKind::Term` (bit 8) in `thermite_lower::effects` over the WIDENED 9-atom `u16` bitset (the proved subsumption bitset widened `u8`→`u16` in `thermite-verified`, `verus --no-cheating` → `27 verified, 0 errors`); `sandbox::TERM_SYSCALLS = &[16 /* ioctl */]` + the `"term" => TERM_SYSCALLS` arm in `syscall_allowlist`. The atom ripples through every `Effect`-exhaustive seam (`manifest::effect_token`, `lower::effect_atom_name`, `vacuity::effect_row_is_maximal`, `generate::render_effect_arm`/`effect_inventory`). The `examples/editor/editor.th` `run` entry's `raw_mode_on`/`raw_mode_off` declare `fx term`, so its transitive `fx` unions `term` and the allowlist INCLUDES `ioctl`:16 — the editor builds + runs FULLY sandboxed (NO `--no-sandbox`, exit 0: raw mode + edit + Ctrl-S save) via `forge/tests/editor_runs.rs`. The grant is SCOPED (a `pure`/`read`/`write`/`net` program's allowlist EXCLUDES `ioctl` — `sandbox::tests::term_grants_ioctl_scoped_to_the_effect` + `sandbox_conformance::term_grant_adds_ioctl_to_the_recorded_allowlist`). `term` (bit 8) is NON-io-sensitive (`widen(8)==0`), so the verus `io_allow` soundness bitset is unaffected over all 512 fx-masks (`sandbox::verus_anchor`, OQ-5 `ioctl`-broad). |
+| REQ-7 (the `term` terminal-control atom + the `ioctl` grant, #106) | SHIPPED | blocker **#132** closed. `Effect::Term` in `thermite_syntax::ast::Effect` (parsed as `fx term` by `parser::parse_effect`); `EffectKind::Term` (bit 8) in `thermite_lower::effects` over the WIDENED 9-atom `u16` bitset (the proved subsumption bitset widened `u8`→`u16` in `thermite-verified`, `verus --no-cheating` → `27 verified, 0 errors`); `sandbox::TERM_SYSCALLS = &[16 /* ioctl */]` and `TERM_AARCH64_SYSCALLS = &[29 /* ioctl */]` + the `"term"` widening arm in `syscall_allowlist_for_arch`. The atom ripples through every `Effect`-exhaustive seam (`manifest::effect_token`, `lower::effect_atom_name`, `vacuity::effect_row_is_maximal`, `generate::render_effect_arm`/`effect_inventory`). The `examples/editor/editor.th` `run` entry's `raw_mode_on`/`raw_mode_off` declare `fx term`, so its transitive `fx` unions `term` and the allowlist INCLUDES host-native `ioctl` — the editor builds + runs FULLY sandboxed (NO `--no-sandbox`, exit 0: raw mode + edit + Ctrl-S save) via `forge/tests/editor_runs.rs`. The grant is SCOPED (a `pure`/`read`/`write`/`net` program's allowlist EXCLUDES `ioctl` — `sandbox::tests::term_grants_ioctl_scoped_to_the_effect` + `sandbox_conformance::term_grant_adds_ioctl_to_the_recorded_allowlist`). `term` (bit 8) is NON-io-sensitive (`widen(8)==0`), so the verus `io_allow` soundness bitset is unaffected over all 512 fx-masks (`sandbox::verus_anchor`, OQ-5 `ioctl`-broad). |

--- a/forge/src/build.rs
+++ b/forge/src/build.rs
@@ -201,8 +201,8 @@ pub struct SandboxRecord {
     pub installed: bool,
     /// The transitive `fx` tokens the allowlist was derived from (REQ-2), sorted.
     pub transitive_fx: Vec<String>,
-    /// The installed x86_64 syscall allowlist (REQ-3), sorted ascending. Empty when
-    /// no prelude was injected.
+    /// The installed host-architecture syscall allowlist (REQ-3), sorted ascending.
+    /// Empty when no prelude was injected.
     pub syscall_allowlist: Vec<u32>,
 }
 
@@ -380,7 +380,7 @@ pub fn build_file(
     let sandbox_record = match (entry, sandbox.mode) {
         (Some(name), SandboxMode::On) => {
             let fx = sandbox::transitive_fx(&program, name);
-            let allowlist = sandbox::syscall_allowlist(&fx);
+            let allowlist = sandbox::syscall_allowlist_for_host(&fx);
             SandboxRecord {
                 installed: true,
                 transitive_fx: fx.into_iter().collect(),
@@ -656,8 +656,7 @@ fn synthesize_entry_main(
     let prelude = match sandbox.mode {
         SandboxMode::On => {
             let fx = sandbox::transitive_fx(program, &f.name);
-            let allowlist = sandbox::syscall_allowlist(&fx);
-            sandbox::emit_sandbox_prelude(&allowlist)
+            sandbox::emit_sandbox_prelude(&fx)
         }
         SandboxMode::Off => String::new(),
     };

--- a/forge/src/sandbox.rs
+++ b/forge/src/sandbox.rs
@@ -15,16 +15,18 @@
 //!    #17 cycle-safe, source-order reachability `check::item_subprogram` consumes,
 //!    restricted to the entry's intra-file closure. A `#[boundary]`/`#[slag]` fn in
 //!    the closure contributes its declared `fx`, and is confined to that.
-//! 2. `fx` → syscall allowlist ([`syscall_allowlist`]): each `fx` token maps to
-//!    a fixed set of x86_64 syscall numbers ([the table](#the-fx--syscall-table));
+//! 2. `fx` → syscall allowlist ([`syscall_allowlist_for_arch`]): each `fx` token
+//!    maps to a fixed set of target-architecture syscall numbers ([the table](#the-fx--syscall-table));
 //!    `pure` is the minimal baseline (run + print + the panic/abort path), `read`/
-//!    `write`/`net`/`time`/`rand`/`term` widen (`term` → `ioctl`:16, #106).
-//!    Deterministic (sorted, deduped).
+//!    `write`/`net`/`time`/`rand`/`term` widen (`term` → `ioctl`, #106).
+//!    Deterministic (sorted, deduped). [`syscall_allowlist`] remains the x86_64
+//!    compatibility wrapper used by the existing verification anchor.
 //! 3. the BPF prelude ([`emit_sandbox_prelude`]): the Rust source that, as the
 //!    first statements of the generated `main`, builds a classic `sock_filter[]`
-//!    program (arch-guard for x86_64 → load `nr` → a `BPF_JEQ` per allowed syscall →
-//!    `SECCOMP_RET_ALLOW`, default `SECCOMP_RET_KILL_PROCESS`) and installs it via
-//!    `prctl(PR_SET_NO_NEW_PRIVS)` + `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER)`.
+//!    program (cfg-selected arch guard for x86_64 or aarch64 → load `nr` → a
+//!    `BPF_JEQ` per allowed syscall → `SECCOMP_RET_ALLOW`, default
+//!    `SECCOMP_RET_KILL_PROCESS`) and installs it via `prctl(PR_SET_NO_NEW_PRIVS)`
+//!    + `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER)`.
 //!
 //! ## The fx → syscall table
 //!
@@ -153,10 +155,95 @@ const TERM_SYSCALLS: &[u32] = &[
     16, // ioctl (termios TCGETS/TCSETS — the cmd cannot be filtered, OQ-5)
 ];
 
+/// The aarch64 syscall numbers use the Linux `asm-generic/unistd.h` numbering. The
+/// table mirrors the x86_64 effect-surface shape, but the runtime baseline still
+/// needs live arm64-Linux conformance before it should be treated as empirically
+/// maxed. In particular, arm64 has no `arch_prctl` or `poll` syscall; the table uses
+/// the syscalls available on native aarch64 Linux.
+const BASELINE_AARCH64_SYSCALLS: &[u32] = &[
+    57,  // close
+    63,  // read
+    64,  // write
+    93,  // exit
+    94,  // exit_group
+    96,  // set_tid_address
+    98,  // futex
+    99,  // set_robust_list
+    123, // sched_getaffinity
+    132, // sigaltstack
+    134, // rt_sigaction
+    135, // rt_sigprocmask
+    139, // rt_sigreturn
+    178, // gettid
+    214, // brk
+    215, // munmap
+    222, // mmap
+    226, // mprotect
+    233, // madvise
+    261, // prlimit64
+    293, // rseq
+];
+
+const READ_AARCH64_SYSCALLS: &[u32] = &[
+    56,  // openat
+    62,  // lseek
+    79,  // newfstatat
+    291, // statx
+];
+
+const WRITE_AARCH64_SYSCALLS: &[u32] = &[
+    56, // openat
+    79, // newfstatat
+    82, // fsync
+];
+
+const NET_AARCH64_SYSCALLS: &[u32] = &[
+    198, // socket
+    203, // connect
+    206, // sendto
+    207, // recvfrom
+    208, // setsockopt
+    209, // getsockopt
+];
+
+const TIME_AARCH64_SYSCALLS: &[u32] = &[
+    113, // clock_gettime
+    115, // clock_nanosleep
+];
+
+const RAND_AARCH64_SYSCALLS: &[u32] = &[
+    278, // getrandom
+];
+
+const TERM_AARCH64_SYSCALLS: &[u32] = &[
+    29, // ioctl
+];
+
 /// The x86_64 `openat` syscall number — the [`emit_probe`] self-test attempts it
 /// (`--sandbox-self-test`); denied under a `pure` filter (kill), allowed under
 /// `read`. Mirrors the `READ_SYSCALLS` `openat`:257 entry.
-const SYS_OPENAT: u32 = 257;
+const SYS_OPENAT_X86_64: u32 = 257;
+/// The aarch64 `openat` syscall number (`asm-generic/unistd.h`).
+const SYS_OPENAT_AARCH64: u32 = 56;
+/// Compatibility alias for x86_64-only tests and the Verus anchor.
+const SYS_OPENAT: u32 = SYS_OPENAT_X86_64;
+
+/// Seccomp architectures the generated runner can install natively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeccompArch {
+    X86_64,
+    Aarch64,
+}
+
+impl SeccompArch {
+    pub fn host() -> Option<Self> {
+        match std::env::consts::ARCH {
+            "x86_64" => Some(Self::X86_64),
+            "aarch64" => Some(Self::Aarch64),
+            _ => None,
+        }
+    }
+}
 
 /// Whether a `forge build --entry` produces a sandboxed runner (REQ-4). On by
 /// default for `--entry` (the §4.1 default is enforcement, not opt-in); `--no-sandbox`
@@ -204,25 +291,42 @@ pub fn transitive_fx(program: &Program, entry: &str) -> BTreeSet<String> {
 /// carried ident is irrelevant. Returns
 /// the syscall numbers sorted and deduped — the same transitive `fx` yields the
 /// byte-identical allowlist (deterministic, R-CODE-5).
-pub fn syscall_allowlist(transitive_fx: &BTreeSet<String>) -> Vec<u32> {
-    let mut set: BTreeSet<u32> = BASELINE_SYSCALLS.iter().copied().collect();
+fn baseline_syscalls(arch: SeccompArch) -> &'static [u32] {
+    match arch {
+        SeccompArch::X86_64 => BASELINE_SYSCALLS,
+        SeccompArch::Aarch64 => BASELINE_AARCH64_SYSCALLS,
+    }
+}
+
+fn widening_syscalls(arch: SeccompArch, verb: &str) -> &'static [u32] {
+    match (arch, verb) {
+        (SeccompArch::X86_64, "read") => READ_SYSCALLS,
+        (SeccompArch::X86_64, "write") => WRITE_SYSCALLS,
+        (SeccompArch::X86_64, "net") => NET_SYSCALLS,
+        (SeccompArch::X86_64, "time") => TIME_SYSCALLS,
+        (SeccompArch::X86_64, "rand") => RAND_SYSCALLS,
+        (SeccompArch::X86_64, "term") => TERM_SYSCALLS,
+        (SeccompArch::Aarch64, "read") => READ_AARCH64_SYSCALLS,
+        (SeccompArch::Aarch64, "write") => WRITE_AARCH64_SYSCALLS,
+        (SeccompArch::Aarch64, "net") => NET_AARCH64_SYSCALLS,
+        (SeccompArch::Aarch64, "time") => TIME_AARCH64_SYSCALLS,
+        (SeccompArch::Aarch64, "rand") => RAND_AARCH64_SYSCALLS,
+        (SeccompArch::Aarch64, "term") => TERM_AARCH64_SYSCALLS,
+        // "pure" / "alloc" / "panic" / "diverge" / any unknown → baseline-only.
+        _ => &[],
+    }
+}
+
+/// Map a transitive `fx` token set to the native syscall allowlist for `arch`
+/// (REQ-3): the baseline unioned with every widening token's added syscalls.
+/// Returns sorted and deduped numbers.
+pub fn syscall_allowlist_for_arch(transitive_fx: &BTreeSet<String>, arch: SeccompArch) -> Vec<u32> {
+    let mut set: BTreeSet<u32> = baseline_syscalls(arch).iter().copied().collect();
     for tok in transitive_fx {
         // The leading verb (before any `(`) selects the widening set; `pure`/
         // `alloc`/`panic`/`diverge` are baseline-only (no widening).
         let verb = tok.split('(').next().unwrap_or(tok);
-        let widen: &[u32] = match verb {
-            "read" => READ_SYSCALLS,
-            "write" => WRITE_SYSCALLS,
-            "net" => NET_SYSCALLS,
-            "time" => TIME_SYSCALLS,
-            "rand" => RAND_SYSCALLS,
-            // `term` (#106) widens with `ioctl`:16 for the termios raw-mode boundary
-            // (runtime-sandbox.md REQ-7). Scoped to the effect — only a `term`
-            // program's allowlist gains `ioctl`.
-            "term" => TERM_SYSCALLS,
-            // "pure" / "alloc" / "panic" / "diverge" / any unknown → baseline-only.
-            _ => &[],
-        };
+        let widen = widening_syscalls(arch, verb);
         for &nr in widen {
             set.insert(nr);
         }
@@ -230,39 +334,42 @@ pub fn syscall_allowlist(transitive_fx: &BTreeSet<String>) -> Vec<u32> {
     set.into_iter().collect()
 }
 
-/// Emit the Rust source of the seccomp-bpf filter-install prelude for `allowlist`
-/// (REQ-1/REQ-3/REQ-5): a self-contained block that builds a classic `sock_filter[]`
-/// program (x86_64 arch-guard → load `nr` → a `BPF_JEQ` per allowed syscall →
-/// `SECCOMP_RET_ALLOW`, default `SECCOMP_RET_KILL_PROCESS`) and installs it via
-/// `prctl(PR_SET_NO_NEW_PRIVS)` + `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER)`. The
-/// `prctl` is declared `extern "C"` (resolved against the std binary's already-linked
-/// libc — no libc crate dependency). Injected as the first statements of the
-/// generated `main` so the entry runs under the filter.
-///
-/// Byte-deterministic: `allowlist` is iterated in order (the caller passes the
-/// sorted [`syscall_allowlist`] output), so the same transitive `fx` yields the
-/// byte-identical prelude (REQ-5, R-CODE-5).
-pub fn emit_sandbox_prelude(allowlist: &[u32]) -> String {
+/// Map a transitive `fx` token set to the x86_64 syscall allowlist (REQ-3). This
+/// compatibility wrapper preserves the historical API used by the Verus anchor.
+pub fn syscall_allowlist(transitive_fx: &BTreeSet<String>) -> Vec<u32> {
+    syscall_allowlist_for_arch(transitive_fx, SeccompArch::X86_64)
+}
+
+/// Map a transitive `fx` token set to the host architecture's manifest allowlist.
+/// Unsupported hosts fall back to the historical x86_64 table; sandboxed generated
+/// runners still reject unsupported compile targets in [`emit_sandbox_prelude`].
+pub fn syscall_allowlist_for_host(transitive_fx: &BTreeSet<String>) -> Vec<u32> {
+    match SeccompArch::host().unwrap_or(SeccompArch::X86_64) {
+        SeccompArch::X86_64 => syscall_allowlist(transitive_fx),
+        SeccompArch::Aarch64 => syscall_allowlist_for_arch(transitive_fx, SeccompArch::Aarch64),
+    }
+}
+
+fn emit_filter_lines(arch_label: &str, audit_arch_const: &str, allowlist: &[u32]) -> String {
     // The classic-BPF program. Each accepted-syscall comparison is a single
     // `BPF_JMP|BPF_JEQ|BPF_K` instruction: if `nr == <num>` jump to the ALLOW
     // return (jt), else fall through (jf=0) to the next comparison. After the last
     // comparison the program falls through to the KILL return. The header loads the
-    // arch then the syscall number; a non-x86_64 arch is killed (REQ-1, OQ-3).
+    // arch then the syscall number; a non-native arch is killed (REQ-1, OQ-3).
     //
     // `seccomp_data` layout (offsets): nr @ 0, arch @ 4.
     let mut filter_lines = String::new();
 
-    // Header: load arch, kill if not x86_64; load nr.
-    filter_lines.push_str(
-        "        // load seccomp_data.arch (offset 4); kill if not x86_64\n\
+    filter_lines.push_str(&format!(
+        "        // load seccomp_data.arch (offset 4); kill if not {arch_label}\n\
          \x20       BpfStmt(BPF_LD | BPF_W | BPF_ABS, 4),\n\
-         \x20       BpfJump(BPF_JMP | BPF_JEQ | BPF_K, AUDIT_ARCH_X86_64, 1, 0),\n\
+         \x20       BpfJump(BPF_JMP | BPF_JEQ | BPF_K, {audit_arch_const}, 1, 0),\n\
          \x20       BpfStmt(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),\n\
          \x20       // load seccomp_data.nr (offset 0)\n\
          \x20       BpfStmt(BPF_LD | BPF_W | BPF_ABS, 0),\n",
-    );
+    ));
 
-    // One JEQ per allowed syscall (jt=1 → jump over the fall-through to ALLOW).
+    // One JEQ per allowed syscall (jt=0 → execute the following ALLOW return).
     for &nr in allowlist {
         filter_lines.push_str(&format!(
             "        BpfJump(BPF_JMP | BPF_JEQ | BPF_K, {nr}, 0, 1),\n\
@@ -272,7 +379,28 @@ pub fn emit_sandbox_prelude(allowlist: &[u32]) -> String {
 
     // Default action: kill the whole process (a syscall off the allowlist → SIGSYS).
     filter_lines.push_str("        BpfStmt(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),\n");
+    filter_lines
+}
 
+/// Emit the Rust source of the seccomp-bpf filter-install prelude for `transitive_fx`
+/// (REQ-1/REQ-3/REQ-5): a self-contained block that builds a cfg-selected classic
+/// `sock_filter[]` program (x86_64 or aarch64 arch-guard → load `nr` → a `BPF_JEQ`
+/// per allowed syscall → `SECCOMP_RET_ALLOW`, default
+/// `SECCOMP_RET_KILL_PROCESS`) and installs it via
+/// `prctl(PR_SET_NO_NEW_PRIVS)` + `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER)`. The
+/// `prctl` is declared `extern "C"` (resolved against the std binary's already-linked
+/// libc — no libc crate dependency). Injected as the first statements of the
+/// generated `main` so the entry runs under the filter.
+///
+/// Byte-deterministic: each per-arch allowlist is sorted by
+/// [`syscall_allowlist_for_arch`], so the same transitive `fx` yields the
+/// byte-identical prelude (REQ-5, R-CODE-5).
+pub fn emit_sandbox_prelude(transitive_fx: &BTreeSet<String>) -> String {
+    let x86_allowlist = syscall_allowlist_for_arch(transitive_fx, SeccompArch::X86_64);
+    let aarch64_allowlist = syscall_allowlist_for_arch(transitive_fx, SeccompArch::Aarch64);
+    let x86_filter_lines = emit_filter_lines("x86_64", "AUDIT_ARCH_X86_64", &x86_allowlist);
+    let aarch64_filter_lines =
+        emit_filter_lines("aarch64", "AUDIT_ARCH_AARCH64", &aarch64_allowlist);
     format!(
         r##"
 // ---- thermite #57 runtime effect sandbox (seccomp-bpf, fx-derived) ----------
@@ -282,7 +410,7 @@ pub fn emit_sandbox_prelude(allowlist: &[u32]) -> String {
 // Raw `extern "C"` prctl resolved against the std binary's linked libc (no libc
 // crate). Deterministic: the allowlist below is the sorted fx->syscall projection.
 {{
-    // classic-BPF opcodes / seccomp constants (x86_64 Linux).
+    // classic-BPF opcodes / seccomp constants (Linux).
     const BPF_LD: u16 = 0x00;
     const BPF_W: u16 = 0x00;
     const BPF_ABS: u16 = 0x20;
@@ -291,6 +419,7 @@ pub fn emit_sandbox_prelude(allowlist: &[u32]) -> String {
     const BPF_K: u16 = 0x00;
     const BPF_RET: u16 = 0x06;
     const AUDIT_ARCH_X86_64: u32 = 0xC000_003E;
+    const AUDIT_ARCH_AARCH64: u32 = 0xC000_00B7;
     const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
     const SECCOMP_RET_KILL_PROCESS: u32 = 0x8000_0000;
     const PR_SET_NO_NEW_PRIVS: i32 = 38;
@@ -312,8 +441,16 @@ pub fn emit_sandbox_prelude(allowlist: &[u32]) -> String {
         fn prctl(option: i32, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> i32;
     }}
 
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    compile_error!("thermite #57 sandbox supports only x86_64 and aarch64 Linux runners");
+
+    #[cfg(target_arch = "x86_64")]
     static FILTER: &[SockFilter] = &[
-{filter_lines}    ];
+{x86_filter_lines}    ];
+
+    #[cfg(target_arch = "aarch64")]
+    static FILTER: &[SockFilter] = &[
+{aarch64_filter_lines}    ];
 
     // SAFETY: `prctl` is the documented Linux seccomp-install primitive; FILTER is a
     // valid, static, correctly-sized classic-BPF program and FILTER.len() fits u16
@@ -351,7 +488,13 @@ pub fn emit_probe() -> String {
 // -> SIGSYS -> the process is killed BEFORE the entry call (exit 159); under a
 // read(_) filter openat is allowlisted -> the probe returns and the entry runs.
 {{
+    #[cfg(target_arch = "x86_64")]
     const SYS_OPENAT: i64 = {SYS_OPENAT};
+    #[cfg(target_arch = "aarch64")]
+    const SYS_OPENAT: i64 = {SYS_OPENAT_AARCH64};
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    compile_error!("thermite #57 sandbox probe supports only x86_64 and aarch64 Linux runners");
+
     const AT_FDCWD: i64 = -100;
     extern "C" {{
         fn syscall(num: i64, ...) -> i64;
@@ -425,6 +568,35 @@ mod tests {
         assert_eq!(
             syscall_allowlist(&set(&["alloc", "panic", "diverge"])),
             syscall_allowlist(&set(&["pure"]))
+        );
+    }
+
+    // Issue #27: the aarch64 table is parallel to the x86_64 table but uses native
+    // Linux arm64 syscall numbers (`openat` 56, `ioctl` 29, `clock_gettime` 113).
+    #[test]
+    fn aarch64_allowlist_uses_native_syscall_numbers() {
+        let read = syscall_allowlist_for_arch(&set(&["read(src)"]), SeccompArch::Aarch64);
+        assert!(
+            read.contains(&56),
+            "read(_) allowlists aarch64 openat: {read:?}"
+        );
+        assert!(
+            !read.contains(&257),
+            "aarch64 read table must not leak x86_64 openat: {read:?}"
+        );
+
+        let time = syscall_allowlist_for_arch(&set(&["time"]), SeccompArch::Aarch64);
+        assert!(time.contains(&113), "time allowlists aarch64 clock_gettime");
+        assert!(
+            !time.contains(&228),
+            "aarch64 time table excludes x86_64 clock_gettime"
+        );
+
+        let term = syscall_allowlist_for_arch(&set(&["term"]), SeccompArch::Aarch64);
+        assert!(term.contains(&29), "term allowlists aarch64 ioctl");
+        assert!(
+            !term.contains(&16),
+            "aarch64 term table excludes x86_64 ioctl"
         );
     }
 
@@ -513,13 +685,13 @@ mod tests {
     }
 
     // REQ-1/REQ-5: the prelude installs the filter (PR_SET_SECCOMP) and is
-    // byte-deterministic over the same allowlist (R-CODE-5).
+    // byte-deterministic over the same transitive fx (R-CODE-5).
     #[test]
     fn prelude_installs_and_is_deterministic() {
-        let allow = syscall_allowlist(&set(&["pure"]));
-        let a = emit_sandbox_prelude(&allow);
-        let b = emit_sandbox_prelude(&allow);
-        assert_eq!(a, b, "REQ-5: same allowlist → byte-identical prelude");
+        let pure_fx = set(&["pure"]);
+        let a = emit_sandbox_prelude(&pure_fx);
+        let b = emit_sandbox_prelude(&pure_fx);
+        assert_eq!(a, b, "REQ-5: same transitive fx → byte-identical prelude");
         assert!(
             a.contains("PR_SET_SECCOMP") && a.contains("PR_SET_NO_NEW_PRIVS"),
             "REQ-1: the prelude installs the seccomp filter"
@@ -528,15 +700,28 @@ mod tests {
             a.contains("SECCOMP_RET_KILL_PROCESS"),
             "REQ-1: the default action is kill-process"
         );
-        // the pure prelude must not JEQ openat (257); a read prelude must.
+        assert!(
+            a.contains("AUDIT_ARCH_X86_64") && a.contains("AUDIT_ARCH_AARCH64"),
+            "issue #27: the prelude carries both supported arch guards"
+        );
+        // the pure prelude must not JEQ openat (257/56); a read prelude must for
+        // each cfg-selected architecture.
         assert!(
             !a.contains("BPF_JEQ | BPF_K, 257"),
             "pure prelude has no openat comparison"
         );
-        let read = emit_sandbox_prelude(&syscall_allowlist(&set(&["read(s)"])));
+        assert!(
+            !a.contains("BPF_JEQ | BPF_K, 56"),
+            "pure prelude has no aarch64 openat comparison"
+        );
+        let read = emit_sandbox_prelude(&set(&["read(s)"]));
         assert!(
             read.contains("BPF_JEQ | BPF_K, 257"),
-            "read prelude has an openat comparison"
+            "read prelude has an x86_64 openat comparison"
+        );
+        assert!(
+            read.contains("BPF_JEQ | BPF_K, 56"),
+            "read prelude has an aarch64 openat comparison"
         );
     }
 
@@ -546,6 +731,7 @@ mod tests {
         let p = emit_probe();
         assert!(p.contains("SYS_OPENAT") && p.contains("syscall"));
         assert!(p.contains(&SYS_OPENAT.to_string()));
+        assert!(p.contains(&SYS_OPENAT_AARCH64.to_string()));
     }
 }
 

--- a/forge/tests/acceptance_programs.rs
+++ b/forge/tests/acceptance_programs.rs
@@ -50,14 +50,14 @@
 //! The verus checks skip with a logged reason when verus is absent (the
 //! `string_format_conformance` / `editor_runs` precedent), rather than panic on a
 //! missing solver (R-CODE-4). The build + run uses `rustc`, but the `--entry`
-//! runner carries the #57 x86_64-Linux seccomp prelude (raw `prctl`), so the
+//! runner carries the #57 native-Linux seccomp prelude (raw `prctl`), so the
 //! build+run tests SKIP with an explicit warning on any non-Linux platform
 //! (`linux_build_run_supported`): FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES
 //! LINUX CI — `cargo test` on macOS/Windows exercises `forge check` / verus /
 //! lowering but not the runnable seccomp twin. To run the build+run path locally on
-//! Apple Silicon, use an **x86_64 Linux container** (the seccomp arch-guard expects
-//! x86_64): e.g. `docker run --platform linux/amd64` / OrbStack with an amd64
-//! machine. `tests/` is not anti-pattern-gated, so `unwrap`/`expect`/`panic!` are
+//! Apple Silicon, use a native **aarch64 Linux container** or an **x86_64 Linux
+//! container**: e.g. `docker run --platform linux/arm64` or `linux/amd64` / OrbStack.
+//! `tests/` is not anti-pattern-gated, so `unwrap`/`expect`/`panic!` are
 //! fine here (R-APG-2).
 //!
 //! R-CHAR-3: expected levels trace to `.design/basis/07-strings.md` REQ-8 (the
@@ -114,23 +114,24 @@ fn verus_present() -> bool {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN on this
-/// platform. The #57 runtime effect sandbox (`forge/src/sandbox.rs`) is x86_64-Linux
-/// ONLY: `synthesize_entry_main` injects a raw `extern "C" { fn prctl }` seccomp-bpf
-/// prelude with an x86_64 BPF arch-guard, so the emitted runner does not link off
-/// Linux (`Undefined symbols: _prctl` on macOS/arm64). The build+run acceptance
+/// platform. The #57 runtime effect sandbox (`forge/src/sandbox.rs`) is native Linux
+/// only: `synthesize_entry_main` injects a raw `extern "C" { fn prctl }` seccomp-bpf
+/// prelude with x86_64/aarch64 BPF arch guards, so the emitted runner does not link
+/// off Linux (`Undefined symbols: _prctl` on macOS). The build+run acceptance
 /// tests therefore SKIP with an explicit warning on any non-Linux platform — they
 /// require LINUX CI for full acceptance. This mirrors the `verus_present()` skip
 /// precedent: a missing capability is a logged skip, not a panic (R-CODE-4). The
 /// `forge check` / verus / lower tests are platform-independent and still run.
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI — `cargo test` on this platform cannot exercise the runnable end-to-end \
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI \
+         — `cargo test` on this platform cannot exercise the runnable end-to-end \
          twin and skips it (the `forge check` / verus / lowering tests still run)."
     );
     false

--- a/forge/tests/build_conformance.rs
+++ b/forge/tests/build_conformance.rs
@@ -74,22 +74,23 @@ fn write_fixture(name: &str, body: &str) -> PathBuf {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN here. The
-/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is x86_64-Linux ONLY (a raw
-/// `prctl` seccomp prelude with an `AUDIT_ARCH_X86_64` BPF guard), so the emitted
-/// runner does not link off Linux (`Undefined symbols: _prctl` on macOS/arm64).
+/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is native Linux only, with
+/// generated filters for x86_64 and aarch64. The emitted runner does not link off
+/// Linux (`Undefined symbols: _prctl` on macOS).
 /// The build+run tests SKIP with an explicit warning on any non-Linux platform —
 /// FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX CI. Mirrors the
 /// `verus_present()` skip precedent (a missing capability is a logged skip, not a
 /// panic, R-CODE-4).
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI; `cargo test` on this platform skips the runnable end-to-end twin."
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI; \
+         `cargo test` on this platform skips the runnable end-to-end twin."
     );
     false
 }

--- a/forge/tests/divergence_effect_link_string_wrappers.rs
+++ b/forge/tests/divergence_effect_link_string_wrappers.rs
@@ -87,22 +87,23 @@ fn write_fixture(name: &str, src: &str) -> PathBuf {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN here. The
-/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is x86_64-Linux ONLY (a raw
-/// `prctl` seccomp prelude with an `AUDIT_ARCH_X86_64` BPF guard), so the emitted
-/// runner does not link off Linux (`Undefined symbols: _prctl` on macOS/arm64).
+/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is native Linux only, with
+/// generated filters for x86_64 and aarch64. The emitted runner does not link off
+/// Linux (`Undefined symbols: _prctl` on macOS).
 /// The build+run tests SKIP with an explicit warning on any non-Linux platform —
 /// FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX CI. Mirrors the
 /// `verus_present()` skip precedent (a missing capability is a logged skip, not a
 /// panic, R-CODE-4).
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI; `cargo test` on this platform skips the runnable end-to-end twin."
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI; \
+         `cargo test` on this platform skips the runnable end-to-end twin."
     );
     false
 }

--- a/forge/tests/divergence_numfmt_display_order.rs
+++ b/forge/tests/divergence_numfmt_display_order.rs
@@ -41,22 +41,23 @@ fn forge_bin() -> PathBuf {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN here. The
-/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is x86_64-Linux ONLY (a raw
-/// `prctl` seccomp prelude with an `AUDIT_ARCH_X86_64` BPF guard), so the emitted
-/// runner does not link off Linux (`Undefined symbols: _prctl` on macOS/arm64).
+/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is native Linux only, with
+/// generated filters for x86_64 and aarch64. The emitted runner does not link off
+/// Linux (`Undefined symbols: _prctl` on macOS).
 /// The build+run tests SKIP with an explicit warning on any non-Linux platform —
 /// FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX CI. Mirrors the
 /// `verus_present()` skip precedent (a missing capability is a logged skip, not a
 /// panic, R-CODE-4).
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI; `cargo test` on this platform skips the runnable end-to-end twin."
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI; \
+         `cargo test` on this platform skips the runnable end-to-end twin."
     );
     false
 }

--- a/forge/tests/editor_runs.rs
+++ b/forge/tests/editor_runs.rs
@@ -180,22 +180,23 @@ fn write_fixture(name: &str, body: &str) -> PathBuf {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN here. The
-/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is x86_64-Linux ONLY (a raw
-/// `prctl` seccomp prelude with an `AUDIT_ARCH_X86_64` BPF guard), so the emitted
-/// runner does not link off Linux (`Undefined symbols: _prctl` on macOS/arm64).
+/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is native Linux only, with
+/// generated filters for x86_64 and aarch64. The emitted runner does not link off
+/// Linux (`Undefined symbols: _prctl` on macOS).
 /// The build+run tests SKIP with an explicit warning on any non-Linux platform —
 /// FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX CI. Mirrors the
 /// `verus_present()` skip precedent (a missing capability is a logged skip, not a
 /// panic, R-CODE-4).
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI; `cargo test` on this platform skips the runnable end-to-end twin."
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI; \
+         `cargo test` on this platform skips the runnable end-to-end twin."
     );
     false
 }

--- a/forge/tests/effect_link_conformance.rs
+++ b/forge/tests/effect_link_conformance.rs
@@ -49,6 +49,11 @@ fn effect_link_demo() -> PathBuf {
 /// `true` iff this host's kernel offers the `kill_process` seccomp action (the #57
 /// mechanism). When absent the seccomp tests skip with a logged note (`runtime-sandbox.md` OQ-3).
 fn seccomp_kill_available() -> bool {
+    if !(cfg!(target_os = "linux")
+        && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64")))
+    {
+        return false;
+    }
     std::fs::read_to_string("/proc/sys/kernel/seccomp/actions_avail")
         .map(|s| s.contains("kill_process"))
         .unwrap_or(false)
@@ -149,6 +154,14 @@ fn find_cert<'a>(certs: &'a [Value], item: &str) -> &'a Value {
 
 // SIGSYS = 31; a process killed by it reports raw signal 31 / shell exit 159.
 const SIGSYS: i32 = 31;
+#[cfg(target_arch = "aarch64")]
+const EXPECT_CLOCK_GETTIME: i64 = 113;
+#[cfg(not(target_arch = "aarch64"))]
+const EXPECT_CLOCK_GETTIME: i64 = 228;
+#[cfg(target_arch = "aarch64")]
+const EXPECT_OPENAT: i64 = 56;
+#[cfg(not(target_arch = "aarch64"))]
+const EXPECT_OPENAT: i64 = 257;
 
 // ---------------------------------------------------------------------------
 // verify_unchanged (AC-4): forge check certifies identically before/after the link.
@@ -274,7 +287,7 @@ fn elapsed_ok_builds_and_runs() {
 
 // ---------------------------------------------------------------------------
 // sandbox_confines (AC-3): the linked os::now's clock_gettime is in the fx-time
-// allowlist (#57: baseline ∪ {clock_gettime 228, clock_nanosleep 230}), so the
+// allowlist (#57: baseline ∪ host-native time syscalls), so the
 // binary runs clean under the default sandbox (exit 0); a `--sandbox-self-test`
 // openat probe under the same `time` filter (openat not in the time allowlist) is
 // SIGSYS-killed (exit 159 = 128+31, the #57 pure_probe_killed precedent). The
@@ -290,8 +303,8 @@ fn sandbox_confines_the_linked_wrapper() {
     }
     let demo = effect_link_demo();
 
-    // (A) the default-sandboxed run: the fx-time allowlist includes clock_gettime
-    // (228), so the linked os::now runs clean and exits 0.
+    // (A) the default-sandboxed run: the fx-time allowlist includes host-native
+    // clock_gettime, so the linked os::now runs clean and exits 0.
     let (ok, stdout, stderr) =
         run_forge_build(&[demo.to_str().unwrap(), "--entry", "elapsed_ok", "--json"]);
     assert!(ok, "the sandboxed build must compile:\n{stdout}\n{stderr}");
@@ -307,12 +320,12 @@ fn sandbox_confines_the_linked_wrapper() {
         .map(|n| n.as_i64().unwrap())
         .collect();
     assert!(
-        allow.contains(&228),
-        "AC-3: the fx-time allowlist INCLUDES clock_gettime (228): {allow:?}"
+        allow.contains(&EXPECT_CLOCK_GETTIME),
+        "AC-3: the fx-time allowlist INCLUDES clock_gettime ({EXPECT_CLOCK_GETTIME}): {allow:?}"
     );
     assert!(
-        !allow.contains(&257),
-        "AC-3: the fx-time allowlist EXCLUDES openat (257) — a Time primitive cannot exceed \
+        !allow.contains(&EXPECT_OPENAT),
+        "AC-3: the fx-time allowlist EXCLUDES openat ({EXPECT_OPENAT}) — a Time primitive cannot exceed \
          Time syscalls: {allow:?}"
     );
     let artifact = artifact_path_from_json(&stdout);

--- a/forge/tests/effect_stdlib_conformance.rs
+++ b/forge/tests/effect_stdlib_conformance.rs
@@ -80,6 +80,11 @@ fn verus_present() -> bool {
 /// `true` iff this host's kernel offers the `kill_process` seccomp action — mirrors
 /// `sandbox_conformance.rs`. When absent the sandbox case skips with a diagnostic (OQ-3).
 fn seccomp_kill_available() -> bool {
+    if !(cfg!(target_os = "linux")
+        && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64")))
+    {
+        return false;
+    }
     std::fs::read_to_string("/proc/sys/kernel/seccomp/actions_avail")
         .map(|s| s.contains("kill_process"))
         .unwrap_or(false)
@@ -525,8 +530,8 @@ fn audit_enumerates_primitives_in_the_tcb() {
 
 // ---------------------------------------------------------------------------
 // AC-3 (sandbox): `forge build --entry` of a program declaring `fx time` derives the
-// #57 seccomp allowlist for that effect — including clock_gettime (syscall 228, per
-// the design doc's fx→syscall table); a `fx pure` probe attempting a denied syscall
+// #57 seccomp allowlist for that effect — including host-native clock_gettime; a
+// `fx pure` probe attempting a denied syscall
 // is SIGSYS-killed (exit 159 = 128+31). The allowlist is fx-derived and per-effect,
 // without a live os:: link (v1; OQ-4). Anchored to cases.json `sandbox`. Runs a
 // seccomp-confined binary, so skips with a diagnostic without a kill_process kernel (OQ-3).
@@ -542,9 +547,9 @@ fn sandbox_derives_fx_time_allowlist_and_kills_off_allowlist() {
     }
     let oracle = cases();
     let case = oracle["sandbox"].as_array().expect("sandbox array")[0].clone();
-    // The oracle names the syscall (clock_gettime); the design doc's fx→syscall table
-    // pins clock_gettime == 228 (the allowlist is numeric). Trace the named oracle to
-    // the doc's constant (R-CHAR-3), never to forge output.
+    // The oracle names the syscall (clock_gettime); the sandbox maps that named
+    // syscall to the host architecture's numeric ABI. Trace the named oracle to
+    // the arch constant (R-CHAR-3), never to forge output.
     let expect_syscall_name = case["expect_allowlist_contains_syscall"]
         .as_str()
         .expect("expect_allowlist_contains_syscall"); // "clock_gettime"
@@ -552,7 +557,10 @@ fn sandbox_derives_fx_time_allowlist_and_kills_off_allowlist() {
         expect_syscall_name, "clock_gettime",
         "the oracle names the Time-effect syscall"
     );
-    const CLOCK_GETTIME: i64 = 228; // .design/basis/03-effect-stdlib.md fx→syscall table
+    #[cfg(target_arch = "aarch64")]
+    const CLOCK_GETTIME: i64 = 113;
+    #[cfg(not(target_arch = "aarch64"))]
+    const CLOCK_GETTIME: i64 = 228;
 
     // A fn declaring `fx time` (pure body — v1 grounds confinement via the
     // fx-declaring-body + the foreign os:: link is v1.1, OQ-4).
@@ -589,7 +597,7 @@ fn sandbox_derives_fx_time_allowlist_and_kills_off_allowlist() {
         .iter()
         .map(|n| n.as_i64().expect("syscall number"))
         .collect();
-    // REQ-5: the Time effect widens the allowlist to include clock_gettime (228).
+    // REQ-5: the Time effect widens the allowlist to include host-native clock_gettime.
     assert!(
         allow.contains(&CLOCK_GETTIME),
         "AC-3: `fx time` derives an allowlist including clock_gettime ({CLOCK_GETTIME}): {allow:?}"

--- a/forge/tests/map_conformance.rs
+++ b/forge/tests/map_conformance.rs
@@ -165,22 +165,23 @@ fn cert_for<'a>(certs: &'a [Value], item: &str) -> &'a Value {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN here. The
-/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is x86_64-Linux ONLY (a raw
-/// `prctl` seccomp prelude with an `AUDIT_ARCH_X86_64` BPF guard), so the emitted
-/// runner does not link off Linux (`Undefined symbols: _prctl` on macOS/arm64).
+/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is native Linux only, with
+/// generated filters for x86_64 and aarch64. The emitted runner does not link off
+/// Linux (`Undefined symbols: _prctl` on macOS).
 /// The build+run tests SKIP with an explicit warning on any non-Linux platform —
 /// FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX CI. Mirrors the
 /// `verus_present()` skip precedent (a missing capability is a logged skip, not a
 /// panic, R-CODE-4).
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI; `cargo test` on this platform skips the runnable end-to-end twin."
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI; \
+         `cargo test` on this platform skips the runnable end-to-end twin."
     );
     false
 }

--- a/forge/tests/recursion_conformance.rs
+++ b/forge/tests/recursion_conformance.rs
@@ -111,22 +111,23 @@ fn level(certs: &[Value], item: &str) -> String {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN here. The
-/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is x86_64-Linux ONLY (a raw
-/// `prctl` seccomp prelude with an `AUDIT_ARCH_X86_64` BPF guard), so the emitted
-/// runner does not link off Linux (`Undefined symbols: _prctl` on macOS/arm64).
+/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is native Linux only, with
+/// generated filters for x86_64 and aarch64. The emitted runner does not link off
+/// Linux (`Undefined symbols: _prctl` on macOS).
 /// The build+run tests SKIP with an explicit warning on any non-Linux platform —
 /// FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX CI. Mirrors the
 /// `verus_present()` skip precedent (a missing capability is a logged skip, not a
 /// panic, R-CODE-4).
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI; `cargo test` on this platform skips the runnable end-to-end twin."
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI; \
+         `cargo test` on this platform skips the runnable end-to-end twin."
     );
     false
 }

--- a/forge/tests/sandbox_conformance.rs
+++ b/forge/tests/sandbox_conformance.rs
@@ -108,22 +108,23 @@ fn write_fixture(name: &str, body: &str) -> PathBuf {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN here. The
-/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is x86_64-Linux ONLY (a raw
-/// `prctl` seccomp prelude with an `AUDIT_ARCH_X86_64` BPF guard), so the emitted
-/// runner does not link off Linux (`Undefined symbols: _prctl` on macOS/arm64).
+/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is native Linux only, with
+/// generated filters for x86_64 and aarch64. The emitted runner does not link off
+/// Linux (`Undefined symbols: _prctl` on macOS).
 /// The build+run tests SKIP with an explicit warning on any non-Linux platform —
 /// FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX CI. Mirrors the
 /// `verus_present()` skip precedent (a missing capability is a logged skip, not a
 /// panic, R-CODE-4).
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI; `cargo test` on this platform skips the runnable end-to-end twin."
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI; \
+         `cargo test` on this platform skips the runnable end-to-end twin."
     );
     false
 }
@@ -132,6 +133,14 @@ fn linux_build_run_supported(test: &str) -> bool {
 const SIGSYS: i32 = 31;
 /// A Rust panic (the `[ens]` L1 contract violation) aborts with process exit 101.
 const PANIC_EXIT: i32 = 101;
+#[cfg(target_arch = "aarch64")]
+const EXPECT_OPENAT: i64 = 56;
+#[cfg(not(target_arch = "aarch64"))]
+const EXPECT_OPENAT: i64 = 257;
+#[cfg(target_arch = "aarch64")]
+const EXPECT_IOCTL: i64 = 29;
+#[cfg(not(target_arch = "aarch64"))]
+const EXPECT_IOCTL: i64 = 16;
 
 // ---- oracle `pure_runs_clean` (AC-1) ----------------------------------------
 //
@@ -164,7 +173,7 @@ fn pure_runs_clean() {
     );
 
     // The manifest records the installed pure allowlist (REQ-5) and that it
-    // excludes openat (257): a pure filter denies file I/O.
+    // excludes the host's openat syscall: a pure filter denies file I/O.
     let v: serde_json::Value = serde_json::from_str(&stdout).expect("manifest JSON");
     assert_eq!(
         v["sandbox"]["installed"], true,
@@ -177,8 +186,8 @@ fn pure_runs_clean() {
         .map(|n| n.as_i64().unwrap())
         .collect();
     assert!(
-        !allow.contains(&257),
-        "AC-1: the pure filter excludes openat (257): {allow:?}"
+        !allow.contains(&EXPECT_OPENAT),
+        "AC-1: the pure filter excludes openat ({EXPECT_OPENAT}): {allow:?}"
     );
 
     let artifact = artifact_path_from_json(&stdout);
@@ -266,7 +275,7 @@ fn probe_allowed_when_fx_widens() {
     ]);
     assert!(ok, "the rf probe build must compile:\n{stdout}\n{stderr}");
 
-    // REQ-2/REQ-3: the read fx widens the allowlist to include openat (257).
+    // REQ-2/REQ-3: the read fx widens the allowlist to include host-native openat.
     let v: serde_json::Value = serde_json::from_str(&stdout).expect("manifest JSON");
     assert_eq!(
         v["sandbox"]["transitive_fx"],
@@ -279,8 +288,8 @@ fn probe_allowed_when_fx_widens() {
         .map(|n| n.as_i64().unwrap())
         .collect();
     assert!(
-        allow.contains(&257),
-        "AC-3: read(_) widens the allowlist to include openat (257): {allow:?}"
+        allow.contains(&EXPECT_OPENAT),
+        "AC-3: read(_) widens the allowlist to include openat ({EXPECT_OPENAT}): {allow:?}"
     );
 
     let artifact = artifact_path_from_json(&stdout);
@@ -401,12 +410,12 @@ fn no_sandbox_omits_prelude() {
     cleanup(&lib);
 }
 
-// ---- AC-6 (#106): the `fx term` grant adds ioctl:16; a non-term excludes it ----
+// ---- AC-6 (#106): the `fx term` grant adds ioctl; a non-term excludes it ----
 //
 // A `term` entry's transitive fx → the manifest-recorded seccomp allowlist includes
-// `ioctl`:16 (the termios raw-mode boundary syscall); a `pure`/`read`/`write` entry's
+// `ioctl` (the termios raw-mode boundary syscall); a `pure`/`read`/`write` entry's
 // allowlist excludes it (the grant is scoped to the `term` effect, not folded into
-// `write`). Expected from runtime-sandbox.md REQ-7 (`TERM_SYSCALLS={ioctl:16}`), a
+// `write`). Expected from runtime-sandbox.md REQ-7 (`TERM_SYSCALLS`), a
 // design constant, never forge's own output (R-CHAR-3).
 
 #[test]
@@ -434,8 +443,8 @@ fn term_grant_adds_ioctl_to_the_recorded_allowlist() {
         .map(|n| n.as_i64().unwrap())
         .collect();
     assert!(
-        allow.contains(&16),
-        "AC-6: fx term grants ioctl (16) in the recorded allowlist: {allow:?}"
+        allow.contains(&EXPECT_IOCTL),
+        "AC-6: fx term grants ioctl ({EXPECT_IOCTL}) in the recorded allowlist: {allow:?}"
     );
     let artifact = artifact_path_from_json(&stdout);
     cleanup(&artifact);
@@ -464,8 +473,8 @@ fn term_grant_adds_ioctl_to_the_recorded_allowlist() {
         .map(|n| n.as_i64().unwrap())
         .collect();
     assert!(
-        !allow2.contains(&16),
-        "AC-6: a non-term (write) entry's allowlist EXCLUDES ioctl (16) — the grant is \
+        !allow2.contains(&EXPECT_IOCTL),
+        "AC-6: a non-term (write) entry's allowlist EXCLUDES ioctl ({EXPECT_IOCTL}) — the grant is \
          scoped to the term effect, not folded into write: {allow2:?}"
     );
     let artifact2 = artifact_path_from_json(&stdout2);

--- a/forge/tests/string_format_conformance.rs
+++ b/forge/tests/string_format_conformance.rs
@@ -97,22 +97,23 @@ fn cert_for<'a>(certs: &'a [Value], item: &str) -> &'a Value {
 }
 
 /// `true` iff the `forge build --entry` runnable artifact can LINK + RUN here. The
-/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is x86_64-Linux ONLY (a raw
-/// `prctl` seccomp prelude with an `AUDIT_ARCH_X86_64` BPF guard), so the emitted
-/// runner does not link off Linux (`Undefined symbols: _prctl` on macOS/arm64).
+/// #57 runtime seccomp sandbox (`forge/src/sandbox.rs`) is native Linux only, with
+/// generated filters for x86_64 and aarch64. The emitted runner does not link off
+/// Linux (`Undefined symbols: _prctl` on macOS).
 /// The build+run tests SKIP with an explicit warning on any non-Linux platform —
 /// FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX CI. Mirrors the
 /// `verus_present()` skip precedent (a missing capability is a logged skip, not a
 /// panic, R-CODE-4).
 fn linux_build_run_supported(test: &str) -> bool {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && (cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"))
+    {
         return true;
     }
     eprintln!(
-        "SKIP {test}: the #57 runtime seccomp sandbox is x86_64-Linux ONLY (the \
-         `forge build --entry` runner emits a raw `prctl` seccomp prelude that does \
-         not link off Linux). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES LINUX \
-         CI; `cargo test` on this platform skips the runnable end-to-end twin."
+        "SKIP {test}: the #57 runtime seccomp sandbox supports x86_64/aarch64 Linux \
+         runners only (the `forge build --entry` runner emits a raw `prctl` seccomp \
+         prelude). FULL ACCEPTANCE OF THE BUILD+RUN PATH REQUIRES SUPPORTED LINUX CI; \
+         `cargo test` on this platform skips the runnable end-to-end twin."
     );
     false
 }


### PR DESCRIPTION
## Summary

- Adds architecture-aware seccomp syscall allowlist generation for x86_64 and aarch64.
- Emits cfg-gated runner filters for `AUDIT_ARCH_X86_64` and `AUDIT_ARCH_AARCH64`, with a native `openat` self-test probe.
- Records the host-architecture allowlist in build manifests and updates conformance tests/docs for x86_64/aarch64 Linux scope.

Closes #27.

## Validation

- `cargo test -p forge --no-run`
- `cargo test -p forge sandbox::tests`
- `cargo test -p forge --test sandbox_conformance -- --nocapture`
- `cargo test -p forge --test effect_link_conformance sandbox_confines_the_linked_wrapper -- --nocapture`
- `cargo test -p forge --test effect_stdlib_conformance sandbox_derives_fx_time_allowlist_and_kills_off_allowlist -- --nocapture`
- `python3 tooling/doc-drift.py`
- `git diff --check`

## Notes

The aarch64 syscall numbers are ABI-grounded, but runtime seccomp behavior was only live-tested on this x86_64 Linux host. Native arm64 Linux conformance still needs an arm64 executor.