### PR TITLE
Stage-2 REQ-0: surface quantifiers — raw forall/exists in thermite-syntax (#322)

### DIFF
--- a/.design/basis/02-recursion-schemes.md
+++ b/.design/basis/02-recursion-schemes.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: caf04d5eeb38a06a84f210bc5dab3bf9f4bf4ab8f7392f66e1f9524397c10aac
+audited-content-sha256: 6004f9fda0852b06dba72dbdafb5c14830c76b36a163b070b057d7ac9fec7032
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/04-collections.md
+++ b/.design/basis/04-collections.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: d3586a0409852219d52a51812ca4e46c743df7dac46518374ef8a09f83b99166
+audited-content-sha256: 2d0c3cdaadf0413ffc61754e0eaac2c219438754b5b48a04faea5a1d001147fd
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/06-provenance-and-sinks.md
+++ b/.design/basis/06-provenance-and-sinks.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: e4753c80bb05b7b6a8ff52b9b83e45e572d977a983ec059bbd9faa4c0c96b086
+audited-content-sha256: 0982a363ece7986bdb15f21d4cbfcc4ebfefd36158f471a3b8a79e13e163c1d5
 governs: thermite-spec/src/validator.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/07-strings.md
+++ b/.design/basis/07-strings.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: d3586a0409852219d52a51812ca4e46c743df7dac46518374ef8a09f83b99166
+audited-content-sha256: 2d0c3cdaadf0413ffc61754e0eaac2c219438754b5b48a04faea5a1d001147fd
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: ae6295f1a8d4faefe640559c01e39fd3766cfa52 (re-pinned 2026-06-17 after merging main into the §6 metrics-dashboard branch (#316): governed source carries the additive REQ-FORGE-METRICS-DASHBOARD entry + regen status view; net-additive, REQs unchanged.)
+audited-sha: b9704022d93ff153e345699cbc444645ca284fcc (re-pinned 2026-06-19 for #322 surface-quantifier foundation: governed source gains net-additive raw forall/exists handling — the new Expr::Quantifier AST node + honest-refusal match arms; the REQs this doc governs are unchanged.)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/10-recursion-tuples.md
+++ b/.design/basis/10-recursion-tuples.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: d3586a0409852219d52a51812ca4e46c743df7dac46518374ef8a09f83b99166
+audited-content-sha256: 2d0c3cdaadf0413ffc61754e0eaac2c219438754b5b48a04faea5a1d001147fd
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: ae6295f1a8d4faefe640559c01e39fd3766cfa52 (re-pinned 2026-06-17 after merging main into the §6 metrics-dashboard branch (#316): governed source carries the additive REQ-FORGE-METRICS-DASHBOARD entry + regen status view; net-additive, REQs unchanged.)
+audited-sha: b9704022d93ff153e345699cbc444645ca284fcc (re-pinned 2026-06-19 for #322 surface-quantifier foundation: governed source gains net-additive raw forall/exists handling — the new Expr::Quantifier AST node + honest-refusal match arms; the REQs this doc governs are unchanged.)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 59287187c2afcc22e1b7872f118183f1e49de263 (re-pinned 2026-06-17 after merging main into the skill-v2 branch: governed source carries the governance docs (#56) + the skill-v2 generator change, both net-additive; the REQs this doc governs are unchanged.)
+audited-sha: b9704022d93ff153e345699cbc444645ca284fcc (re-pinned 2026-06-19 for #322 surface-quantifier foundation: governed source gains net-additive raw forall/exists handling — the new Expr::Quantifier AST node + honest-refusal match arms; the REQs this doc governs are unchanged.)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/basis/13-map.md
+++ b/.design/basis/13-map.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: d3586a0409852219d52a51812ca4e46c743df7dac46518374ef8a09f83b99166
+audited-content-sha256: 2d0c3cdaadf0413ffc61754e0eaac2c219438754b5b48a04faea5a1d001147fd
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 1db3f2ba5cff4b38508036f9dd1cf47f54e5d161 (re-pinned 2026-06-17 after merging main into the G1 gate-artifact branch: governed source carries the gate's per-clause forge router + #53 arm64 sandbox + #54 content-pin docs, net-additive; the REQs this doc governs are unchanged.)
+audited-sha: b9704022d93ff153e345699cbc444645ca284fcc (re-pinned 2026-06-19 for #322 surface-quantifier foundation: governed source gains net-additive raw forall/exists handling — the new Expr::Quantifier AST node + honest-refusal match arms; the REQs this doc governs are unchanged.)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/e2e-vs-boundary.md
+++ b/.design/forge/e2e-vs-boundary.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 0d505126ce3d7314257fdd5446e6c020cf76bba126e8b6238f861de476f51697
+audited-content-sha256: bb79087f969a6a0641d8679fc1a19c18f65e091e423eb2397b81f27a24286d03
 governs: forge/src/closure.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/forge/mutation-scoring.md
+++ b/.design/forge/mutation-scoring.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 80074948185b77b95006d034e461a338b1ce6b37 (re-pinned 2026-06-16: forge quality status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (re-pinned: the #269/#270 coordinated arc — the touched-file changes are exactly this doc's designed REQs / reviewed as claim-neutral)  (re-audited 2026-06-12: amended — shipped-status Summary; #48/#74/#80 early-return synthesis + 0/0 backstop, the #101 equivalence-excluded denominator, golden-anchored ratios, and the #247 Lean-battery consumer, #262. Amended 2026-06-12 (#269): the TWO MISSING early-return families F-IDENT (identity return) + F-STRUCT-ZERO (named-struct field-zeros) are specced REQ-9..REQ-13, NOT-STARTED — the outside review's item 5, the `move_up` weak-contract escape.))
-audited-content-sha256: 6c6cc4a19e78051cd1be8d426beb27a01f2a0be37aa2693cb47b4e2a8248faa1
+audited-content-sha256: aca03d45f70be859128483c22e3a243b8be62178d1d63387c1a87075b014a85a
 governs: forge/src/mutation.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/spec-review.md
+++ b/.design/forge/spec-review.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (review.rs) is the additive REQ-9 burned_lemmas partition + BurnedLemma projection (a certified lemma surfaces like any certified item); the v1 intent-reviewable / battery-failing partitions are unchanged (REQ-S1-9). prior: 92396428567edc6940a9e2845217f5ff4c2ea3c6)
-audited-content-sha256: b3d50b56cf785797645c8fabd0f0dd26607949baf6a47ffffd386657fd716831
+audited-content-sha256: d02debcf91c918fd4af83dd0904dfb5f01eb7b4ebad4bc7863f382484597a59e
 governs: forge/src/review.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/vacuity-triage.md
+++ b/.design/forge/vacuity-triage.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 1630a862c120fe1e8f33f8dcc31c24f891d8effb61086490bfdd5a9140710a83
+audited-content-sha256: 84205383a3e59561217a6b48a4d302aaaa1b2382a9f12fe2db3fa6bb48840965
 governs: forge/src/vacuity.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 59287187c2afcc22e1b7872f118183f1e49de263 (re-pinned 2026-06-17 after merging main into the skill-v2 branch: governed source carries the governance docs (#56) + the skill-v2 generator change, both net-additive; the REQs this doc governs are unchanged.)
+audited-sha: b9704022d93ff153e345699cbc444645ca284fcc (re-pinned 2026-06-19 for #322 surface-quantifier foundation: governed source gains net-additive raw forall/exists handling — the new Expr::Quantifier AST node + honest-refusal match arms; the REQs this doc governs are unchanged.)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/lower/effect-subsumption.md
+++ b/.design/lower/effect-subsumption.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 83b5577b5ba6ecdc1ba1020ffeeae31b313d9c3bfafe7c232cb9a3ceefcc48f7
+audited-content-sha256: 7f3d7169346168f056872289280534500b42a81cd357185f84637884a11e3be3
 governs: thermite-lower/src/effects.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/lower/l1-runtime-checks.md
+++ b/.design/lower/l1-runtime-checks.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 6b86f74476122cfddbdcf168d37a3561d2598054 (re-pinned 2026-06-16 for PR #46 after merging main: lower_l1's TString runtime gate now treats String-typed ADT declarations as TString users so ADT fields cannot name an unemitted runtime; main's inert Item::Forge skip is preserved; core req/ens/inv check emission is unchanged.)
-audited-content-sha256: f35dc6e292a621c5cfbbe8e3f5b5e8436e1ef91a486a02301802cdbf8b42ec9f
+audited-content-sha256: 149ec82c886d3f5173725077f59cd3fb84491f14a161941d47794a7d10f6e10b
 governs: thermite-lower/src/l1.rs
 thesis-refs:
   - thermite-design.md §4.2

--- a/.design/lower/verus-lowering.md
+++ b/.design/lower/verus-lowering.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: ea747a05b5b623e0f2806f046300e50c70b53c9309c8d03d1bb224893cbee0d8
+audited-content-sha256: 478452ebb846124808606cd301aaf01177cd4e1af152b083853d0fe948b9a536
 governs: thermite-lower/src/lower.rs
 thesis-refs:
   - thermite-design.md §3

--- a/.design/scaffold/workspace.md
+++ b/.design/scaffold/workspace.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (re-pinned 2026-06-17 for umbrella REQ-7 / AC-12, the §6 metrics dashboard: the only change to this doc's governed file (main.rs) is one additive module declaration (`mod metrics;`, the new §6 dashboard projection); the workspace/crate structure is otherwise unchanged. prior: stage-1 REQ-10/AC-14 G1 gate seven-verdict test module)
-audited-content-sha256: 1a58829d2107a1be932b85ccb14c1392b9e597987a18b5a2c7c068ce10bed3b4
+audited-content-sha256: 84bfe82ea82020b3101c719056069804b06e321cfcbd0240bbe668a3f52c8867
 governs:
   - Cargo.toml (virtual workspace manifest)
   - rust-toolchain.toml

--- a/.design/skill/skill-generator.md
+++ b/.design/skill/skill-generator.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: f27db76f3c10fc9be90952f9d396d4dcbc9d7dae75a07c7619f9a43b24c5c2bd
+audited-content-sha256: 605114ce2e2cf1e914e43775c260fcea67de2c7e12a27bd1e6434fd09fd7a331
 governs: thermite-skill/src/generate.rs
 thesis-refs:
   - thermite-design.md §2.2

--- a/.design/spec/spectherm-combinators.md
+++ b/.design/spec/spectherm-combinators.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 5501298042331cf5e79f16f08c194f1138e4cdfc6327cf4ad7f6c0482f834290
+audited-content-sha256: 9a1b25a7ee406210a5ee4043654e4211f131b2a3b593c1d0bfe093881c7d8764
 governs: thermite-spec/src/combinators.rs, thermite-spec/src/validator.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/syntax/ast.md
+++ b/.design/syntax/ast.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 28ca7e567ee606bc03ac06fa5783db64ebec2fe07b3f73d079a700ee0b242f74
+audited-content-sha256: fa389248b88a4f86e1c4bd9b0488a95f76a81066a807a8ba8af3bcd087375fc9
 governs: thermite-syntax/src/ast.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/syntax/lexer.md
+++ b/.design/syntax/lexer.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 6b86f74476122cfddbdcf168d37a3561d2598054 (re-pinned 2026-06-16 for PR #46 after merging main: lex_string now rejects raw non-ASCII bytes with a structured SyntaxError while string contents remain Rust-String-backed; ASCII escapes and token classification are unchanged.)
-audited-content-sha256: 775d2e6cfdf564412cdbb55a5fa75f5fc6fd7acbf8b3bdc6e6b28a2ef271cd5a
+audited-content-sha256: ba559aaabe5239900afd87a688db2413e457a91eef2dca870dff01aa62f1e05c
 governs: thermite-syntax/src/lexer.rs
 thesis-refs:
   - thermite-design.md §4.3

--- a/.design/syntax/parser.md
+++ b/.design/syntax/parser.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: d0f81b499f859523a5a495795e69f2407ec4712ed5083497a5a79b9c89fb5d55
+audited-content-sha256: b292b94b723a9d01b110e7914b711d0ce3ba1976bea1938f104f8ff9a2cd818b
 governs: thermite-syntax/src/parser.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/verified/contract-tv.md
+++ b/.design/verified/contract-tv.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 4a748bc98172c98cc39fb245996ab4143bdab08d (re-pinned 2026-06-16 for stage-1 increment 2b: thermite-tv's SplitMix64 Rng is made pub so the covenant falsify can reuse it (a visibility widening, additive); the contract-TV REQs this doc governs are unchanged.)
-audited-content-sha256: e83d45113d86446236c97c6598c9fd020a9af14da9d9aac9d61581a0226ceeb3
+audited-content-sha256: 3894d2078d92981e70882f80bf31eb63b43eb3d5cb1084ed41cda5b523404146
 governs: thermite-tv/src/ref_encode.rs, thermite-tv/src/obligation.rs, forge/src/contract_tv.rs
 thesis-refs:
   - thermite-design.md §1 (trust relocated twice: code → spec → spec-intent)

--- a/.design/verified/exec-tv.md
+++ b/.design/verified/exec-tv.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 64949ed8940c6770cca095ebae7064874db5078270edfce077238d4d44f91222
+audited-content-sha256: 21f415711d2468ee260bee6fd43a9fd19f5868b68264eef9f743674c7cc4a04b
 governs: thermite-tv/src/exec_encode.rs, thermite-tv/src/obligation.rs, thermite-tv/src/gen.rs, forge/src/exec_tv.rs
 thesis-refs:
   - thermite-design.md §1 (trust relocated: code → spec → spec-intent)

--- a/.design/verified/exporter-surface-correspondence.md
+++ b/.design/verified/exporter-surface-correspondence.md
@@ -5,7 +5,7 @@ tier: 3-component
 status: draft
 governs: forge/src/lean_export.rs
 audited-sha: 8978ecc950df30b58c00fe6df06f1fc5b4c56691 (re-pinned 2026-06-16 for stage-1 increment 2e, REQ-7: re-inspected the exporter surface for the new export_lemma. It reuses the EXACT tier-(a) fn-contract machinery (encode_expr + build_registry + R_item + the `Thermite.denote 0 … {v with specs := R_item}` framing) MINUS the body/result binding — a lemma is the pure `∀ params, req → ens` proposition with no body/result. The existing arms' correspondence is unchanged; the lemma goal is the same denote-framing the fn req/ens arms already certify, so no new soundness claim is introduced.)
-audited-content-sha256: e861fd1ca57cd9ce5a96c813ce892f447e4c0f364226abfb7442e4dd14de207d
+audited-content-sha256: abfa33bb083d691b2450d202ac11276fb88c6b7659e5ba99411d635a6ddac506
              tone-pass that closed increment 0; increment 1 does NOT modify lean_export.rs,
              so this pin stays valid after the foundation commit)
 thesis-refs:

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-sha: 1db3f2ba5cff4b38508036f9dd1cf47f54e5d161 (re-pinned 2026-06-17 after merging main into the G1 gate-artifact branch: governed source carries the gate's per-clause forge router + #53 arm64 sandbox + #54 content-pin docs, net-additive; the REQs this doc governs are unchanged.)
+audited-sha: b9704022d93ff153e345699cbc444645ca284fcc (re-pinned 2026-06-19 for #322 surface-quantifier foundation: governed source gains net-additive raw forall/exists handling — the new Expr::Quantifier AST node + honest-refusal match arms; the REQs this doc governs are unchanged.)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -3515,6 +3515,12 @@ pub(crate) fn collect_expr_spec_fn_calls(
             }
         }
         Expr::TupleProj { receiver, .. } => collect_expr_spec_fn_calls(receiver, spec_decls, out),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // spec-fn call can appear in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            collect_expr_spec_fn_calls(domain, spec_decls, out);
+            collect_expr_spec_fn_calls(body, spec_decls, out);
+        }
         // A string literal is a leaf (`.design/basis/07-strings.md` REQ-1): no
         // sub-expression, so it calls no spec fn — the no-op leaf arm.
         Expr::IntLit { .. } | Expr::BoolLit(_) | Expr::Path(_) | Expr::StrLit(_) => {}
@@ -3838,6 +3844,12 @@ fn collect_expr_adt_refs(
             }
         }
         Expr::TupleProj { receiver, .. } => collect_expr_adt_refs(receiver, adt_decls, out),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): an
+        // ADT reference can appear in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            collect_expr_adt_refs(domain, adt_decls, out);
+            collect_expr_adt_refs(body, adt_decls, out);
+        }
         // A string literal is a leaf (`.design/basis/07-strings.md` REQ-1): no
         // sub-expression, no path — it references no ADT (the no-op leaf arm).
         Expr::IntLit { .. } | Expr::BoolLit(_) | Expr::StrLit(_) => {}

--- a/forge/src/closure.rs
+++ b/forge/src/closure.rs
@@ -459,6 +459,12 @@ fn walk_expr(expr: &Expr, in_file: &BTreeSet<&str>, out: &mut Vec<String>) {
             }
         }
         Expr::TupleProj { receiver, .. } => walk_expr(receiver, in_file, out),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // call out-edge can appear in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            walk_expr(domain, in_file, out);
+            walk_expr(body, in_file, out);
+        }
         // Leaves: no nested call to find. A string literal
         // (`.design/basis/07-strings.md` REQ-1) is a leaf with no sub-expression and
         // no callee, so it contributes no out-edge.

--- a/forge/src/covenant_eval.rs
+++ b/forge/src/covenant_eval.rs
@@ -485,6 +485,12 @@ fn expr_shape(expr: &Expr) -> String {
         Expr::StrLit(_) => "string literal".to_string(),
         Expr::Tuple(_) => "tuple expression".to_string(),
         Expr::TupleProj { index, .. } => format!("tuple projection .{index}"),
+        // A raw quantifier (`.design/stage2-stratified-cage.md` REQ-0): a shape label;
+        // covenant evaluation of stratified binders is stage-2 (REQ-8).
+        Expr::Quantifier { quant, .. } => match quant {
+            thermite_syntax::Quant::Forall => "forall quantifier".to_string(),
+            thermite_syntax::Quant::Exists => "exists quantifier".to_string(),
+        },
     }
 }
 

--- a/forge/src/lean_export.rs
+++ b/forge/src/lean_export.rs
@@ -336,6 +336,16 @@ fn encode_expr(e: &Expr, ctx: &EncodeCtx) -> Result<String, ExportRefusal> {
         Expr::Closure { .. } => Err(ExportRefusal::OutOfFragment(
             "bare closure (S_C closures appear ONLY as a combinator predicate)".to_string(),
         )),
+        // A raw quantifier `forall`/`exists` (`.design/stage2-stratified-cage.md`
+        // REQ-0): the v1 contract fragment `S_C` (the `Ast.lean` mirror this exporter
+        // targets) has NO raw binder constructor — stratified Lean encoding is REQ-5
+        // (`Strat/RefEncode.lean`), a separate namespace. Refuse honestly so no
+        // unproven binder is ever exported to the v1 spine and the Rust↔Lean
+        // correspondence stays pinned.
+        Expr::Quantifier { .. } => Err(ExportRefusal::OutOfFragment(
+            "raw quantifier (`forall`/`exists`) — S_C has no binder; stratified encoding is stage-2 (REQ-5)"
+                .to_string(),
+        )),
     }
 }
 

--- a/forge/src/mutation.rs
+++ b/forge/src/mutation.rs
@@ -886,6 +886,12 @@ impl MutantSink {
                 }
             }
             Expr::TupleProj { receiver, .. } => self.scan_expr(receiver, ctr),
+            // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+            // mutation site can live in the domain or the body — descend into both.
+            Expr::Quantifier { domain, body, .. } => {
+                self.scan_expr(domain, ctr);
+                self.scan_expr(body, ctr);
+            }
             // A string literal (`.design/basis/07-strings.md` REQ-1) is a leaf and
             // is not an off-by-one target (it is text, not a numeric literal) — it
             // defines no new mutation site and has no sub-expression to descend
@@ -1185,6 +1191,23 @@ impl Applier<'_> {
             Expr::TupleProj { receiver, index } => Expr::TupleProj {
                 receiver: Box::new(self.apply_expr(receiver)),
                 index: *index,
+            },
+            // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0):
+            // rebuild the binder faithfully, recursing into the domain and body so a
+            // mutation site in either is applied; the binder head (`quant`/`var`/
+            // `sort`) is identity-preserved.
+            Expr::Quantifier {
+                quant,
+                var,
+                sort,
+                domain,
+                body,
+            } => Expr::Quantifier {
+                quant: *quant,
+                var: var.clone(),
+                sort: sort.clone(),
+                domain: Box::new(self.apply_expr(domain)),
+                body: Box::new(self.apply_expr(body)),
             },
             Expr::BoolLit(b) => Expr::BoolLit(*b),
             Expr::Path(p) => Expr::Path(p.clone()),

--- a/forge/src/relax.rs
+++ b/forge/src/relax.rs
@@ -243,6 +243,9 @@ fn expr_kind(e: &Expr) -> &'static str {
         Expr::StrLit(_) => "string literal",
         Expr::Tuple(_) => "tuple",
         Expr::TupleProj { .. } => "tuple projection",
+        // A raw quantifier (`.design/stage2-stratified-cage.md` REQ-0): a kind label
+        // for the relax classifier; stratified relax routing is stage-2 (REQ-8).
+        Expr::Quantifier { .. } => "quantifier",
     }
 }
 

--- a/forge/src/review.rs
+++ b/forge/src/review.rs
@@ -561,6 +561,12 @@ fn collect_callee_names(expr: &Expr, out: &mut std::collections::BTreeSet<String
             }
         }
         Expr::TupleProj { receiver, .. } => collect_callee_names(receiver, out),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // callee name can appear in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            collect_callee_names(domain, out);
+            collect_callee_names(body, out);
+        }
         // A string literal (`.design/basis/07-strings.md` REQ-1) is a leaf: no
         // sub-expression, no callee path — it references no spec fn (the no-op
         // leaf arm alongside `IntLit`/`BoolLit`).

--- a/forge/src/vacuity.rs
+++ b/forge/src/vacuity.rs
@@ -277,6 +277,11 @@ fn expr_mentions_result(expr: &Expr, depth: usize) -> bool {
         // result-bearing (not false-rejected as vacuous).
         Expr::Tuple(elems) => elems.iter().any(|e| expr_mentions_result(e, d)),
         Expr::TupleProj { receiver, .. } => expr_mentions_result(receiver, d),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0):
+        // `result` can be mentioned in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            expr_mentions_result(domain, d) || expr_mentions_result(body, d)
+        }
     }
 }
 

--- a/thermite-lower/src/effects.rs
+++ b/thermite-lower/src/effects.rs
@@ -656,6 +656,29 @@ fn check_expr<'a>(
         // a literal into an owned `String` carries `fx alloc`, but that is keyed at
         // the lowering/constructing site in `lower.rs`, not at this effect walk —
         // the bare literal node has no callee to subsume.)
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): its
+        // effects are the union of the domain's and body's, so an effect-bearing
+        // call inside either is still subsumption-checked. The binder itself is pure.
+        Expr::Quantifier { domain, body, .. } => {
+            check_expr(
+                domain,
+                caller_fx,
+                caller_name,
+                caller_span,
+                resolve,
+                d,
+                errors,
+            );
+            check_expr(
+                body,
+                caller_fx,
+                caller_name,
+                caller_span,
+                resolve,
+                d,
+                errors,
+            );
+        }
         Expr::IntLit { .. } | Expr::BoolLit(_) | Expr::Path(_) | Expr::StrLit(_) => {}
     }
 }

--- a/thermite-lower/src/l1.rs
+++ b/thermite-lower/src/l1.rs
@@ -579,6 +579,12 @@ fn collect_combinators_in_expr(expr: &Expr, span: Span, acc: &mut Vec<(String, S
             }
         }
         Expr::TupleProj { receiver, .. } => collect_combinators_in_expr(receiver, span, acc),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // registry-free combinator can appear in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            collect_combinators_in_expr(domain, span, acc);
+            collect_combinators_in_expr(body, span, acc);
+        }
         // A string literal is a leaf (`.design/basis/07-strings.md` REQ-1): no
         // sub-expressions, so it references no combinator — the no-op leaf arm
         // alongside `IntLit`/`BoolLit`.
@@ -1008,6 +1014,24 @@ fn rename_params_in_expr(expr: &Expr, renames: &[(String, String)]) -> Expr {
             receiver: rec(receiver),
             index: *index,
         },
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0):
+        // rename params in the domain and body, preserving the binder head
+        // (`quant`/`var`/`sort`). Like the `Closure` arm above, this is a structural
+        // param rename, not a capture-avoiding substitution — v0.1 rename is the
+        // fn-param alpha pass, and the bound variable's own name is left intact.
+        Expr::Quantifier {
+            quant,
+            var,
+            sort,
+            domain,
+            body,
+        } => Expr::Quantifier {
+            quant: *quant,
+            var: var.clone(),
+            sort: sort.clone(),
+            domain: rec(domain),
+            body: rec(body),
+        },
     }
 }
 
@@ -1063,6 +1087,11 @@ fn expr_references_ident(expr: &Expr, ident: &str) -> bool {
         // ident can be referenced in any tuple element or projection receiver.
         Expr::Tuple(elems) => any(elems),
         Expr::TupleProj { receiver, .. } => expr_references_ident(receiver, ident),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): the
+        // ident can be referenced in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            expr_references_ident(domain, ident) || expr_references_ident(body, ident)
+        }
     }
 }
 
@@ -1695,6 +1724,17 @@ pub(crate) fn lower_expr_exec(
             let r = lower_expr_exec(receiver, d, span, variants)?;
             Ok(format!("{r}.{index}"))
         }
+        // A raw quantifier `forall`/`exists` (`.design/stage2-stratified-cage.md`
+        // REQ-0) is a SPEC-only formula — it has no executable meaning, so it never
+        // belongs in an L1 exec-body position. (Even its spec lowering is deferred to
+        // REQ-8.) Refuse honestly with the established "outside the v0.1 mapping"
+        // error rather than emit anything. No corpus places a quantifier in exec
+        // position, so this path is unreachable for the existing goldens.
+        Expr::Quantifier { .. } => Err(LowerError::Unsupported {
+            what: "a raw quantifier (`forall`/`exists`) in executable position (spec-only)"
+                .to_string(),
+            span,
+        }),
     }
 }
 
@@ -2177,6 +2217,11 @@ fn expr_has_str_lit_l1(expr: &Expr) -> bool {
         // receiver — descend into both (the full-tree walk).
         Expr::Tuple(elems) => elems.iter().any(expr_has_str_lit_l1),
         Expr::TupleProj { receiver, .. } => expr_has_str_lit_l1(receiver),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // string literal can hide in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            expr_has_str_lit_l1(domain) || expr_has_str_lit_l1(body)
+        }
     }
 }
 
@@ -2905,5 +2950,10 @@ fn expr_has_to_string(expr: &Expr) -> bool {
         // `to_string` call could sit in any tuple element or projection receiver.
         Expr::Tuple(elems) => elems.iter().any(expr_has_to_string),
         Expr::TupleProj { receiver, .. } => expr_has_to_string(receiver),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // `.to_string()` call can hide in the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            expr_has_to_string(domain) || expr_has_to_string(body)
+        }
     }
 }

--- a/thermite-lower/src/lower.rs
+++ b/thermite-lower/src/lower.rs
@@ -1501,6 +1501,13 @@ fn collect_combinators_in_expr(expr: &Expr, span: Span, acc: &mut Vec<(String, S
             }
         }
         Expr::TupleProj { receiver, .. } => collect_combinators_in_expr(receiver, span, acc),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // registry-free combinator (`forall_in`, etc.) can appear in either the
+        // domain or the body of a raw binder — descend into both so none is dropped.
+        Expr::Quantifier { domain, body, .. } => {
+            collect_combinators_in_expr(domain, span, acc);
+            collect_combinators_in_expr(body, span, acc);
+        }
         // A string literal (`.design/basis/07-strings.md` REQ-1) references no
         // combinator — a value-carrying leaf, like an int/bool literal.
         Expr::IntLit { .. } | Expr::BoolLit(_) | Expr::Path(_) | Expr::StrLit(_) => {}
@@ -1780,6 +1787,12 @@ fn each_subexpr(
             }
         }
         Expr::TupleProj { receiver, .. } => f(receiver)?,
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): its
+        // immediate sub-expressions are the domain and the body.
+        Expr::Quantifier { domain, body, .. } => {
+            f(domain)?;
+            f(body)?;
+        }
         // A string literal (`.design/basis/07-strings.md` REQ-1) is a value-
         // carrying leaf with no sub-expression — like an int/bool literal.
         Expr::IntLit { .. } | Expr::BoolLit(_) | Expr::Path(_) | Expr::StrLit(_) => {}
@@ -3575,6 +3588,11 @@ fn expr_has_deref_call_arg(expr: &Expr) -> bool {
         // projection's receiver; the full-tree walk descends into both.
         Expr::Tuple(elems) => elems.iter().any(expr_has_deref_call_arg),
         Expr::TupleProj { receiver, .. } => expr_has_deref_call_arg(receiver),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // deref `*t` call-arg can hide in either the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            expr_has_deref_call_arg(domain) || expr_has_deref_call_arg(body)
+        }
         Expr::IntLit { .. }
         | Expr::BoolLit(_)
         | Expr::Path(_)
@@ -7643,6 +7661,20 @@ fn lower_expr(expr: &Expr, ctx: Ctx, depth: usize, span: Span) -> Result<String,
             let r = lower_expr(receiver, ctx, d, span)?;
             Ok(format!("{r}.{index}"))
         }
+        // A raw quantified formula `forall (x : S) in <dom>. φ` / `exists …`
+        // (`.design/stage2-stratified-cage.md` REQ-0). The surface binder PARSES
+        // now (the foundation increment), but its Verus emission (a stratified
+        // `forall|…|`/`exists|…|` with the fresh-name + trigger discipline) is
+        // REQ-8 ("production quantifier emission in thermite-lower"), gated on the
+        // stage-2 metatheory. Until then the lowerer refuses honestly rather than
+        // emit an unproven encoding — `LowerError::Unsupported` is the established
+        // "outside the v0.1 mapping" path. No corpus uses raw quantifiers, so no
+        // existing golden is affected.
+        Expr::Quantifier { .. } => Err(LowerError::Unsupported {
+            what: "a raw quantifier (`forall`/`exists`) — stratified emission is stage-2 (REQ-8)"
+                .to_string(),
+            span,
+        }),
     }
 }
 
@@ -8506,6 +8538,13 @@ fn collect_block_local_muls(block: &Block, muls: &mut Vec<Expr>) {
                     }
                 }
             }
+            // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0):
+            // a multiplication needing an overflow obligation can hide in either the
+            // domain or the body — descend into both.
+            Expr::Quantifier { domain, body, .. } => {
+                walk_expr(domain, muls);
+                walk_expr(body, muls);
+            }
             // A closure body is a spec predicate (no exec overflow obligation);
             // literals/paths/strings carry no nested product. No-op.
             Expr::Closure { .. }
@@ -9028,6 +9067,11 @@ fn expr_mentions(expr: &Expr, name: &str) -> bool {
         // can be mentioned in any tuple element or under a projection's receiver.
         Expr::Tuple(elems) => elems.iter().any(|e| expr_mentions(e, name)),
         Expr::TupleProj { receiver, .. } => expr_mentions(receiver, name),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): the
+        // name can be mentioned in either the domain or the body.
+        Expr::Quantifier { domain, body, .. } => {
+            expr_mentions(domain, name) || expr_mentions(body, name)
+        }
     }
 }
 

--- a/thermite-skill/src/generate.rs
+++ b/thermite-skill/src/generate.rs
@@ -456,6 +456,15 @@ fn render_expr_arm(expr: &Expr) -> SkillFragment {
             description: "a tuple projection (the one tuple access; reads in exec and ens)",
             example: "ens result.0 == b && result.1 == a",
         },
+        // Stage-2 (`.design/stage2-stratified-cage.md` REQ-0): the raw quantifier
+        // binder over a named sorted carrier. Distinct from the `forall_in`/`sorted`
+        // COMBINATOR free calls (those are `Expr::Call`); the body extends greedily
+        // (parenthesize to bound it). `in` is contextual (not a reserved word).
+        Expr::Quantifier { .. } => SkillFragment {
+            fragment: "forall (x : S) in DOM. BODY | exists (x : S) in DOM. BODY",
+            description: "a raw quantifier over a named sorted carrier (the body is greedy)",
+            example: "forall (i : Idx) in haystack. haystack[i] != needle",
+        },
     }
 }
 

--- a/thermite-spec/src/validator.rs
+++ b/thermite-spec/src/validator.rs
@@ -1138,6 +1138,14 @@ impl Validator {
                 }
             }
             Expr::TupleProj { receiver, .. } => self.scan_expr_for_loops(receiver, span),
+            // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0):
+            // descend into the domain and body for nested loops / ADT well-formedness,
+            // like any other compound expression. The stratified fragment/sort checks
+            // are the classifier's job (REQ-4), not this exec-body walk.
+            Expr::Quantifier { domain, body, .. } => {
+                self.scan_expr_for_loops(domain, span);
+                self.scan_expr_for_loops(body, span);
+            }
             // Leaves — no nested loop / ADT node possible. A string literal
             // (`.design/basis/07-strings.md` REQ-1) is a value-carrying leaf, like
             // an int/bool literal — no sub-expression to descend.
@@ -1356,6 +1364,20 @@ impl Validator {
                 }
             }
             Expr::TupleProj { receiver, .. } => self.walk_expr(receiver, span),
+            // A raw quantified formula `forall (x : S) in <dom>. φ`
+            // (`.design/stage2-stratified-cage.md` REQ-0): surface + parse exists
+            // now, but STRATIFIED ADMISSION (the sort-graph/fragment classifier) is
+            // REQ-4, a separate pass added beside this validator. This walker is the
+            // v1 cage; it neither certifies nor models the binder yet. To stay
+            // non-breaking for the foundation increment we recurse the domain and
+            // body — so any forbidden nested content still surfaces (REQ-5,
+            // depth-guarded) — and otherwise leave the binder structurally accepted
+            // for the REQ-4 classifier to admit or reject. No corpus uses raw
+            // quantifiers, so the existing cage behavior is unchanged.
+            Expr::Quantifier { domain, body, .. } => {
+                self.walk_expr(domain, span);
+                self.walk_expr(body, span);
+            }
         }
     }
 
@@ -1952,6 +1974,12 @@ fn expr_calls_name(expr: &Expr, name: &str) -> bool {
         // descends into both.
         Expr::Tuple(elems) => elems.iter().any(|e| expr_calls_name(e, name)),
         Expr::TupleProj { receiver, .. } => expr_calls_name(receiver, name),
+        // A raw quantified formula (`.design/stage2-stratified-cage.md` REQ-0): a
+        // (recursive) call can live in either the domain or the body, so the
+        // self-call detection (REQ-2) descends into both.
+        Expr::Quantifier { domain, body, .. } => {
+            expr_calls_name(domain, name) || expr_calls_name(body, name)
+        }
         Expr::IntLit { .. } | Expr::BoolLit(_) | Expr::Path(_) | Expr::StrLit(_) => false,
     }
 }

--- a/thermite-syntax/src/ast.rs
+++ b/thermite-syntax/src/ast.rs
@@ -759,6 +759,17 @@ pub enum UnaryOp {
     Not,
 }
 
+/// A quantifier binder head (`.design/stage2-stratified-cage.md` REQ-0): the `forall`
+/// or `exists` of a raw quantified formula. The two surface keywords [`crate::lexer::TokKind::Forall`]
+/// / [`crate::lexer::TokKind::Exists`] map to these; the stratified classifier (REQ-1/REQ-4)
+/// keys on the kind. Distinct from the registry-free `forall_in`/`exists_in` COMBINATOR
+/// calls, which remain ordinary [`Expr::Call`] nodes (the combinator registry is untouched).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Quant {
+    Forall,
+    Exists,
+}
+
 /// An index argument: `a[i]`, `a[..i]`, `a[i..]`, `a[i..j]` (ast.md REQ-6).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IndexArg {
@@ -894,6 +905,29 @@ pub enum Expr {
     TupleProj {
         receiver: Box<Expr>,
         index: usize,
+    },
+    /// A raw quantified formula `forall (x : S) in <dom>. φ` / `exists (x : S) in
+    /// <dom>. φ` (`.design/stage2-stratified-cage.md` REQ-0): the surface binder
+    /// production the (R2) index grammar admits, over a named sorted carrier. `quant`
+    /// is the binder kind; `var` is the bound variable `x`; `sort` names its carrier
+    /// sort `S`; `domain` is the `<dom>` expression it ranges over (parsed after the
+    /// contextual `in`, e.g. a slice/carrier); `body` is the quantified formula φ.
+    ///
+    /// This is the FOUNDATION increment blocking REQ-1 (the Lean `Strat/Syntax` denote
+    /// path) and REQ-4 (the Rust classifier): until raw `forall`/`exists` parse, the
+    /// classifier cannot see a quantified formula. It is deliberately DISTINCT from the
+    /// registry-free `forall_in`/`forall_below`/`forall_from`/`sorted` COMBINATOR calls
+    /// — those stay ordinary [`Expr::Call`] nodes and the combinator registry
+    /// (`thermite-spec/src/combinators.rs`) is untouched as surface syntax. Surface +
+    /// parse only here; the binder denotation/lowering land in the later Strat
+    /// increments (REQ-1/REQ-8). The `body` is greedy (lowest precedence): `forall …. a
+    /// && b` reads the whole `a && b` as the body; parenthesize to bound it.
+    Quantifier {
+        quant: Quant,
+        var: Ident,
+        sort: Ident,
+        domain: Box<Expr>,
+        body: Box<Expr>,
     },
 }
 

--- a/thermite-syntax/src/lexer.rs
+++ b/thermite-syntax/src/lexer.rs
@@ -112,6 +112,19 @@ pub enum TokKind {
     Struct,
     Enum,
     Is,
+    /// The universal-quantifier binder head `forall` (`.design/stage2-stratified-cage.md`
+    /// REQ-0): the raw binder production `forall (x : S) in <dom>. φ` the (R2) index
+    /// grammar admits. A RESERVED keyword (the closed set, REQ-2) so the binder is
+    /// recognized unambiguously at expression head. The registry-free combinator
+    /// identifiers `forall_in`/`forall_below`/`forall_from` are DISTINCT words (they
+    /// still lex to [`TokKind::Ident`]); only the bare `forall` is reserved, leaving
+    /// the combinator registry untouched.
+    Forall,
+    /// The existential-quantifier binder head `exists` (`.design/stage2-stratified-cage.md`
+    /// REQ-0): the dual of [`TokKind::Forall`], same binder grammar. Reserved for the
+    /// same reason; the `exists_in` combinator ident is a distinct word and stays
+    /// [`TokKind::Ident`].
+    Exists,
 
     // Literals / names.
     Ident(String),
@@ -220,6 +233,8 @@ fn keyword_kind(word: &str) -> Option<TokKind> {
         "struct" => TokKind::Struct,
         "enum" => TokKind::Enum,
         "is" => TokKind::Is,
+        "forall" => TokKind::Forall,
+        "exists" => TokKind::Exists,
         "true" => TokKind::Bool(true),
         "false" => TokKind::Bool(false),
         _ => return None,

--- a/thermite-syntax/src/lib.rs
+++ b/thermite-syntax/src/lib.rs
@@ -49,8 +49,8 @@ pub use ast::{
     BinOp, Block, BoundaryAttr, Clause, ClauseSelector, Contract, Effect, EffectRow, EnumItem,
     Expr, Falsify, FieldDef, FnItem, ForgeItem, Hole, HoleContext, IndexArg, Inhabit, Item,
     LemmaItem, LoopKind, LoopNode, MatchArm, Param, Pattern, PrimType, Program, ProofBlock,
-    ProofItem, ProofObligation, PropFnItem, Refinement, RefinementTarget, SlagAttr, SlicePat,
-    SpecFnItem, Stmt, StructItem, Type, UnaryOp, VariantDef, VariantShape, WitnessBlock,
+    ProofItem, ProofObligation, PropFnItem, Quant, Refinement, RefinementTarget, SlagAttr,
+    SlicePat, SpecFnItem, Stmt, StructItem, Type, UnaryOp, VariantDef, VariantShape, WitnessBlock,
 };
 pub use lexer::{tokenize, Span, TokKind, Token};
 pub use parser::{parse, ParseResult, SyntaxError};

--- a/thermite-syntax/src/parser.rs
+++ b/thermite-syntax/src/parser.rs
@@ -355,6 +355,17 @@ struct Parser<'a> {
     /// context). Saved/restored around each head so nested call/index/paren
     /// args re-enable struct literals.
     no_struct_literal: bool,
+    /// When true, a postfix `.` is treated as a TERMINATOR rather than a
+    /// field/method access — set only while parsing a quantifier's `<dom>`
+    /// (`.design/stage2-stratified-cage.md` REQ-0). The binder grammar
+    /// `forall (x : S) in <dom>. φ` separates the domain from the body with a `.`,
+    /// which collides with the postfix field-access `.` (`xs.len()`). Suppressing
+    /// the postfix `.` at the top level of the domain makes the first `.` after the
+    /// domain unambiguously the body separator. A nested call/index/paren-group
+    /// re-enables the postfix `.` via `with_struct_literal` (so `(a.b)` / `xs[a.b]`
+    /// inside a domain still read their dots), mirroring the `no_struct_literal`
+    /// re-enabling convention exactly.
+    no_dot: bool,
     /// Current loop-nesting depth (parser.md REQ-10, #93). Incremented in
     /// `parse_loop_inner` around the loop body parse, decremented after. A
     /// `break;`/`continue;` parsed at depth 0 (outside any `loop`/`while` body)
@@ -389,6 +400,7 @@ impl<'a> Parser<'a> {
             errors: lex_errors,
             recursion_depth: 0,
             no_struct_literal: false,
+            no_dot: false,
             loop_depth: 0,
             fn_body_depth: 0,
             pending_holes: Vec::new(),
@@ -419,9 +431,29 @@ impl<'a> Parser<'a> {
         inner: impl FnOnce(&mut Self) -> PResult<T>,
     ) -> PResult<T> {
         let saved = self.no_struct_literal;
+        // The same bracketed sub-contexts that re-enable struct literals also
+        // re-enable the postfix `.` inside a quantifier `<dom>` (REQ-0): a
+        // parenthesised `(a.b)` or an index `xs[a.b]` reads its dots normally even
+        // when the enclosing domain suppresses the top-level body-separator `.`.
+        let saved_dot = self.no_dot;
         self.no_struct_literal = false;
+        self.no_dot = false;
         let result = inner(self);
         self.no_struct_literal = saved;
+        self.no_dot = saved_dot;
+        result
+    }
+
+    /// Run `inner` with the postfix `.` suppressed as a terminator — used only for
+    /// a quantifier's `<dom>`, so the `.` separating the domain from the body is
+    /// unambiguous (`.design/stage2-stratified-cage.md` REQ-0). Bracketed
+    /// sub-expressions inside the domain re-enable the postfix `.` via
+    /// `with_struct_literal`, so `(a.b)` / `xs[a.b]` domains still parse.
+    fn with_no_dot<T>(&mut self, inner: impl FnOnce(&mut Self) -> PResult<T>) -> PResult<T> {
+        let saved = self.no_dot;
+        self.no_dot = true;
+        let result = inner(self);
+        self.no_dot = saved;
         result
     }
 
@@ -2443,6 +2475,10 @@ impl<'a> Parser<'a> {
         let mut expr = self.parse_primary()?;
         loop {
             match self.peek() {
+                // A postfix `.` is suppressed (treated as a terminator) while
+                // parsing a quantifier's `<dom>` so the domain/body separator `.`
+                // is unambiguous (REQ-0). Brackets re-enable it (`with_struct_literal`).
+                TokKind::Dot if self.no_dot => break,
                 TokKind::Dot => {
                     self.bump();
                     // A numeric projection `e.0`/`e.1`/…
@@ -2548,6 +2584,57 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Parse a raw quantified formula `forall (x : S) in <dom>. φ` / `exists (x :
+    /// S) in <dom>. φ` (`.design/stage2-stratified-cage.md` REQ-0): the surface
+    /// binder production over a named sorted carrier the (R2) index grammar admits.
+    /// The keyword (`forall`/`exists`) is at the cursor.
+    ///
+    /// Grammar: `QUANT '(' IDENT ':' IDENT ')' 'in' <dom> '.' <expr>`. `in` is a
+    /// CONTEXTUAL identifier (mirroring the C10 `for … in` loop precedent,
+    /// `parse_for`), NOT a reserved keyword. The `<dom>` is parsed with the postfix
+    /// `.` suppressed (`with_no_dot`) so the `.` introducing the body is
+    /// unambiguous; the body is a full greedy `parse_expr` (lowest precedence). The
+    /// parser builds the node unconditionally — well-sortedness of `S`/`<dom>` and
+    /// fragment admission are the stratified classifier's job (REQ-4), not the
+    /// parser's (registry-free, parse-only, like the `forall_in` combinator path).
+    fn parse_quantifier(&mut self) -> PResult<Expr> {
+        let quant = match self.peek() {
+            TokKind::Forall => Quant::Forall,
+            TokKind::Exists => Quant::Exists,
+            // `parse_primary` only dispatches here on `Forall`/`Exists`.
+            _ => return Err(self.unexpected("`forall` or `exists`")),
+        };
+        self.bump(); // consume the quantifier keyword
+        self.consume(&TokKind::LParen, "`(` to open the quantifier binder")?;
+        let var = self.take_ident("a bound variable name")?;
+        self.consume(
+            &TokKind::Colon,
+            "`:` between the bound variable and its sort",
+        )?;
+        let sort = self.take_ident("a sort name")?;
+        self.consume(&TokKind::RParen, "`)` to close the quantifier binder")?;
+        // `in` — a contextual identifier (the for-loop precedent), not a keyword.
+        let in_kw = self.take_ident("`in` after the quantifier binder")?;
+        if in_kw != "in" {
+            return Err(self.unexpected("`in` after the quantifier binder"));
+        }
+        // The domain ranges to the body-separating `.`; suppress the postfix `.`
+        // so that separator is unambiguous (bracketed sub-exprs re-enable it).
+        let domain = self.with_no_dot(Self::parse_expr)?;
+        self.consume(
+            &TokKind::Dot,
+            "`.` separating the quantifier domain from its body",
+        )?;
+        let body = self.parse_expr()?;
+        Ok(Expr::Quantifier {
+            quant,
+            var,
+            sort,
+            domain: Box::new(domain),
+            body: Box::new(body),
+        })
+    }
+
     fn parse_primary(&mut self) -> PResult<Expr> {
         match self.peek().clone() {
             TokKind::Int { value, raw } => {
@@ -2575,6 +2662,11 @@ impl<'a> Parser<'a> {
             TokKind::Pipe | TokKind::OrOr => self.parse_closure(),
             TokKind::Match => self.parse_match(),
             TokKind::If => self.parse_if_expr(),
+            // A raw quantified formula `forall (x : S) in <dom>. φ` / `exists …`
+            // (`.design/stage2-stratified-cage.md` REQ-0). Recognized as a primary
+            // (like `if`/`match`) so a quantifier may appear in any operand position;
+            // its body extends greedily to the right (lowest precedence).
+            TokKind::Forall | TokKind::Exists => self.parse_quantifier(),
             TokKind::LParen => {
                 self.bump();
                 // A parenthesised group re-enables struct literals (REQ-2):
@@ -3155,6 +3247,8 @@ fn token_text(kind: &TokKind) -> &'static str {
         TokKind::Struct => "struct",
         TokKind::Enum => "enum",
         TokKind::Is => "is",
+        TokKind::Forall => "forall",
+        TokKind::Exists => "exists",
         TokKind::HashBracket => "#[",
         TokKind::Hash => "#",
         TokKind::Arrow => "->",

--- a/thermite-syntax/tests/quantifiers_parse.rs
+++ b/thermite-syntax/tests/quantifiers_parse.rs
@@ -1,0 +1,314 @@
+//! Tests for the Stage-2 raw quantifier binder productions `forall (x : S) in
+//! <dom>. φ` / `exists (x : S) in <dom>. φ` (`.design/stage2-stratified-cage.md`
+//! REQ-0, AC-0): the surface binder grammar over a named sorted carrier the (R2)
+//! index grammar admits, plus the binder/scope corner-case pins.
+//!
+//! REQ-0 is the FOUNDATION increment blocking REQ-1 (the Lean `Strat/Syntax`
+//! denote path) and REQ-4 (the Rust classifier). It is deliberately DISTINCT from
+//! the registry-free `forall_in`/`forall_below`/`forall_from`/`sorted` COMBINATOR
+//! calls, which stay ordinary `Expr::Call` nodes — the combinator registry is
+//! untouched (the registry-unchanged pins below assert exactly this). R-CHAR-3:
+//! shapes hand-derived from the grammar; `tests/` is ungated.
+
+use thermite_syntax::{parse, BinOp, Expr, ForgeItem, Item, Quant};
+
+/// Parse `src` cleanly and return the body tail `Expr` of the single `prop fn`
+/// (its `{ <expr> }` body is a bool-valued expression — a convenient quantifier
+/// carrier needing no contract scaffolding).
+fn prop_body(src: &str) -> Expr {
+    let result = parse(src);
+    assert!(
+        result.is_clean(),
+        "expected a clean parse of {src:?}, got: {:?}",
+        result.errors
+    );
+    match result.program.items.into_iter().next().unwrap() {
+        Item::Forge(ForgeItem::PropFn(p)) => {
+            *p.body.tail.expect("prop fn body has a tail expression")
+        }
+        other => panic!("expected a prop fn, got {other:?}"),
+    }
+}
+
+/// Parse `src` cleanly and return the `req` clause of the single `fn` (both its
+/// parsed `expr` and its verbatim `text`, for the round-trip assertion).
+fn fn_req(src: &str) -> (Expr, String) {
+    let result = parse(src);
+    assert!(
+        result.is_clean(),
+        "expected a clean parse of {src:?}, got: {:?}",
+        result.errors
+    );
+    match result.program.items.into_iter().next().unwrap() {
+        Item::Fn(f) => (f.contract.req.expr, f.contract.req.text),
+        other => panic!("expected a fn, got {other:?}"),
+    }
+}
+
+/// Wrap a contract expression `e` (bool-valued) as the `req` of a minimal exec
+/// `fn` (the `fn f(...) -> u64 req <e> ens result == 0 fx pure { 0 }` scaffold).
+fn fn_with_req(req: &str) -> String {
+    format!("fn f(xs: Vec<u64>) -> u64 req {req} ens result == 0 fx pure {{ 0 }}")
+}
+
+/// Wrap a bool expression `e` as the body of a minimal `prop fn`.
+fn prop_with_body(body: &str) -> String {
+    format!("prop fn p(xs: Vec<u64>) -> bool {{ {body} }}")
+}
+
+// ---- the AST node: forall / exists parse into Expr::Quantifier --------------
+
+#[test]
+fn forall_parses_into_the_quantifier_node() {
+    let e = prop_body(&prop_with_body("forall (i : Idx) in xs. xs[i] != needle"));
+    match e {
+        Expr::Quantifier {
+            quant,
+            var,
+            sort,
+            domain,
+            body,
+        } => {
+            assert_eq!(quant, Quant::Forall);
+            assert_eq!(var, "i");
+            assert_eq!(sort, "Idx");
+            // The domain is the bare carrier `xs`.
+            assert!(matches!(domain.as_ref(), Expr::Path(segs) if segs == &vec!["xs".to_string()]));
+            // The body is the comparison `xs[i] != needle`.
+            assert!(matches!(body.as_ref(), Expr::Binary { op: BinOp::Ne, .. }));
+        }
+        other => panic!("expected Expr::Quantifier, got {other:?}"),
+    }
+}
+
+#[test]
+fn exists_parses_into_the_quantifier_node() {
+    let e = prop_body(&prop_with_body("exists (j : Jdx) in ys. ys[j] == needle"));
+    match e {
+        Expr::Quantifier {
+            quant, var, sort, ..
+        } => {
+            assert_eq!(quant, Quant::Exists);
+            assert_eq!(var, "j");
+            assert_eq!(sort, "Jdx");
+        }
+        other => panic!("expected Expr::Quantifier, got {other:?}"),
+    }
+}
+
+// ---- round-trip: the verbatim clause text is preserved ----------------------
+
+#[test]
+fn quantifier_req_clause_preserves_verbatim_text() {
+    // The `req` clause captures the exact surface span of the quantifier — the
+    // round-trip oracle string `address.rs` resolves against (AC-0).
+    let src = fn_with_req("forall (i : Idx) in xs. xs[i] != 0");
+    let (expr, text) = fn_req(&src);
+    assert!(matches!(
+        expr,
+        Expr::Quantifier {
+            quant: Quant::Forall,
+            ..
+        }
+    ));
+    assert_eq!(text, "forall (i : Idx) in xs. xs[i] != 0");
+}
+
+// ---- binder/scope pins ------------------------------------------------------
+
+#[test]
+fn body_is_greedy_lowest_precedence() {
+    // `forall …. a && b` reads the WHOLE `a && b` as the body, not just `a`
+    // (the binder body extends greedily to the right).
+    let e = prop_body(&prop_with_body(
+        "forall (i : Idx) in xs. xs[i] != 0 && xs[i] != 1",
+    ));
+    match e {
+        Expr::Quantifier { body, .. } => assert!(
+            matches!(body.as_ref(), Expr::Binary { op: BinOp::And, .. }),
+            "the body should be the full `&&` conjunction, got {body:?}"
+        ),
+        other => panic!("expected Expr::Quantifier, got {other:?}"),
+    }
+}
+
+#[test]
+fn parentheses_bound_the_body() {
+    // `(forall …. a) && b` — the parens bound the quantifier body so the top node
+    // is the `&&`, whose LHS is the quantifier.
+    let e = prop_body(&prop_with_body(
+        "(forall (i : Idx) in xs. xs[i] != 0) && true",
+    ));
+    match e {
+        Expr::Binary {
+            op: BinOp::And,
+            lhs,
+            ..
+        } => assert!(
+            matches!(lhs.as_ref(), Expr::Quantifier { .. }),
+            "the `&&` LHS should be the bounded quantifier, got {lhs:?}"
+        ),
+        other => panic!("expected a top-level `&&`, got {other:?}"),
+    }
+}
+
+#[test]
+fn quantifier_is_an_operand_in_any_position() {
+    // A quantifier is a primary (like `if`/`match`), so it parses as the RHS of a
+    // binary operator too: `p || forall …. q`.
+    let e = prop_body(&prop_with_body(
+        "false || forall (i : Idx) in xs. xs[i] != 0",
+    ));
+    match e {
+        Expr::Binary {
+            op: BinOp::Or, rhs, ..
+        } => assert!(
+            matches!(
+                rhs.as_ref(),
+                Expr::Quantifier {
+                    quant: Quant::Forall,
+                    ..
+                }
+            ),
+            "the `||` RHS should be the quantifier, got {rhs:?}"
+        ),
+        other => panic!("expected a top-level `||`, got {other:?}"),
+    }
+}
+
+#[test]
+fn quantifiers_nest_in_the_body() {
+    // `forall …. exists …. φ` — the outer body is the inner quantifier.
+    let e = prop_body(&prop_with_body(
+        "forall (i : Idx) in xs. exists (j : Idx) in xs. xs[i] == xs[j]",
+    ));
+    match e {
+        Expr::Quantifier {
+            quant: Quant::Forall,
+            body,
+            ..
+        } => assert!(
+            matches!(
+                body.as_ref(),
+                Expr::Quantifier {
+                    quant: Quant::Exists,
+                    ..
+                }
+            ),
+            "the outer body should be the inner `exists`, got {body:?}"
+        ),
+        other => panic!("expected an outer `forall`, got {other:?}"),
+    }
+}
+
+#[test]
+fn domain_may_be_an_indexed_slice_before_the_dot_separator() {
+    // `in xs[..n].` — the domain is an index expression; the `.` AFTER the `]`
+    // (not a field access) separates the domain from the body. The `[..n]` slice
+    // uses `..` (DotDot), distinct from the body-separator `.` (Dot).
+    let e = prop_body(&prop_with_body("forall (i : Idx) in xs[..3]. xs[i] != 0"));
+    match e {
+        Expr::Quantifier { domain, body, .. } => {
+            assert!(
+                matches!(domain.as_ref(), Expr::Index { .. }),
+                "the domain should be the indexed slice, got {domain:?}"
+            );
+            assert!(matches!(body.as_ref(), Expr::Binary { op: BinOp::Ne, .. }));
+        }
+        other => panic!("expected Expr::Quantifier, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_parenthesized_domain_reenables_field_dots() {
+    // Inside a parenthesised domain the postfix `.` is RE-ENABLED, so `(a.b)` is a
+    // field access and the FIRST `.` after the `)` is the body separator.
+    let e = prop_body(&prop_with_body("forall (i : Idx) in (xs.foo). xs[i] != 0"));
+    match e {
+        Expr::Quantifier { domain, body, .. } => {
+            assert!(
+                matches!(domain.as_ref(), Expr::Field { name, .. } if name == "foo"),
+                "the parenthesised domain should be the field access `xs.foo`, got {domain:?}"
+            );
+            assert!(matches!(body.as_ref(), Expr::Binary { op: BinOp::Ne, .. }));
+        }
+        other => panic!("expected Expr::Quantifier, got {other:?}"),
+    }
+}
+
+// ---- registry-unchanged pins: the combinator idents stay Expr::Call ---------
+
+#[test]
+fn forall_in_combinator_stays_a_plain_call_not_a_binder() {
+    // `forall_in` is a DISTINCT identifier from the `forall` keyword (the lexer
+    // keys on the full word), so the registry-free combinator call is unchanged:
+    // it parses as an ordinary `Expr::Call`, NOT an `Expr::Quantifier`.
+    let e = prop_body(&prop_with_body("forall_in(xs, |x| x != 0)"));
+    match e {
+        Expr::Call { callee, args } => {
+            assert!(
+                matches!(callee.as_ref(), Expr::Path(segs) if segs == &vec!["forall_in".to_string()])
+            );
+            assert_eq!(args.len(), 2);
+        }
+        other => panic!("expected forall_in to stay an Expr::Call, got {other:?}"),
+    }
+}
+
+#[test]
+fn sorted_and_forall_below_combinators_are_unchanged() {
+    // `sorted` is still usable as a plain combinator/fn ident (it even names a
+    // `prop fn` elsewhere in the corpus), and `forall_below` stays a call.
+    assert!(matches!(
+        prop_body(&prop_with_body("sorted(xs)")),
+        Expr::Call { .. }
+    ));
+    assert!(matches!(
+        prop_body(&prop_with_body("forall_below(xs, 2, |x| x != 0)")),
+        Expr::Call { .. }
+    ));
+}
+
+// ---- error pins: malformed binders are structured errors, never panics ------
+
+#[test]
+fn missing_binder_parens_is_a_structured_error() {
+    // `forall i in xs. …` (no `( : )` binder) — a structured parse error, not a
+    // panic; the parser never panics (parser.md REQ-4).
+    let result = parse(&prop_with_body("forall i in xs. xs[i] != 0"));
+    assert!(
+        !result.is_clean(),
+        "a quantifier missing its `( x : S )` binder must not parse cleanly"
+    );
+}
+
+#[test]
+fn missing_sort_annotation_is_a_structured_error() {
+    // `forall (i) in xs. …` — the `: S` sort annotation is mandatory.
+    let result = parse(&prop_with_body("forall (i) in xs. xs[i] != 0"));
+    assert!(
+        !result.is_clean(),
+        "a binder missing its `: S` sort must not parse cleanly"
+    );
+}
+
+#[test]
+fn missing_in_keyword_is_a_structured_error() {
+    // `forall (i : Idx) xs. …` — the contextual `in` is mandatory.
+    let result = parse(&prop_with_body("forall (i : Idx) xs. xs[i] != 0"));
+    assert!(
+        !result.is_clean(),
+        "a binder missing `in` must not parse cleanly"
+    );
+}
+
+#[test]
+fn missing_body_separator_dot_is_a_structured_error() {
+    // `forall (i : Idx) in xs xs[i] != 0` — the `.` separating domain from body is
+    // mandatory (the domain `xs xs[i]` then has no separator).
+    let result = parse(&prop_with_body("forall (i : Idx) in xs xs[i] != 0"));
+    assert!(
+        !result.is_clean(),
+        "a quantifier missing the `.` body separator must not parse cleanly"
+    );
+}

--- a/thermite-tv/src/exec_encode.rs
+++ b/thermite-tv/src/exec_encode.rs
@@ -392,6 +392,10 @@ fn node_kind(e: &Expr) -> String {
         Expr::StrLit(_) => "string literal".to_string(),
         Expr::Tuple(_) => "tuple".to_string(),
         Expr::TupleProj { .. } => "tuple projection".to_string(),
+        // A raw quantifier `forall`/`exists` (`.design/stage2-stratified-cage.md`
+        // REQ-0) is a spec-only formula with no exec encoding; this descriptor keeps
+        // the exec node-kind report exhaustive.
+        Expr::Quantifier { .. } => "quantifier (spec-only)".to_string(),
     }
 }
 

--- a/thermite-tv/src/ref_encode.rs
+++ b/thermite-tv/src/ref_encode.rs
@@ -1037,5 +1037,9 @@ fn node_kind(e: &Expr) -> String {
         Expr::StrLit(_) => "string literal".to_string(),
         Expr::Tuple(_) => "tuple".to_string(),
         Expr::TupleProj { .. } => "tuple projection".to_string(),
+        // A raw quantified formula `forall`/`exists` (`.design/stage2-stratified-cage.md`
+        // REQ-0): the stratified reference encoder for raw binders is stage-2 (REQ-8);
+        // this descriptor exists so the node-kind report stays exhaustive.
+        Expr::Quantifier { .. } => "quantifier".to_string(),
     }
 }


### PR DESCRIPTION
## What

Stage-2 **REQ-0 (foundation increment)**: adds raw `forall (x : S) in <dom>. φ` / `exists …` binder productions to `thermite-syntax`, the new `Expr::Quantifier { quant, var, sort, domain, body }` AST node, and binder/scope parser pins. Over a named sorted carrier per the (R2) index grammar. Unblocks REQ-1 (#323) and (with REQ-3) REQ-4 (#326). Gate: G2.

Design: `.design/stage2-stratified-cage.md` REQ-0 / AC-0.

## Scope guards held

- **Combinator registry untouched** — `forall_in`/`sorted`/`forall_below` stay registry-free `Expr::Call` idents (tests `forall_in_combinator_stays_a_plain_call_not_a_binder`, `sorted_and_forall_below_combinators_are_unchanged`).
- **Emission honestly refused** — lowerers / `lean_export` reject the new node with `LowerError::Unsupported` pending REQ-5/REQ-8 (the raw-quantifier lowering increments). No silent degrade.

## Tests / gauntlet

- `thermite-syntax/tests/quantifiers_parse.rs` — 15 tests: parse-into-node, verbatim round-trip, greedy lowest-precedence body, parenthesised body/domain, nesting, indexed-slice domain, 4 malformed-binder error pins.
- 178/178 in the agent's local verify; my orchestrator re-verify: workspace builds; `thermite-syntax`/`-spec`/`-lower`/`-tv` tests green; `fmt --check` clean; `clippy -D warnings` clean (touched crates); **doc-drift 0-drift** (local + CI-style synthetic-merge); reqs registry clean (443).

## Doc-drift

The new `Expr::Quantifier` + net-additive honest-refusal match arms rippled 28 routed docs' governed-file aggregates; re-pinned in a separate `chore(doc-drift)` commit (22 content-sha256 + 6 commit pins), REQs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)