### PR TITLE
fix(doc-drift): re-pin 4 lower.rs docs after #74 squash (#339)

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 0abe5ce11c15f3d96d1c7211ad17858a9f1a1fd0 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
+audited-sha: 80c88ea12c0a7fdd9a4f662e6c0e6c20c32ba385 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 0abe5ce11c15f3d96d1c7211ad17858a9f1a1fd0 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
+audited-sha: 80c88ea12c0a7fdd9a4f662e6c0e6c20c32ba385 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 0abe5ce11c15f3d96d1c7211ad17858a9f1a1fd0 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
+audited-sha: 80c88ea12c0a7fdd9a4f662e6c0e6c20c32ba385 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 0abe5ce11c15f3d96d1c7211ad17858a9f1a1fd0 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
+audited-sha: 80c88ea12c0a7fdd9a4f662e6c0e6c20c32ba385 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9


### PR DESCRIPTION
Post-merge follow-up (the #322→#65 pattern). REQ-8 (#74) re-pinned 4 `lower.rs`-governed commit-pin docs to its branch tip; the squash made that a non-ancestor of main → `INVALID-PIN`. Re-pins them to the #74 squash commit `80c88ea1` (valid main ancestor). doc-drift 0-drift. 🤖 Generated with [Claude Code](https://claude.com/claude-code)