### PR TITLE
[codex] Update map wrapper for current Verus finite sets

### DIFF
--- a/forge/tests/map_conformance.rs
+++ b/forge/tests/map_conformance.rs
@@ -197,7 +197,7 @@ pub spec const MAP_CAP: usize = 1_000_000;
 pub struct TMapU64U64 { pub data: Vec<(u64, u64)> }
 impl TMapU64U64 {
     pub open spec fn spec_dom(&self) -> Set<int> {
-        Set::new(|kk: int| exists|j: int|
+        Set::new_assuming_finite(|kk: int| exists|j: int|
             0 <= j < self.data.len() && #[trigger] self.data@[j].0 as int == kk)
     }
     pub open spec fn well_formed(&self) -> bool {

--- a/tests/golden/lower/map_kv.verus.rs
+++ b/tests/golden/lower/map_kv.verus.rs
@@ -4,7 +4,7 @@ verus! {
 pub struct TMapU64U64 { pub data: Vec<(u64, u64)> }
 impl TMapU64U64 {
     pub open spec fn spec_dom(&self) -> Set<int> {
-        Set::new(|kk: int| exists|j: int|
+        Set::new_assuming_finite(|kk: int| exists|j: int|
             0 <= j < self.data.len() && #[trigger] self.data@[j].0 as int == kk)
     }
     pub open spec fn well_formed(&self) -> bool {

--- a/thermite-lower/src/lower.rs
+++ b/thermite-lower/src/lower.rs
@@ -4805,11 +4805,11 @@ fn emit_one_map_wrapper(key: &Type, val: &Type) -> Result<String, LowerError> {
     out.push('\n');
     writeln!(out, "pub struct {name} {{ pub data: Vec<({kty}, {vty})> }}").ok();
     writeln!(out, "impl {name} {{").ok();
-    // The key-set abstraction `spec_dom` (the spec membership view; REQ-4). A named
-    // spec fn over a `Set` comprehension with an explicit trigger (the §4.2 cage:
-    // never an anonymous nested quantifier admitted raw).
+    // The key-set abstraction `spec_dom` (the spec membership view; REQ-4). The
+    // wrapper's backing vector is finite, so current Verus' finite-set API uses
+    // `new_assuming_finite` for this bounded comprehension.
     out.push_str("    pub open spec fn spec_dom(&self) -> Set<int> {\n");
-    out.push_str("        Set::new(|kk: int| exists|j: int|\n");
+    out.push_str("        Set::new_assuming_finite(|kk: int| exists|j: int|\n");
     out.push_str(
         "            0 <= j < self.data.len() && #[trigger] self.data@[j].0 as int == kk)\n",
     );


### PR DESCRIPTION
## Summary

- Update the bounded `Map` wrapper lowering to use current Verus' finite-set API for `spec_dom`.
- Refresh the committed `map_kv` golden lowering and the standalone map conformance probe to match.

## Root cause

Current Verus returns `Option<Set<_>>` from `Set::new(...)`. Thermite's generated bounded map wrapper expects a concrete `Set<int>`, so the Verus-backed `map_kv` checks failed before verification with a type mismatch. The wrapper's backing vector is finite, so `Set::new_assuming_finite(...)` is the compatible constructor for this bounded comprehension.

## Validation

- `cargo test -p forge --test check_conformance`
- `cargo test -p forge --test map_conformance`
- `cargo test -p thermite-lower --test lower_conformance`
- `make gauntlet`