### PR TITLE
chore(post-g1): rotating-seed TV cron + #148 regression + umbrella AC sync (#319)

### DIFF
--- a/.design/forge/cli.md
+++ b/.design/forge/cli.md
@@ -3,8 +3,8 @@
 <!--
 tier: 3-component
 status: shipped
-audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (re-pinned 2026-06-17 for umbrella REQ-7 / AC-12, the §6 metrics dashboard: the only change to this doc's governed file (cli.rs) is the additive `--metrics` flag in the `forge audit` parse + the `run_audit` body that prints the read-only §6 dashboard companion — gates nothing, #274; every other subcommand + flag parse is unchanged. prior: stage-1 REQ-10/AC-14 G1 gate `--engine forge` value)
-audited-content-sha256: 4e133a092811889aaeca5577bf409310533f7e3950ea7f69d721967fb06927a9
+audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (re-pinned 2026-06-18 for umbrella REQ-2c / AC-4, the rotating-seed scheduled-CI watchdog: the only change to this doc's governed file (cli.rs) is the additive `--seed <u64>` flag on `forge tv` — parsed into `Command::Tv.seed`, threaded to `run_tv`→`run_generated` for the off-corpus space only (the corpus phase keeps the pinned seed); a missing/non-numeric value is a Usage error (REQ-8 flag discipline, test `parses_tv_seed_flag`). Every other subcommand + flag parse is unchanged. prior: §6 metrics dashboard `--metrics` value)
+audited-content-sha256: ff919b92b7f812e57241b6dc360741ef5a4814ab525d1c30d627aa47895df534
 governs: forge/src/cli.rs
 thesis-refs:
   - thermite-design.md §5
@@ -198,7 +198,11 @@ The verbs fall into four families, each with its own exit-code convention
    surfaced but never fail the exit (R-HONEST-3 — and verus-absent is loud,
    not a silent pass). Their `--json` documents are hand-built in
    `fn tv_report_json` / `exec_tv_report_json` / `body_tv_report_json in
-   cli.rs`.
+   cli.rs`. `forge tv --seed <u64>` overrides the off-corpus generator seed
+   (`--generated` space) — the lever the rotating-seed scheduled-CI watchdog
+   uses (`thermite2-program.md` REQ-2c, `.github/workflows/generated-tv.yml`);
+   absent, it rides the pinned deterministic `TV_DEFAULT_SEED`, and the corpus
+   phase always does, so the fixed corpus gate stays reproducible.
 3. **View/build verbs** — `review` (`run_review`: artifact emission +
    optional `--reviewer` pipe, writing `<file>.review.json` via
    `fn review_record_path`; forge never fabricates a verdict), `build`

--- a/.design/thermite2-program.md
+++ b/.design/thermite2-program.md
@@ -103,25 +103,25 @@ source of sequencing truth in the `.design/` tree.
   contains the plan's acceptance text (SPIKE-1: "zero sorries", the
   ">40 lemmas" failure signal, the conventions note deliverable; SPIKE-2:
   "hit rate measured and reported, whatever it is"). (REQ-1)
-- [ ] AC-2: `.github/workflows/ci.yml` contains a job that runs `lake build`
+- [x] AC-2: `.github/workflows/ci.yml` contains a job that runs `lake build`
   (or `lake env lean`) against `lean/lakefile.toml`, and the lean-smt
   dependency is pinned by SHA; the job is green on main before any M1 issue
   closes. (REQ-2a)
-- [ ] AC-3: `lower_inv_operand` in `thermite-lower/src/lower.rs` emits
+- [x] AC-3: `lower_inv_operand` in `thermite-lower/src/lower.rs` emits
   parenthesized casts (#148); the known-divergence ledger entry is removed
   and a regression test pins the fix. (REQ-2b)
-- [ ] AC-4: A scheduled (cron-triggered) CI workflow runs the `--generated`
+- [x] AC-4: A scheduled (cron-triggered) CI workflow runs the `--generated`
   corpus with a rotating seed and fails on any divergence. (REQ-2c)
 - [ ] AC-5: README contains the regime-split paragraph qualifying the editor
   claim. (REQ-2d)
 - [ ] AC-6: Nine stage-1 issues exist, each referencing gate G1, with
   dependency order stated; items 1–2 are closed before any of 3–7 starts
   review. (REQ-3)
-- [ ] AC-7: A hermetic test suite exercises all seven verdicts and asserts
+- [x] AC-7: A hermetic test suite exercises all seven verdicts and asserts
   the never-converts-silently property (no test path turns any non-`Proved`
   verdict into `Proved` or into another verdict without a hard failure).
   (REQ-4)
-- [ ] AC-8: G1 is encoded as a checklist in the stage-1 milestone: the
+- [x] AC-8: G1 is encoded as a checklist in the stage-1 milestone: the
   merge-class L3 certificate exists in `conformance/` with covenant
   evidence, axiom gate, re-elaboration mutation score, and burn receipt
   fields populated; the v1 corpus (`conformance/*.th` + golden
@@ -135,16 +135,16 @@ source of sequencing truth in the `.design/` tree.
 - [ ] AC-11: This doc's Q-register table matches the program plan §5
   defaults; any merged change contradicting a default is preceded by a
   register-updating comment on GH issue #2. (REQ-6)
-- [ ] AC-12: From M1, `forge` emits the routing-reason and verdict telemetry
+- [x] AC-12: From M1, `forge` emits the routing-reason and verdict telemetry
   fields the §6 dashboard needs (cage-vs-forge share by reason, verdict
   counts, TV phase split), and the audit prints them. (REQ-7)
-- [ ] AC-13: `thermite2-semantics.md` exists and module-header comments in
+- [x] AC-13: `thermite2-semantics.md` exists and module-header comments in
   `lean/Thermite/` and `thermite-lower/` point at it rather than restating
   conventions; `goal.md` contains the five R-rule candidates; the issue #2
   body carries a changelog table. (REQ-8)
 - [ ] AC-14: Every program document merged into `.design/` after this one
   states baseline `c46da3ac` or later and links this umbrella. (REQ-9)
-- [ ] AC-15: `.design/` contains a stage-1 design doc before the first
+- [x] AC-15: `.design/` contains a stage-1 design doc before the first
   stage-1 implementation issue is worked, and likewise for stages 2 and 3.
   (REQ-10)
 

--- a/.github/workflows/generated-tv.yml
+++ b/.github/workflows/generated-tv.yml
@@ -1,0 +1,82 @@
+name: generated-tv
+
+# The rotating-seed off-corpus translation-validation job (thermite2-program.md
+# REQ-2c / AC-4). `forge tv --generated` discharges the per-clause production-vs-
+# reference equivalence obligation over a deterministically GENERATED clause space
+# — the off-corpus escape hatch that catches lowering divergences the fixed
+# conformance corpus never exercises. The main `ci` gate runs this space at the
+# pinned `TV_DEFAULT_SEED` (reproducible); this scheduled job runs it with a
+# ROTATING seed (`github.run_number`), so each run walks a different slice of the
+# clause space and a seed-dependent divergence eventually surfaces as a red build.
+# A DIVERGENT clause exits non-zero (forge's verification-failure exit) and fails
+# the job — exactly the signal we want a scheduled lowering-fidelity watchdog to
+# raise. (Unverifiable/Skipped never fail the exit — R-HONEST-3.)
+
+on:
+  schedule:
+    # Daily at 07:13 UTC (off the hour to dodge the cron stampede). Each run's
+    # github.run_number is monotonic, so the seed rotates every day.
+    - cron: '13 7 * * *'
+  # Manual trigger for on-demand runs (e.g. validating this workflow itself).
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: 'Override the rotating seed (default: github.run_number)'
+        required: false
+        type: string
+      count:
+        description: 'Number of generated clauses (default: 200)'
+        required: false
+        type: string
+
+jobs:
+  generated-tv:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install toolchain (pinned to rust-toolchain.toml channel)
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Rust build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: generated-tv
+
+      - name: Cache Verus
+        uses: actions/cache@v4
+        with:
+          path: ~/verus-dist
+          key: verus-0.2026.05.24.ecee80a-x86-linux
+
+      - name: Install Verus (L3 verification gate — pinned to dev version)
+        run: |
+          set -euo pipefail
+          VERUS_VER="0.2026.05.24.ecee80a"
+          if ! find "$HOME/verus-dist" -type f -name verus 2>/dev/null | grep -q .; then
+            curl -fsSL -o /tmp/verus.zip \
+              "https://github.com/verus-lang/verus/releases/download/release/${VERUS_VER}/verus-${VERUS_VER}-x86-linux.zip"
+            mkdir -p "$HOME/verus-dist"
+            unzip -q /tmp/verus.zip -d "$HOME/verus-dist"
+          fi
+          VERUS_BIN_PATH="$(find "$HOME/verus-dist" -type f -name verus | head -1)"
+          test -n "$VERUS_BIN_PATH"
+          echo "VERUS_BIN=$VERUS_BIN_PATH" >> "$GITHUB_ENV"
+          echo "$(dirname "$VERUS_BIN_PATH")" >> "$GITHUB_PATH"
+          "$VERUS_BIN_PATH" --version
+
+      - name: Build forge
+        run: cargo build -p forge --release
+
+      - name: Rotating-seed generated translation-validation
+        # Seed rotates with the run number (or the manual override); the corpus
+        # phase rides a representative conformance file. A DIVERGENT clause fails
+        # the exit and the job — the watchdog signal.
+        run: |
+          set -euo pipefail
+          SEED="${{ github.event.inputs.seed || github.run_number }}"
+          COUNT="${{ github.event.inputs.count || '200' }}"
+          echo "::notice::generated TV — seed=$SEED count=$COUNT"
+          ./target/release/forge tv conformance/binary_search.th \
+            --generated "$COUNT" --seed "$SEED"

--- a/forge/src/cli.rs
+++ b/forge/src/cli.rs
@@ -347,8 +347,8 @@ enum Command {
         /// `fx` rows. `--target kernel` + `--entry` is a usage error.
         target: BuildTarget,
     },
-    /// `forge tv <file> [--generated [N]] [--json]` — the contract-faithfulness
-    /// translation-validation deeper audit (epic #139, #144;
+    /// `forge tv <file> [--generated [N]] [--seed <u64>] [--json]` — the
+    /// contract-faithfulness translation-validation deeper audit (epic #139, #144;
     /// `.design/verified/contract-tv.md` REQ-5). A separate opt-in command, not
     /// folded into `forge check` (which stays fast): for each `req`/`ens`/loop-
     /// `inv`/`dec` clause it discharges the per-clause Z3 equivalence obligation
@@ -363,6 +363,12 @@ enum Command {
         /// `--generated [N]` — also run the off-corpus generated TV space (REQ-3).
         /// `Some(n)` requests `n` generated clauses; `None` skips the generated run.
         generated: Option<usize>,
+        /// `--seed <u64>` — the generator seed for the `--generated` space. `None`
+        /// uses the pinned [`TV_DEFAULT_SEED`] (deterministic, for the corpus gate);
+        /// a rotating value (the scheduled-CI job, `thermite2-program.md` REQ-2c)
+        /// walks a different slice of the off-corpus clause space each run, surfacing
+        /// seed-dependent lowering divergences the fixed-seed gate would never reach.
+        seed: Option<u64>,
     },
     /// `forge exec-tv <file> [--generated [N]] [--json]` — the exec-position (body)
     /// translation-validation deeper audit (epic #151, #154/#156;
@@ -872,6 +878,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
             let mut file: Option<PathBuf> = None;
             let mut json = false;
             let mut generated: Option<usize> = None;
+            let mut seed: Option<u64> = None;
             let mut iter = iter.peekable();
             while let Some(arg) = iter.next() {
                 match arg.as_str() {
@@ -889,6 +896,18 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                         };
                         generated = Some(n);
                     }
+                    "--seed" => {
+                        // `--seed <u64>` takes a mandatory numeric value (the rotating
+                        // generator seed, REQ-2c). A missing or non-numeric value is a
+                        // Usage error, never a silent default (REQ-8 flag discipline).
+                        let raw = iter.next().ok_or_else(|| {
+                            ForgeError::Usage("`--seed` requires a u64 value".to_string())
+                        })?;
+                        let parsed = raw.parse::<u64>().map_err(|_| {
+                            ForgeError::Usage(format!("`--seed` value `{raw}` is not a u64"))
+                        })?;
+                        seed = Some(parsed);
+                    }
                     flag if flag.starts_with("--") => {
                         return Err(ForgeError::Usage(format!("unknown flag `{flag}`")));
                     }
@@ -904,13 +923,15 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
             }
             let file = file.ok_or_else(|| {
                 ForgeError::Usage(
-                    "`forge tv` requires a <file> [--generated [N]] [--json]".to_string(),
+                    "`forge tv` requires a <file> [--generated [N]] [--seed <u64>] [--json]"
+                        .to_string(),
                 )
             })?;
             Ok(Command::Tv {
                 file,
                 json,
                 generated,
+                seed,
             })
         }
         "exec-tv" => {
@@ -1158,7 +1179,7 @@ fn usage_text() -> &'static str {
      | forge review <file> [item] [--json] [--reviewer <cmd>] | forge build <file> [--entry <fn>] \
      [--out <PATH>] [--target std|kernel] [--json] [--no-sandbox] [--sandbox-self-test] | forge tv \
      <file> \
-     [--generated [N]] [--json] | forge exec-tv <file> [--generated [N]] [--no-generated] \
+     [--generated [N]] [--seed <u64>] [--json] | forge exec-tv <file> [--generated [N]] [--no-generated] \
      [--json] | forge body-tv <file> [--json] | forge goal <file> [item] [--proof] | forge \
      battery <file> [item] | forge edit <file> <addr> --replace <code> | forge fill <file> \
      <hole-addr> <code>"
@@ -1227,7 +1248,8 @@ fn dispatch(args: &[String]) -> Result<ExitCode, ForgeError> {
             file,
             json,
             generated,
-        } => run_tv(&file, json, generated),
+            seed,
+        } => run_tv(&file, json, generated, seed),
         Command::ExecTv {
             file,
             json,
@@ -1705,16 +1727,21 @@ fn run_build(
 /// environment failure (file unreadable, parse failure) propagates as a
 /// `ForgeError` (the environment exit). A verus-absent run reports `unverifiable`
 /// clauses (surfaced, never a silent pass — R-CODE-4) and does not fail the exit.
-fn run_tv(file: &Path, json: bool, generated: Option<usize>) -> Result<ExitCode, ForgeError> {
+fn run_tv(
+    file: &Path,
+    json: bool,
+    generated: Option<usize>,
+    seed: Option<u64>,
+) -> Result<ExitCode, ForgeError> {
     use crate::contract_tv::{self, TV_DEFAULT_RLIMIT, TV_DEFAULT_SEED};
 
+    // `--seed` overrides the pinned default for the off-corpus generated space (the
+    // rotating-seed CI job, REQ-2c); the corpus phase stays on the deterministic
+    // pinned seed so the fixed corpus gate remains reproducible regardless.
+    let gen_seed = seed.unwrap_or(TV_DEFAULT_SEED);
     let corpus = contract_tv::tv_file(file, TV_DEFAULT_SEED, TV_DEFAULT_RLIMIT)?;
     let gen_report = match generated {
-        Some(n) => Some(contract_tv::run_generated(
-            TV_DEFAULT_SEED,
-            n,
-            TV_DEFAULT_RLIMIT,
-        )?),
+        Some(n) => Some(contract_tv::run_generated(gen_seed, n, TV_DEFAULT_RLIMIT)?),
         None => None,
     };
 
@@ -2616,6 +2643,42 @@ mod tests {
         ));
         assert!(matches!(
             parse_args(&argv(&["check", "a.th", "--rlimit", "0"])),
+            Err(ForgeError::Usage(_))
+        ));
+    }
+
+    // REQ-2c (`thermite2-program.md` AC-4): `forge tv --seed <u64>` sets the
+    // off-corpus generator seed (the rotating-seed scheduled-CI lever); the default
+    // (no flag) is `None` (→ the pinned `TV_DEFAULT_SEED`); a missing / non-numeric
+    // value is a Usage error, never a silent default (REQ-8 flag discipline).
+    #[test]
+    fn parses_tv_seed_flag() {
+        assert_eq!(
+            parse_args(&argv(&["tv", "a.th", "--generated", "10", "--seed", "42"])).ok(),
+            Some(Command::Tv {
+                file: PathBuf::from("a.th"),
+                json: false,
+                generated: Some(10),
+                seed: Some(42),
+            })
+        );
+        // Default when the flag is absent: `None` (the pinned deterministic seed).
+        assert_eq!(
+            parse_args(&argv(&["tv", "a.th"])).ok(),
+            Some(Command::Tv {
+                file: PathBuf::from("a.th"),
+                json: false,
+                generated: None,
+                seed: None,
+            })
+        );
+        // Missing value and non-numeric are Usage errors.
+        assert!(matches!(
+            parse_args(&argv(&["tv", "a.th", "--seed"])),
+            Err(ForgeError::Usage(_))
+        ));
+        assert!(matches!(
+            parse_args(&argv(&["tv", "a.th", "--seed", "nope"])),
             Err(ForgeError::Usage(_))
         ));
     }

--- a/thermite-lower/tests/divergence_struct_inv_cast_lt.rs
+++ b/thermite-lower/tests/divergence_struct_inv_cast_lt.rs
@@ -1,31 +1,26 @@
-//! Pinned divergence (#148): the #146 cast-`<` paren fix is incomplete on the
-//! struct type-invariant lowering path.
+//! Regression: the cast-`<` paren discipline on the struct type-invariant
+//! lowering path (blocker #148, CLOSED — this test pins the fix).
 //!
-//! Commit 167b9f4 fixed `lower_binary_operand` (the fn-contract / loop-`inv`
+//! Commit 167b9f4 first fixed `lower_binary_operand` (the fn-contract / loop-`inv`
 //! path, used by `forge tv` + `forge check`'s `requires`/`ensures`/loop
 //! `invariant`): a `Cast` left-operand of a `<`-leading op (`<`/`<=`/`<<`) is
 //! parenthesized so `x as u32 < 33` does not mis-parse as a generic-argument
 //! list (`u32<33, …>` → "expected `,`"). See `divergence_cast_paren.rs` for the
 //! #122/#146 family.
 //!
-//! But the struct type-invariant path (`lower_inv_expr` → `lower_inv_operand`,
-//! the REQ-8 `well_formed()` predicate, `.design/lower/...` struct invariants)
-//! has its own operand-parenthesizer (`lower_inv_operand`) that was not given the
-//! cast-`<` fix. So a struct invariant carrying a cast left of `<`
-//! (`} inv (x as u32) < cap`) emits the bare `x as u32 < cap` and `forge check`
-//! reports L0 with `error: expected ,` — the same #146 mis-parse, on a path the
-//! fix missed. The whole cast-`<` class must be fixed (R-DEFER-8: a convention
-//! starts somewhere; the fix is incomplete until every cast-`<` site is covered).
+//! The struct type-invariant path (`lower_inv_expr` → `lower_inv_operand`, the
+//! REQ-8 `well_formed()` predicate, `.design/lower/...` struct invariants) has its
+//! own operand-parenthesizer, which #148 extended with the SAME cast-`<` guard
+//! (`lower_inv_operand` in `thermite-lower/src/lower.rs`: a `Cast` left operand of
+//! an `is_lt_leading` parent is parenthesized — R-DEFER-8, the convention is now
+//! uniform across every emission site). So `} inv (x as u32) < cap` lowers to the
+//! parse-correct `(self.x as u32) < self.cap`, not the bare `self.x as u32 <
+//! self.cap` that Verus/Rust would read as `u32<…>`.
 //!
 //! Authority: blocker #146 / #148 (the cast-`<` paren discipline — the dual of
-//! #122). Expected: the lowering parenthesizes the cast (`(x as u32) < cap`), the
-//! same form `lower_binary_operand` now emits and `thermite_tv::ref_encode`
-//! always emits. R-CHAR-3: the paren'd form is the design's parse-correct form,
-//! not copied from the lowerer's output (the lowerer currently emits the
-//! unparenthesized form).
-//!
-//! `#[ignore]`d (blocker #148 tracks the fix; un-ignore when `lower_inv_operand`
-//! gets the cast-`<` paren — R-DEFER-3).
+//! #122). R-CHAR-3: the paren'd form below is the design's parse-correct form,
+//! asserted directly, not copied from the lowerer's output. This test runs in CI
+//! (no `#[ignore]`) and fails if the struct-inv parenthesizer ever regresses.
 
 /// A struct type-invariant with a cast left of `<` must lower with the cast
 /// parenthesized (`(x as u32) < cap`), never the mis-parsing bare form


### PR DESCRIPTION
Post-G1 cleanup (the debt deferred during the gate push).

### `forge tv --seed <u64>` + the rotating-seed watchdog (REQ-2c / AC-4)
`forge tv --generated` ran only at the pinned `TV_DEFAULT_SEED`, so a "rotating-seed" job had nothing to rotate. Added a `--seed` flag (threaded to the **off-corpus** generated run only — the corpus phase keeps the deterministic seed so the fixed gate stays reproducible). Missing/non-numeric → Usage error (`parses_tv_seed_flag`). New scheduled workflow `generated-tv.yml` runs it daily with `github.run_number` as the seed, failing on any divergence — the off-corpus lowering-fidelity watchdog.

### #148 regression header (AC-3)
The cast-`<` paren fix landed in `lower_inv_operand` and the test passes in CI (no `#[ignore]`), but its header still framed it as an open "Pinned divergence ... incomplete ... `#[ignore]`d." Rewrote it as the closed-regression pin it is.

### Umbrella AC sync
Ticked the eight verified ACs (2/3/4/7/8/12/13/15). Left honest: stage-2/3 (AC-9 G2 flip, AC-10 @bv) and process-historical/unverified (AC-1/5/6/11/14).

Verified locally (Verus + spine): contract-TV conformance 5/5, all CLI parse tests 8/8, the #148 regression test green, fmt + clippy clean, 0 doc-drift, reqs 443/119. cli.md re-pinned to the new governed-file hash.

Closes #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)