### PR TITLE
[codex] Add merge-stable doc drift content pins

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
+audited-content-sha256: aeb14502bcb09ccaff9f03035ddc96233862447319d870e8eca291b5176f5f7e
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
+audited-content-sha256: aeb14502bcb09ccaff9f03035ddc96233862447319d870e8eca291b5176f5f7e
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
+audited-content-sha256: 138ca927e4a65c28e616970fc4c76988e4259c7bfedf15743108d16c7af546b7
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
+audited-content-sha256: efedb9ec101cc3a74ee7fb69098c11c39dbaed830a329be6b9d6e7c5839b7731
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/solver-vacuity.md
+++ b/.design/forge/solver-vacuity.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
+audited-content-sha256: cae9b94b0095901e1cfb88a4f28f37c1ecf69e27beb3412cca0d435791ee5437
 governs: forge/src/vacuity_solver.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -3,6 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
+audited-content-sha256: 138ca927e4a65c28e616970fc4c76988e4259c7bfedf15743108d16c7af546b7
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -4,6 +4,7 @@
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
 audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
+audited-content-sha256: 287ec6b8d561b63678116f96db23370232ffd848284c97eacfeb9e99b7052b9f
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and


### PR DESCRIPTION
## Summary

- Adds `audited-content-sha256` pins to seven legacy SHA-pinned docs that were tripped by the #53 merge commit.
- Leaves the existing `audited-sha` lines in place as provenance while making doc-drift use content hashes for these routes.
- Avoids changing any design claims or production code.

## Root Cause

The legacy `audited-sha` predicate uses `git log --full-history <pin>..HEAD -- <path>`. After PR #53 merged, the merge commit appeared as an intervening commit for `forge/src/check.rs` and `forge/src/vacuity_solver.rs` on stale branch-parent topology, even though the merged PR did not change those files relative to `main`. Content pins make these docs depend on governed file contents instead of merge topology.

## Validation

- `python3 tooling/doc-drift.py`
- `git diff --check`