### PR TITLE
Stage-3 REQ-1: the @bv clause tag, parse-gated (#343)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,16 +19,6 @@
       {
         "hooks": [
           {
-            "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/tooling/spec-discipline.py\"; if [ -f \"$HOOK\" ]; then python3 \"$HOOK\"; else exit 0; fi",
-            "timeout": 5,
-            "type": "command"
-          }
-        ],
-        "matcher": "Read"
-      },
-      {
-        "hooks": [
-          {
             "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/.claude/hooks/heartbeat.py\"; if [ -f \"$HOOK\" ]; then python3 \"$HOOK\"; else exit 0; fi",
             "timeout": 3,
             "type": "command"
@@ -56,21 +46,6 @@
           }
         ],
         "matcher": "Write|Edit|Bash"
-      },
-      {
-        "hooks": [
-          {
-            "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/tooling/spec-discipline.py\"; if [ -f \"$HOOK\" ]; then python3 \"$HOOK\"; else exit 0; fi",
-            "timeout": 5,
-            "type": "command"
-          },
-          {
-            "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/tooling/anti-pattern-gate.py\"; if [ -f \"$HOOK\" ]; then python3 \"$HOOK\"; else exit 0; fi",
-            "timeout": 5,
-            "type": "command"
-          }
-        ],
-        "matcher": "Write|Edit"
       }
     ],
     "SessionStart": [

--- a/.crosslink/hook-config.json
+++ b/.crosslink/hook-config.json
@@ -1,7 +1,13 @@
 {
   "agent_overrides": {
-    "agent_lint_commands": [],
-    "agent_test_commands": [],
+    "agent_lint_commands": [
+      "cargo clippy -- -D warnings",
+      "cargo fmt --check",
+      "shellcheck **/*.sh"
+    ],
+    "agent_test_commands": [
+      "cargo test"
+    ],
     "blocked_git_commands": [
       "git push --force",
       "git push -f",
@@ -43,7 +49,7 @@
     "pwd",
     "echo"
   ],
-  "auto_steal_stale_locks": "3",
+  "auto_steal_stale_locks": false,
   "blocked_git_commands": [
     "git push",
     "git merge",
@@ -61,14 +67,14 @@
     "git branch -D",
     "git branch -m"
   ],
-  "comment_discipline": "required",
+  "comment_discipline": "encouraged",
   "cpitd_auto_install": true,
   "gated_git_commands": [
     "git commit"
   ],
   "intervention_tracking": true,
-  "kickoff_verification": "ci",
-  "reminder_drift_threshold": "0",
+  "kickoff_verification": "local",
+  "reminder_drift_threshold": 3,
   "sentinel": {
     "default_agent": {
       "model": "claude-sonnet-4-6",
@@ -95,11 +101,6 @@
       }
     }
   },
-  "sentinel.default_agent.verify": "local",
-  "sentinel.enabled": false,
-  "sentinel.escalation.enabled": false,
-  "sentinel.sources.github_labels.enabled": false,
-  "signing_enforcement": "enforced",
-  "tracker_remote": "origin",
+  "signing_enforcement": "audit",
   "tracking_mode": "strict"
 }

--- a/.design/basis/02-recursion-schemes.md
+++ b/.design/basis/02-recursion-schemes.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: cc1f43cb04b696799050ad299d24b8615fa1f71f6b78faf9e1b00d3bfac7cac7
+audited-content-sha256: 9465c40b9cb13c9d7d1df49e36d751bee6fd76d4e2e13980c2384d33101e02cf
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/04-collections.md
+++ b/.design/basis/04-collections.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 75910d228493cf244e3722c6a29ec127b44afed444db4b5e965a8666485abd56
+audited-content-sha256: 7b94ae19debe08195561fa5cfd7a64afa7214923f7a06fab7021d4f132ccc83a
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/07-strings.md
+++ b/.design/basis/07-strings.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 75910d228493cf244e3722c6a29ec127b44afed444db4b5e965a8666485abd56
+audited-content-sha256: 7b94ae19debe08195561fa5cfd7a64afa7214923f7a06fab7021d4f132ccc83a
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 80c88ea12c0a7fdd9a4f662e6c0e6c20c32ba385 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
+audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/10-recursion-tuples.md
+++ b/.design/basis/10-recursion-tuples.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 75910d228493cf244e3722c6a29ec127b44afed444db4b5e965a8666485abd56
+audited-content-sha256: 7b94ae19debe08195561fa5cfd7a64afa7214923f7a06fab7021d4f132ccc83a
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 80c88ea12c0a7fdd9a4f662e6c0e6c20c32ba385 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
+audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 80c88ea12c0a7fdd9a4f662e6c0e6c20c32ba385 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
+audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/basis/13-map.md
+++ b/.design/basis/13-map.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 75910d228493cf244e3722c6a29ec127b44afed444db4b5e965a8666485abd56
+audited-content-sha256: 7b94ae19debe08195561fa5cfd7a64afa7214923f7a06fab7021d4f132ccc83a
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 60fd029e65c83b38f81a7e03ad8911318455064b (re-pinned 2026-06-19 for #322 surface-quantifier foundation: governed source gains net-additive raw forall/exists handling — the new Expr::Quantifier AST node + honest-refusal match arms; the REQs this doc governs are unchanged.)
+audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/solver-vacuity.md
+++ b/.design/forge/solver-vacuity.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 90b8325951b0f625a693baf07776da39d0b95fbe (re-pinned 2026-06-17 after merging main into the #275 vacuity-fix branch: governed source carries #51's topology-stable doc-drift change + #275's ADT-deps/compile-error vacuity fix, both net-additive; the REQs this doc governs are unchanged.)
-audited-content-sha256: cae9b94b0095901e1cfb88a4f28f37c1ecf69e27beb3412cca0d435791ee5437
+audited-content-sha256: 3e29b4cdbc90c740be167ad1ee957ea5d30082d72248c9f49bf2f0345533e5d3
 governs: forge/src/vacuity_solver.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/strengthening-probes.md
+++ b/.design/forge/strengthening-probes.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 80074948185b77b95006d034e461a338b1ce6b37 (re-pinned 2026-06-16: forge quality status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (re-audited 2026-06-12: amended — shipped-status Summary + the #101 survivor-input and render_expr surface notes, #262))
-audited-content-sha256: e43ba3b93b48ae4d06376e5488d0cda196bc3fae6fef854f0c625d4834a68f82
+audited-content-sha256: 01965bb2b97997c7fd69220b232f122cb8d7d5fe9852434b20b9d615d96c28cc
 governs: forge/src/strengthen.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/forge/vacuity-triage.md
+++ b/.design/forge/vacuity-triage.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 84205383a3e59561217a6b48a4d302aaaa1b2382a9f12fe2db3fa6bb48840965
+audited-content-sha256: 3442b3f427149be52992f952e1b3904e7f3b22c55b8ae8ac44bb3803fb8d7ccc
 governs: forge/src/vacuity.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 80c88ea12c0a7fdd9a4f662e6c0e6c20c32ba385 (re-pinned 2026-06-21 for #330 REQ-8: thermite-lower/src/lower.rs gains net-additive stratified quantifier emission; the v1 behavior this doc governs is unchanged. NOTE: branch-tip pin — needs post-merge re-pin to the squash commit, per the #322->#65 pattern.)
+audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/lower/verus-lowering.md
+++ b/.design/lower/verus-lowering.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: f9c7a7ba56e13c3daa28bfa7d27999f574c00a45beb40cfc86bbb368de27fed6
+audited-content-sha256: 034fc6320217d90c3c87601028a31d4b1e667cca958bc58cd270fe7b7055514f
 governs: thermite-lower/src/lower.rs
 thesis-refs:
   - thermite-design.md §3

--- a/.design/scaffold/workspace.md
+++ b/.design/scaffold/workspace.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (content-sha256 re-pinned 2026-06-20 for stage-2 REQ-4 / AC-4 (#326), the classifier ops half: the changes to this doc's governed lib roots are additive — `pub mod classifier;` + the classifier re-exports in thermite-spec/src/lib.rs (the new Rust admission classifier), and `mod strat_tv;` in forge/src/main.rs (the differential battery module); the workspace/crate structure is otherwise unchanged. The legacy commit pin stays at the 5ae0816c stable-main ancestor; only the active content-sha256 digest moves. prior: 2026-06-17 umbrella REQ-7 / AC-12 §6 metrics dashboard `mod metrics;`; stage-1 REQ-10/AC-14 G1 gate seven-verdict test module)
-audited-content-sha256: cb569778f51b32ee34f37b61a49d5698367501f5dd9f2180ac33491e8883eb70
+audited-content-sha256: 32826b9803bd5a6a00c0f393f5a34cfb899d1021d057e7ffc06bedc8a60116d5
 governs:
   - Cargo.toml (virtual workspace manifest)
   - rust-toolchain.toml

--- a/.design/skill/skill-generator.md
+++ b/.design/skill/skill-generator.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 605114ce2e2cf1e914e43775c260fcea67de2c7e12a27bd1e6434fd09fd7a331
+audited-content-sha256: 98783d27edc5a9b84d188fe7188215d66d9909eeb3d16d7d306a1efa3a46187b
 governs: thermite-skill/src/generate.rs
 thesis-refs:
   - thermite-design.md §2.2

--- a/.design/syntax/ast.md
+++ b/.design/syntax/ast.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: fa389248b88a4f86e1c4bd9b0488a95f76a81066a807a8ba8af3bcd087375fc9
+audited-content-sha256: 78e6bebca26ae3a4927ff79402052404c79e78205bcfe314eb8b46bd3f69ab5c
 governs: thermite-syntax/src/ast.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/syntax/lexer.md
+++ b/.design/syntax/lexer.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 6b86f74476122cfddbdcf168d37a3561d2598054 (re-pinned 2026-06-16 for PR #46 after merging main: lex_string now rejects raw non-ASCII bytes with a structured SyntaxError while string contents remain Rust-String-backed; ASCII escapes and token classification are unchanged.)
-audited-content-sha256: ba559aaabe5239900afd87a688db2413e457a91eef2dca870dff01aa62f1e05c
+audited-content-sha256: 40c8543a12c29861e0e015b0e49e16dd85568429bbe72b9017536b2b81c4d2f9
 governs: thermite-syntax/src/lexer.rs
 thesis-refs:
   - thermite-design.md §4.3

--- a/.design/syntax/parser.md
+++ b/.design/syntax/parser.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: b292b94b723a9d01b110e7914b711d0ce3ba1976bea1938f104f8ff9a2cd818b
+audited-content-sha256: acd4523c740509217077bb6fbe3b9dcb7e52b57bfc7235069a9531c1efd25ecc
 governs: thermite-syntax/src/parser.rs
 thesis-refs:
   - thermite-design.md §4.1

--- a/.design/verified/exec-stmt-tv.md
+++ b/.design/verified/exec-stmt-tv.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: a7901ec46a5a6ac16b03e15d8f8594afc39f47c6e05dccd1146bee6362dfb4db
+audited-content-sha256: 53e9a27809ae6399cd68f9ec7956660ef4a78a21847170ee088d0a1caa72ecaa
 governs: thermite-tv/src/exec_stmt_encode.rs, thermite-tv/src/obligation.rs, thermite-lower/src/lower.rs, forge/src/body_tv.rs, forge/src/tv_signal.rs
 thesis-refs:
   - thermite-design.md §1 (trust relocated: code → spec → spec-intent)

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-sha: 60fd029e65c83b38f81a7e03ad8911318455064b (re-pinned 2026-06-19 for #322 surface-quantifier foundation: governed source gains net-additive raw forall/exists handling — the new Expr::Quantifier AST node + honest-refusal match arms; the REQs this doc governs are unchanged.)
+audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,18 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # Stage-3 REQ-1 / AC-1: the @bv tag's build-flag gate (the structural lock
+      # R-BV-1). The default `cargo nextest run --workspace` (in the `test` job)
+      # already exercises the NEGATIVE half — the tag is a parse error without the
+      # `bv_shadow` plumbing. Here we additionally (a) clippy and (b) test the
+      # POSITIVE half: with `--features bv_shadow`, all four widths + `nowrap`
+      # parse with the AST tag recovered. Both halves of AC-1 thus run in one CI
+      # run. (`.design/stage3-bv-reconstruction.md` REQ-1.)
+      - name: bv_shadow build-flag gate (stage-3 REQ-1 / AC-1)
+        run: |
+          cargo clippy -p thermite-syntax --all-targets --features bv_shadow -- -D warnings
+          cargo test -p thermite-syntax --features bv_shadow --test bv_tag_parse
+
       # nextest does not run doctests; run them here so coverage matches the
       # previous `cargo test --workspace`.
       - name: cargo test --doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,14 @@ jobs:
       # Stage-3 REQ-1 / AC-1: the @bv tag's build-flag gate (the structural lock
       # R-BV-1). The default `cargo nextest run --workspace` (in the `test` job)
       # already exercises the NEGATIVE half — the tag is a parse error without the
-      # `bv_shadow` plumbing. Here we additionally (a) clippy and (b) test the
-      # POSITIVE half: with `--features bv_shadow`, all four widths + `nowrap`
+      # `bv` plumbing. Here we additionally (a) clippy and (b) test the
+      # POSITIVE half: with `--features bv`, all four widths + `nowrap`
       # parse with the AST tag recovered. Both halves of AC-1 thus run in one CI
       # run. (`.design/stage3-bv-reconstruction.md` REQ-1.)
-      - name: bv_shadow build-flag gate (stage-3 REQ-1 / AC-1)
+      - name: bv build-flag gate (stage-3 REQ-1 / AC-1)
         run: |
-          cargo clippy -p thermite-syntax --all-targets --features bv_shadow -- -D warnings
-          cargo test -p thermite-syntax --features bv_shadow --test bv_tag_parse
+          cargo clippy -p thermite-syntax --all-targets --features bv -- -D warnings
+          cargo test -p thermite-syntax --features bv --test bv_tag_parse
 
       # nextest does not run doctests; run them here so coverage matches the
       # previous `cargo test --workspace`.

--- a/.kickoff-session
+++ b/.kickoff-session
@@ -1,0 +1,1 @@
+5i5F-0Ixw-stage-3-req-1-the-bv-tag-parse-gated-the-first-clause

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -1948,6 +1948,7 @@ fn synth_l3_lemma(
             expr: subst_ens,
             text: format!("{}::ens#{k} (result := body)", f.name),
             span,
+            bv: None,
         }],
         proof: ProofBlock {
             text: proof_text.to_string(),

--- a/forge/src/meaning.rs
+++ b/forge/src/meaning.rs
@@ -475,6 +475,7 @@ mod tests {
                     expr: thermite_syntax::Expr::BoolLit(true),
                     text: String::new(),
                     span: thermite_syntax::Span::new(0, 0),
+                    bv: None,
                 },
                 ens: Vec::new(),
                 fx: thermite_syntax::EffectRow::Pure,

--- a/forge/src/strengthen.rs
+++ b/forge/src/strengthen.rs
@@ -120,6 +120,7 @@ fn result_equals(rhs: Expr) -> Clause {
         },
         text: rendered,
         span: synth_span(),
+        bv: None,
     }
 }
 

--- a/forge/src/vacuity.rs
+++ b/forge/src/vacuity.rs
@@ -513,6 +513,7 @@ mod tests {
             expr: Expr::BoolLit(true),
             text: String::new(),
             span: dummy_span(),
+            bv: None,
         }
     }
 

--- a/forge/src/vacuity_solver.rs
+++ b/forge/src/vacuity_solver.rs
@@ -772,6 +772,7 @@ mod tests {
                     expr: thermite_syntax::Expr::BoolLit(true),
                     text: String::new(),
                     span: thermite_syntax::Span::new(0, 0),
+                    bv: None,
                 },
                 ens: Vec::new(),
                 fx: thermite_syntax::EffectRow::Pure,

--- a/thermite-lower/src/lower.rs
+++ b/thermite-lower/src/lower.rs
@@ -9839,11 +9839,13 @@ mod exec_body_tests {
                 expr: Expr::BoolLit(true),
                 text: "true".to_string(),
                 span: zero_span(),
+                bv: None,
             }],
             dec: Clause {
                 expr: int(0),
                 text: "0".to_string(),
                 span: zero_span(),
+                bv: None,
             },
             body: Block {
                 stmts: vec![],

--- a/thermite-lower/tests/divergence_effects.rs
+++ b/thermite-lower/tests/divergence_effects.rs
@@ -30,6 +30,7 @@ fn true_clause() -> Clause {
         expr: Expr::BoolLit(true),
         text: "true".to_string(),
         span: span(),
+        bv: None,
     }
 }
 

--- a/thermite-lower/tests/effects.rs
+++ b/thermite-lower/tests/effects.rs
@@ -29,6 +29,7 @@ fn true_clause() -> Clause {
         expr: Expr::BoolLit(true),
         text: "true".to_string(),
         span: span(),
+        bv: None,
     }
 }
 

--- a/thermite-skill/src/generate.rs
+++ b/thermite-skill/src/generate.rs
@@ -747,6 +747,7 @@ fn item_inventory() -> Vec<Item> {
         expr: Expr::BoolLit(true),
         text: String::new(),
         span,
+        bv: None,
     };
     let empty_block = || Block {
         stmts: Vec::new(),

--- a/thermite-spec/tests/combinators_conformance.rs
+++ b/thermite-spec/tests/combinators_conformance.rs
@@ -256,6 +256,7 @@ fn validate_never_panics_on_deep_nesting() {
         expr: e,
         text: String::new(),
         span,
+        bv: None,
     };
     let program = Program {
         items: vec![Item::Fn(FnItem {

--- a/thermite-syntax/Cargo.toml
+++ b/thermite-syntax/Cargo.toml
@@ -11,11 +11,11 @@ rust-version.workspace = true
 # The shadow-flag plumbing for the stage-3 `@bv` machine-semantics clause tag
 # (`.design/stage3-bv-reconstruction.md` REQ-1). NON-DEFAULT and the structural
 # lock (R-BV-1): the parser code path that accepts `ens@bvN` / `inv@bvN` /
-# `@bvN(nowrap)` is `#[cfg(feature = "bv_shadow")]`-gated, so a build without this
+# `@bvN(nowrap)` is `#[cfg(feature = "bv")]`-gated, so a build without this
 # feature *cannot* parse the tag — the tag is a structured parse error there
 # (AC-1's negative half). Gate G3 ships the locks behind this same flag; until
 # then the tag is opt-in and loud.
-bv_shadow = []
+bv = []
 
 # Test-only: the conformance tests read the hand-authored JSON oracle fixtures
 # under `conformance/`. Production code (`src/`) has no serde dependency.

--- a/thermite-syntax/Cargo.toml
+++ b/thermite-syntax/Cargo.toml
@@ -7,6 +7,16 @@ rust-version.workspace = true
 # Leaf crate (REQ-2): no intra-workspace dependencies.
 [dependencies]
 
+[features]
+# The shadow-flag plumbing for the stage-3 `@bv` machine-semantics clause tag
+# (`.design/stage3-bv-reconstruction.md` REQ-1). NON-DEFAULT and the structural
+# lock (R-BV-1): the parser code path that accepts `ens@bvN` / `inv@bvN` /
+# `@bvN(nowrap)` is `#[cfg(feature = "bv_shadow")]`-gated, so a build without this
+# feature *cannot* parse the tag — the tag is a structured parse error there
+# (AC-1's negative half). Gate G3 ships the locks behind this same flag; until
+# then the tag is opt-in and loud.
+bv_shadow = []
+
 # Test-only: the conformance tests read the hand-authored JSON oracle fixtures
 # under `conformance/`. Production code (`src/`) has no serde dependency.
 [dev-dependencies]

--- a/thermite-syntax/src/ast.rs
+++ b/thermite-syntax/src/ast.rs
@@ -627,7 +627,7 @@ impl BvWidth {
 /// REQ-1). It marks a clause for interpretation over fixed-width wraparound
 /// (`by(bit_vector)`, QF_BV) semantics. `nowrap` additionally requests the
 /// no-overflow side obligation (REQ-5). The tag parses ONLY when the shadow-flag
-/// plumbing is compiled in (the `bv_shadow` cargo feature, REQ-1's structural
+/// plumbing is compiled in (the `bv` cargo feature, REQ-1's structural
 /// lock R-BV-1); lowering + the three locks are REQ-2..REQ-5.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BvTag {
@@ -646,9 +646,9 @@ pub struct BvTag {
 ///
 /// `bv` carries an optional `@bvN` machine-semantics tag
 /// (`.design/stage3-bv-reconstruction.md` REQ-1). It is `None` for every v1/v2
-/// clause and for every clause when the `bv_shadow` plumbing is not compiled in
+/// clause and for every clause when the `bv` plumbing is not compiled in
 /// (the tag cannot parse there); `Some` only on an `ens`/`inv`/`req`/lemma clause
-/// that carried the tag in a `bv_shadow` build. The tag sits OUTSIDE `text`, so
+/// that carried the tag in a `bv` build. The tag sits OUTSIDE `text`, so
 /// the addressing oracle string is unchanged by it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Clause {

--- a/thermite-syntax/src/ast.rs
+++ b/thermite-syntax/src/ast.rs
@@ -589,14 +589,73 @@ pub struct Contract {
     pub fx: EffectRow,
 }
 
+/// The fixed bit-width of a `@bv` machine-semantics clause tag
+/// (`.design/stage3-bv-reconstruction.md` REQ-1). Exactly the four widths the
+/// RFC commits to (RFC-1 §4); any other `bvN` spelling is a parse error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BvWidth {
+    W8,
+    W16,
+    W32,
+    W64,
+}
+
+impl BvWidth {
+    /// The width in bits (`8`/`16`/`32`/`64`).
+    pub fn bits(self) -> u32 {
+        match self {
+            BvWidth::W8 => 8,
+            BvWidth::W16 => 16,
+            BvWidth::W32 => 32,
+            BvWidth::W64 => 64,
+        }
+    }
+
+    /// The canonical surface spelling (`bv8`/`bv16`/`bv32`/`bv64`).
+    pub fn spelling(self) -> &'static str {
+        match self {
+            BvWidth::W8 => "bv8",
+            BvWidth::W16 => "bv16",
+            BvWidth::W32 => "bv32",
+            BvWidth::W64 => "bv64",
+        }
+    }
+}
+
+/// A `@bvN` / `@bvN(nowrap)` machine-semantics clause tag — the first
+/// clause-level annotation in `thermite-syntax` (`.design/stage3-bv-reconstruction.md`
+/// REQ-1). It marks a clause for interpretation over fixed-width wraparound
+/// (`by(bit_vector)`, QF_BV) semantics. `nowrap` additionally requests the
+/// no-overflow side obligation (REQ-5). The tag parses ONLY when the shadow-flag
+/// plumbing is compiled in (the `bv_shadow` cargo feature, REQ-1's structural
+/// lock R-BV-1); lowering + the three locks are REQ-2..REQ-5.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BvTag {
+    pub width: BvWidth,
+    /// `true` for the `@bvN(nowrap)` spelling — a no-overflow side obligation is
+    /// requested (REQ-5). `false` for the bare `@bvN`.
+    pub nowrap: bool,
+    /// The source span of the whole tag, from `@` through the closing `)` (or the
+    /// width token when no `(nowrap)` follows).
+    pub span: Span,
+}
+
 /// A clause carrying its parsed expression AND the verbatim source text it was
 /// built from. The `text` is the oracle string `address.rs` resolves an
 /// `inv`/`dec` address to (semantic-addressing.md AC-1/AC-2).
+///
+/// `bv` carries an optional `@bvN` machine-semantics tag
+/// (`.design/stage3-bv-reconstruction.md` REQ-1). It is `None` for every v1/v2
+/// clause and for every clause when the `bv_shadow` plumbing is not compiled in
+/// (the tag cannot parse there); `Some` only on an `ens`/`inv`/`req`/lemma clause
+/// that carried the tag in a `bv_shadow` build. The tag sits OUTSIDE `text`, so
+/// the addressing oracle string is unchanged by it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Clause {
     pub expr: Expr,
     pub text: String,
     pub span: Span,
+    pub bv: Option<BvTag>,
 }
 
 /// An effect row (ast.md REQ-7; §4.1). The corpus uses only `pure`.

--- a/thermite-syntax/src/desugar.rs
+++ b/thermite-syntax/src/desugar.rs
@@ -65,6 +65,9 @@ pub fn desugar_refinements(program: &mut Program) {
 fn conjoin(a: Clause, b: Clause) -> Clause {
     let text = format!("({}) && ({})", a.text, b.text);
     let span = a.span.to(b.span);
+    // Preserve a `@bv` tag if either side carried one (a refinement predicate
+    // never does, so in practice this keeps the original clause's tag, REQ-1).
+    let bv = a.bv.or(b.bv);
     Clause {
         expr: Expr::Binary {
             op: BinOp::And,
@@ -73,5 +76,6 @@ fn conjoin(a: Clause, b: Clause) -> Clause {
         },
         text,
         span,
+        bv,
     }
 }

--- a/thermite-syntax/src/lexer.rs
+++ b/thermite-syntax/src/lexer.rs
@@ -186,6 +186,14 @@ pub enum TokKind {
     Amp,
     Pipe,
     Bang,
+    /// The clause-mode tag introducer `@` (`.design/stage3-bv-reconstruction.md`
+    /// REQ-1): the head of a clause-level annotation `ens@bvN` / `inv@bvN` /
+    /// `@bvN(nowrap)`. The lexer always produces this token; whether the parser
+    /// will *accept* it is the build-flag gate (the shadow-flag plumbing, REQ-1's
+    /// structural lock R-BV-1), enforced in the parser, not here. Before stage 3 a
+    /// `@` was a stray character; no valid pre-stage-3 program contains one, so
+    /// promoting it to a token is backward compatible.
+    At,
 
     /// A structural HOLE — either a body hole `?N` (`.design/forge/goal-repl.md`
     /// REQ-4, #193) or a PROOF hole `?pN` (`.design/stage1-forge-tier.md` REQ-3,
@@ -350,7 +358,7 @@ pub fn tokenize(src: &str) -> (Vec<Token>, Vec<SyntaxError>) {
             });
             i += len;
         } else {
-            // Unrecognized character (e.g. a stray `@`): diagnostic, continue.
+            // Unrecognized character (e.g. a stray `~`): diagnostic, continue.
             let ch_len = utf8_char_len(c);
             errors.push(SyntaxError::stray_char(
                 src[i..(i + ch_len).min(n)].to_string(),
@@ -886,6 +894,7 @@ fn lex_punct(bytes: &[u8], i: usize) -> Option<(TokKind, usize)> {
         b'&' => TokKind::Amp,
         b'|' => TokKind::Pipe,
         b'!' => TokKind::Bang,
+        b'@' => TokKind::At, // clause-mode tag introducer (stage-3 REQ-1)
         _ => return None,
     };
     Some((one, 1))

--- a/thermite-syntax/src/lib.rs
+++ b/thermite-syntax/src/lib.rs
@@ -46,11 +46,12 @@ pub mod parser;
 
 pub use address::{addresses_of, resolve, AddrKind, AddressEntry, AddressError};
 pub use ast::{
-    BinOp, Block, BoundaryAttr, Clause, ClauseSelector, Contract, Effect, EffectRow, EnumItem,
-    Expr, Falsify, FieldDef, FnItem, ForgeItem, Hole, HoleContext, IndexArg, Inhabit, Item,
-    LemmaItem, LoopKind, LoopNode, MatchArm, Param, Pattern, PrimType, Program, ProofBlock,
-    ProofItem, ProofObligation, PropFnItem, Quant, Refinement, RefinementTarget, SlagAttr,
-    SlicePat, SpecFnItem, Stmt, StructItem, Type, UnaryOp, VariantDef, VariantShape, WitnessBlock,
+    BinOp, Block, BoundaryAttr, BvTag, BvWidth, Clause, ClauseSelector, Contract, Effect,
+    EffectRow, EnumItem, Expr, Falsify, FieldDef, FnItem, ForgeItem, Hole, HoleContext, IndexArg,
+    Inhabit, Item, LemmaItem, LoopKind, LoopNode, MatchArm, Param, Pattern, PrimType, Program,
+    ProofBlock, ProofItem, ProofObligation, PropFnItem, Quant, Refinement, RefinementTarget,
+    SlagAttr, SlicePat, SpecFnItem, Stmt, StructItem, Type, UnaryOp, VariantDef, VariantShape,
+    WitnessBlock,
 };
 pub use lexer::{tokenize, Span, TokKind, Token};
 pub use parser::{parse, ParseResult, SyntaxError};

--- a/thermite-syntax/src/parser.rs
+++ b/thermite-syntax/src/parser.rs
@@ -162,14 +162,14 @@ pub enum SyntaxError {
     /// shadow-flag plumbing compiled in (`.design/stage3-bv-reconstruction.md`
     /// REQ-1, AC-1). This is the structural lock (R-BV-1): the feature cannot
     /// exist without its visibility machinery, so a build that lacks the
-    /// `bv_shadow` cargo feature treats the tag as a parse error rather than
+    /// `bv` cargo feature treats the tag as a parse error rather than
     /// silently accepting (and then under-tracking) wraparound semantics. The span
     /// points at the `@`.
     BvTagWithoutShadowPlumbing { span: Span },
     /// A `@bv` tag whose width is not one of the four committed widths
     /// `bv8`/`bv16`/`bv32`/`bv64` (`.design/stage3-bv-reconstruction.md` REQ-1).
     /// `found` is the verbatim token that followed `@` (e.g. `bv7`, `bv`, `foo`).
-    /// Only reachable in a `bv_shadow` build (else `BvTagWithoutShadowPlumbing`
+    /// Only reachable in a `bv` build (else `BvTagWithoutShadowPlumbing`
     /// fires first).
     BvWidthInvalid { found: String, span: Span },
 }
@@ -298,7 +298,7 @@ impl std::fmt::Display for SyntaxError {
                 f,
                 "the `@bv` machine-semantics clause tag at byte {} requires the \
                  shadow-flag plumbing, which is not compiled into this build (build \
-                 `thermite-syntax` with the `bv_shadow` feature to enable it)",
+                 `thermite-syntax` with the `bv` feature to enable it)",
                 span.start
             ),
             SyntaxError::BvWidthInvalid { found, span } => write!(
@@ -1495,7 +1495,7 @@ impl<'a> Parser<'a> {
     /// (`.design/stage3-bv-reconstruction.md` REQ-1), the first clause-level
     /// annotation in `thermite-syntax`. Returns `Ok(None)` when no `@` follows the
     /// clause keyword (every v1/v2 clause). When a `@` IS present, the tag parses
-    /// only if the shadow-flag plumbing is compiled in (the `bv_shadow` cargo
+    /// only if the shadow-flag plumbing is compiled in (the `bv` cargo
     /// feature) — this is the build-flag gate, REQ-1's structural lock R-BV-1:
     ///
     /// - WITHOUT the feature, the `@`-handling code path below is `#[cfg]`-removed,
@@ -1515,12 +1515,12 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
         let at_span = self.peek_span();
-        #[cfg(not(feature = "bv_shadow"))]
+        #[cfg(not(feature = "bv"))]
         {
             // The shadow-flag plumbing is absent: the tag cannot parse (R-BV-1).
             Err(SyntaxError::BvTagWithoutShadowPlumbing { span: at_span })
         }
-        #[cfg(feature = "bv_shadow")]
+        #[cfg(feature = "bv")]
         {
             self.bump(); // consume `@`
             let width = self.parse_bv_width()?;
@@ -1551,8 +1551,8 @@ impl<'a> Parser<'a> {
     /// Parse the `bvN` width token of a `@bv` tag (`.design/stage3-bv-reconstruction.md`
     /// REQ-1). The `bvN` spelling lexes as a single identifier (`bv64`), so this
     /// matches the whole ident against the four committed widths; anything else is
-    /// `BvWidthInvalid`. Only compiled in a `bv_shadow` build.
-    #[cfg(feature = "bv_shadow")]
+    /// `BvWidthInvalid`. Only compiled in a `bv` build.
+    #[cfg(feature = "bv")]
     fn parse_bv_width(&mut self) -> PResult<BvWidth> {
         let span = self.peek_span();
         let ident = match self.peek().clone() {

--- a/thermite-syntax/src/parser.rs
+++ b/thermite-syntax/src/parser.rs
@@ -158,6 +158,20 @@ pub enum SyntaxError {
     /// holes `?pN`; a body hole `?N` there is the mirror error of
     /// `ProofHoleOutsideProofBlock` (`number` is the verbatim hole number written).
     BodyHoleInProofBlock { number: u32, span: Span },
+    /// A `@bv` machine-semantics clause tag appeared in a build WITHOUT the
+    /// shadow-flag plumbing compiled in (`.design/stage3-bv-reconstruction.md`
+    /// REQ-1, AC-1). This is the structural lock (R-BV-1): the feature cannot
+    /// exist without its visibility machinery, so a build that lacks the
+    /// `bv_shadow` cargo feature treats the tag as a parse error rather than
+    /// silently accepting (and then under-tracking) wraparound semantics. The span
+    /// points at the `@`.
+    BvTagWithoutShadowPlumbing { span: Span },
+    /// A `@bv` tag whose width is not one of the four committed widths
+    /// `bv8`/`bv16`/`bv32`/`bv64` (`.design/stage3-bv-reconstruction.md` REQ-1).
+    /// `found` is the verbatim token that followed `@` (e.g. `bv7`, `bv`, `foo`).
+    /// Only reachable in a `bv_shadow` build (else `BvTagWithoutShadowPlumbing`
+    /// fires first).
+    BvWidthInvalid { found: String, span: Span },
 }
 
 /// The maximum recursive-descent nesting depth the parser will follow before
@@ -210,7 +224,9 @@ impl SyntaxError {
             | SyntaxError::BreakContinueOutsideLoop { span, .. }
             | SyntaxError::HoleOutsideFnBody { span, .. }
             | SyntaxError::ProofHoleOutsideProofBlock { span, .. }
-            | SyntaxError::BodyHoleInProofBlock { span, .. } => *span,
+            | SyntaxError::BodyHoleInProofBlock { span, .. }
+            | SyntaxError::BvTagWithoutShadowPlumbing { span }
+            | SyntaxError::BvWidthInvalid { span, .. } => *span,
         }
     }
 }
@@ -276,6 +292,19 @@ impl std::fmt::Display for SyntaxError {
                 f,
                 "body hole `?{number}` inside a proof block at byte {} (a proof block \
                  admits only proof holes `?pN`)",
+                span.start
+            ),
+            SyntaxError::BvTagWithoutShadowPlumbing { span } => write!(
+                f,
+                "the `@bv` machine-semantics clause tag at byte {} requires the \
+                 shadow-flag plumbing, which is not compiled into this build (build \
+                 `thermite-syntax` with the `bv_shadow` feature to enable it)",
+                span.start
+            ),
+            SyntaxError::BvWidthInvalid { found, span } => write!(
+                f,
+                "`@{found}` at byte {} is not a valid `@bv` width (expected one of \
+                 `bv8`/`bv16`/`bv32`/`bv64`)",
                 span.start
             ),
         }
@@ -1368,7 +1397,14 @@ impl<'a> Parser<'a> {
         self.consume(&TokKind::RBrace, "`}` to close the refinement predicate")?;
         let span = start.to(end);
         let text = self.span_text(span);
-        Ok(Clause { expr, text, span })
+        // A refinement-sugar predicate carries no `@bv` tag (REQ-1's tag attaches
+        // to `ens`/`inv`/`req`/lemma clauses through `parse_clause`).
+        Ok(Clause {
+            expr,
+            text,
+            span,
+            bv: None,
+        })
     }
 
     /// Parse the mandatory contract `req` then `ens`+ then `fx`, in that exact
@@ -1432,6 +1468,10 @@ impl<'a> Parser<'a> {
     /// the expression for addressing (`Clause.text`).
     fn parse_clause(&mut self, keyword: &TokKind) -> PResult<Clause> {
         self.consume(keyword, "a clause keyword")?;
+        // An optional `@bvN` machine-semantics tag sits between the keyword and the
+        // clause expression (`ens@bv64 P`). It is parsed BEFORE `start` so the
+        // clause `text` (the addressing oracle string) stays the expression only.
+        let bv = self.parse_bv_tag()?;
         let start = self.peek_span();
         // A clause expression is a no-struct-literal head: a clause is followed
         // by another clause keyword or a block `{` (a loop body, a spec-fn body),
@@ -1443,7 +1483,96 @@ impl<'a> Parser<'a> {
         let end = self.prev_span();
         let span = start.to(end);
         let text = self.span_text(span);
-        Ok(Clause { expr, text, span })
+        Ok(Clause {
+            expr,
+            text,
+            span,
+            bv,
+        })
+    }
+
+    /// Parse an optional `@bvN` / `@bvN(nowrap)` machine-semantics clause tag
+    /// (`.design/stage3-bv-reconstruction.md` REQ-1), the first clause-level
+    /// annotation in `thermite-syntax`. Returns `Ok(None)` when no `@` follows the
+    /// clause keyword (every v1/v2 clause). When a `@` IS present, the tag parses
+    /// only if the shadow-flag plumbing is compiled in (the `bv_shadow` cargo
+    /// feature) — this is the build-flag gate, REQ-1's structural lock R-BV-1:
+    ///
+    /// - WITHOUT the feature, the `@`-handling code path below is `#[cfg]`-removed,
+    ///   so the tag is a structured parse error (`BvTagWithoutShadowPlumbing`) and
+    ///   the feature genuinely cannot exist in the build (AC-1's negative half).
+    /// - WITH the feature, `@bvN` for N ∈ {8, 16, 32, 64} parses, plus the optional
+    ///   `(nowrap)` modifier (`@bvN(nowrap)`, REQ-5's surface). A bad width
+    ///   (`@bv7`, `@bv`) is `BvWidthInvalid`; a malformed modifier is the generic
+    ///   unexpected-token error.
+    ///
+    /// The tag is accepted on every clause that flows through `parse_clause`
+    /// (`ens`/`inv`/`req` and the lemma's `req`/`ens`), so `lemma` items accept it
+    /// under the same gate (REQ-1). `dec`/`fx` use their own parsers and carry no
+    /// tag.
+    fn parse_bv_tag(&mut self) -> PResult<Option<BvTag>> {
+        if !self.check(&TokKind::At) {
+            return Ok(None);
+        }
+        let at_span = self.peek_span();
+        #[cfg(not(feature = "bv_shadow"))]
+        {
+            // The shadow-flag plumbing is absent: the tag cannot parse (R-BV-1).
+            Err(SyntaxError::BvTagWithoutShadowPlumbing { span: at_span })
+        }
+        #[cfg(feature = "bv_shadow")]
+        {
+            self.bump(); // consume `@`
+            let width = self.parse_bv_width()?;
+            // An optional `(nowrap)` modifier (REQ-5's surface form).
+            let mut nowrap = false;
+            let mut end = self.prev_span();
+            if self.eat(&TokKind::LParen) {
+                let marker = self.take_ident("`nowrap`")?;
+                if marker != "nowrap" {
+                    return Err(SyntaxError::Unexpected {
+                        expected: "`nowrap`".to_string(),
+                        found: format!("identifier `{marker}`"),
+                        span: self.prev_span(),
+                    });
+                }
+                self.consume(&TokKind::RParen, "`)` to close `(nowrap)`")?;
+                nowrap = true;
+                end = self.prev_span();
+            }
+            Ok(Some(BvTag {
+                width,
+                nowrap,
+                span: at_span.to(end),
+            }))
+        }
+    }
+
+    /// Parse the `bvN` width token of a `@bv` tag (`.design/stage3-bv-reconstruction.md`
+    /// REQ-1). The `bvN` spelling lexes as a single identifier (`bv64`), so this
+    /// matches the whole ident against the four committed widths; anything else is
+    /// `BvWidthInvalid`. Only compiled in a `bv_shadow` build.
+    #[cfg(feature = "bv_shadow")]
+    fn parse_bv_width(&mut self) -> PResult<BvWidth> {
+        let span = self.peek_span();
+        let ident = match self.peek().clone() {
+            TokKind::Ident(w) => w,
+            other => {
+                return Err(SyntaxError::BvWidthInvalid {
+                    found: token_text(&other).to_string(),
+                    span,
+                });
+            }
+        };
+        let width = match ident.as_str() {
+            "bv8" => BvWidth::W8,
+            "bv16" => BvWidth::W16,
+            "bv32" => BvWidth::W32,
+            "bv64" => BvWidth::W64,
+            _ => return Err(SyntaxError::BvWidthInvalid { found: ident, span }),
+        };
+        self.bump(); // consume the width ident
+        Ok(width)
     }
 
     /// Parse a `dec <measure>` clause, supporting the forge-tier measure forms
@@ -1476,7 +1605,12 @@ impl<'a> Parser<'a> {
                 callee: Box::new(Expr::Path(vec!["wf".to_string()])),
                 args: vec![rel],
             };
-            return Ok(Clause { expr, text, span });
+            return Ok(Clause {
+                expr,
+                text,
+                span,
+                bv: None,
+            });
         }
         // `dec <expr>` (incl. `dec lex(...)` as an ordinary call) — the same
         // no-struct-literal head as `parse_clause` (a trailing `{` is the body).
@@ -1484,7 +1618,13 @@ impl<'a> Parser<'a> {
         let end = self.prev_span();
         let span = start.to(end);
         let text = self.span_text(span);
-        Ok(Clause { expr, text, span })
+        // A `dec` measure carries no `@bv` tag.
+        Ok(Clause {
+            expr,
+            text,
+            span,
+            bv: None,
+        })
     }
 
     /// True if the token `n` ahead of the cursor can begin an expression — used to
@@ -1870,6 +2010,7 @@ impl<'a> Parser<'a> {
             expr: dec_expr,
             text: "hi - i".to_string(),
             span: start,
+            bv: None,
         };
         // The loop condition `i < hi`.
         let cond = Expr::Binary {
@@ -3285,6 +3426,7 @@ fn token_text(kind: &TokKind) -> &'static str {
         TokKind::Amp => "&",
         TokKind::Pipe => "|",
         TokKind::Bang => "!",
+        TokKind::At => "@",
         TokKind::Ident(_)
         | TokKind::Int { .. }
         | TokKind::Bool(_)

--- a/thermite-syntax/tests/bv_tag_parse.rs
+++ b/thermite-syntax/tests/bv_tag_parse.rs
@@ -1,0 +1,252 @@
+//! Tests for the Stage-3 `@bv` machine-semantics clause tag
+//! (`.design/stage3-bv-reconstruction.md` REQ-1, AC-1): the first clause-level
+//! annotation in `thermite-syntax`, parse-gated behind the shadow-flag plumbing.
+//!
+//! The tag (`ens@bvN` / `inv@bvN` / `@bvN(nowrap)`, N ∈ {8, 16, 32, 64}) parses
+//! ONLY when the crate is built with the `bv_shadow` cargo feature — the
+//! structural lock R-BV-1: a build without the plumbing genuinely cannot parse
+//! the tag (the parser code path is `#[cfg]`-removed), so the tag is a structured
+//! syntax error there. This file pins BOTH halves of AC-1, each behind the
+//! matching `cfg`:
+//!
+//! - `#[cfg(not(feature = "bv_shadow"))]` — the negative half: `ens@bv64` fails to
+//!   parse with `SyntaxError::BvTagWithoutShadowPlumbing`.
+//! - `#[cfg(feature = "bv_shadow")]` — the positive half: all four widths +
+//!   `nowrap` parse with the AST tag recovered and the clause `text` round-trips
+//!   (the tag sits outside the addressing oracle string).
+//!
+//! CI runs `cargo test -p thermite-syntax` (negative half) AND
+//! `cargo test -p thermite-syntax --features bv_shadow` (positive half) so both
+//! configurations are exercised in one run (AC-1's "build-flag test in CI").
+//! R-CHAR-3: shapes hand-derived from the grammar; `tests/` is ungated.
+
+use thermite_syntax::{parse, SyntaxError};
+
+// ===========================================================================
+// Negative half (AC-1): without the shadow-flag plumbing, the tag is a parse
+// error — the feature cannot exist in the build.
+// ===========================================================================
+
+#[cfg(not(feature = "bv_shadow"))]
+mod plumbing_absent {
+    use super::*;
+
+    /// `ens@bv64` in a build WITHOUT `bv_shadow` is a structured syntax error
+    /// pointing at the `@` (the structural lock R-BV-1 / AC-1 negative half).
+    #[test]
+    fn ens_bv_tag_is_a_parse_error_without_plumbing() {
+        let src = "fn f(a: u64) -> u64 req true ens@bv64 result == 0 fx pure { 0 }";
+        let result = parse(src);
+        assert!(
+            !result.is_clean(),
+            "the `@bv` tag must NOT parse without the shadow-flag plumbing"
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, SyntaxError::BvTagWithoutShadowPlumbing { .. })),
+            "expected a BvTagWithoutShadowPlumbing error, got: {:?}",
+            result.errors
+        );
+    }
+
+    /// The same gate applies to a `@bvN(nowrap)` spelling and to an `inv` clause —
+    /// nothing carrying the tag parses without the plumbing.
+    #[test]
+    fn nowrap_and_inv_tags_are_parse_errors_without_plumbing() {
+        for src in [
+            "fn f(a: u64) -> u64 req true ens@bv64(nowrap) result == 0 fx pure { 0 }",
+            "struct S { x: u64 } inv@bv32 x == x",
+        ] {
+            let result = parse(src);
+            assert!(
+                result
+                    .errors
+                    .iter()
+                    .any(|e| matches!(e, SyntaxError::BvTagWithoutShadowPlumbing { .. })),
+                "expected BvTagWithoutShadowPlumbing for {src:?}, got: {:?}",
+                result.errors
+            );
+        }
+    }
+
+    /// The error message names the `bv_shadow` feature so the gate is discoverable.
+    #[test]
+    fn the_error_message_points_at_the_feature() {
+        let src = "fn f(a: u64) -> u64 req true ens@bv64 result == 0 fx pure { 0 }";
+        let err = parse(src)
+            .errors
+            .into_iter()
+            .find(|e| matches!(e, SyntaxError::BvTagWithoutShadowPlumbing { .. }))
+            .expect("a BvTagWithoutShadowPlumbing error");
+        assert!(
+            err.to_string().contains("bv_shadow"),
+            "the diagnostic should name the `bv_shadow` feature: {err}"
+        );
+    }
+}
+
+// ===========================================================================
+// Positive half (AC-1): with the shadow-flag plumbing, all four widths +
+// `nowrap` parse, the AST tag is recovered, and the clause text round-trips.
+// ===========================================================================
+
+#[cfg(feature = "bv_shadow")]
+mod plumbing_present {
+    use super::*;
+    use thermite_syntax::{BvWidth, Clause, ForgeItem, Item};
+
+    /// Parse `src` cleanly and return the single `fn`'s `ens` clauses.
+    fn fn_ens(src: &str) -> Vec<Clause> {
+        let result = parse(src);
+        assert!(
+            result.is_clean(),
+            "expected a clean parse of {src:?}, got: {:?}",
+            result.errors
+        );
+        match result.program.items.into_iter().next().unwrap() {
+            Item::Fn(f) => f.contract.ens,
+            other => panic!("expected a fn, got {other:?}"),
+        }
+    }
+
+    /// Scaffold a minimal exec `fn` whose single `ens` clause is `<ens> result == 0`.
+    fn fn_with_ens(ens: &str) -> String {
+        format!("fn f(a: u64) -> u64 req true ens{ens} result == 0 fx pure {{ 0 }}")
+    }
+
+    #[test]
+    fn all_four_widths_parse() {
+        for (tag, width, bits) in [
+            ("@bv8", BvWidth::W8, 8),
+            ("@bv16", BvWidth::W16, 16),
+            ("@bv32", BvWidth::W32, 32),
+            ("@bv64", BvWidth::W64, 64),
+        ] {
+            let ens = fn_ens(&fn_with_ens(tag));
+            let bv = ens[0].bv.expect("the tagged ens clause carries a BvTag");
+            assert_eq!(bv.width, width, "width for {tag}");
+            assert_eq!(bv.width.bits(), bits, "bits for {tag}");
+            assert!(!bv.nowrap, "a bare {tag} is not nowrap");
+        }
+    }
+
+    #[test]
+    fn nowrap_modifier_parses() {
+        let ens = fn_ens(&fn_with_ens("@bv64(nowrap)"));
+        let bv = ens[0].bv.expect("a BvTag");
+        assert_eq!(bv.width, BvWidth::W64);
+        assert!(bv.nowrap, "`@bv64(nowrap)` sets nowrap");
+    }
+
+    #[test]
+    fn the_tag_sits_outside_the_clause_text_round_trip() {
+        // The clause `text` is the addressing oracle string (semantic-addressing
+        // AC-1): the `@bv64` tag must NOT bleed into it — only the expression.
+        let ens = fn_ens(&fn_with_ens("@bv64"));
+        assert_eq!(ens[0].text, "result == 0");
+        assert!(ens[0].bv.is_some());
+    }
+
+    #[test]
+    fn tagged_and_untagged_clauses_coexist_on_one_item() {
+        // The RFC mix64 shape: wraparound and unbounded clauses side by side, each
+        // labeled. Here a `@bv64` ens next to an untagged ens.
+        let src = "fn f(a: u64) -> u64 req true \
+                   ens@bv64 result == 0 \
+                   ens result == a \
+                   fx pure { 0 }";
+        let ens = fn_ens(src);
+        assert_eq!(ens.len(), 2);
+        assert_eq!(ens[0].bv.expect("first ens is tagged").width, BvWidth::W64);
+        assert!(ens[1].bv.is_none(), "second ens is untagged");
+    }
+
+    #[test]
+    fn inv_clause_accepts_the_tag() {
+        // A struct type-invariant `inv@bvN` parses under the same gate.
+        let result = parse("struct S { x: u64 } inv@bv32 x == x");
+        assert!(
+            result.is_clean(),
+            "expected a clean parse, got: {:?}",
+            result.errors
+        );
+        match result.program.items.into_iter().next().unwrap() {
+            Item::Struct(s) => {
+                let inv = s.inv.expect("the struct has an inv clause");
+                assert_eq!(inv.bv.expect("the inv is tagged").width, BvWidth::W32);
+                assert_eq!(inv.text, "x == x");
+            }
+            other => panic!("expected a struct, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lemma_items_accept_the_tag() {
+        // REQ-1: `lemma` items accept the tag under the same gate (its `ens`
+        // conclusion flows through the shared `parse_clause` seam).
+        let result = parse("lemma l(a: u64) req true ens@bv64 a == a proof { omega }");
+        assert!(
+            result.is_clean(),
+            "expected a clean parse, got: {:?}",
+            result.errors
+        );
+        match result.program.items.into_iter().next().unwrap() {
+            Item::Forge(ForgeItem::Lemma(l)) => {
+                assert_eq!(
+                    l.ens[0].bv.expect("the lemma ens is tagged").width,
+                    BvWidth::W64
+                );
+            }
+            other => panic!("expected a lemma, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_invalid_width_is_a_structured_error() {
+        // `@bv7` is not one of the four committed widths -> BvWidthInvalid.
+        let result = parse(&fn_with_ens("@bv7"));
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, SyntaxError::BvWidthInvalid { found, .. } if found == "bv7")),
+            "expected BvWidthInvalid(bv7), got: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn a_bare_at_with_no_width_is_a_structured_error() {
+        // `@` with no `bvN` following -> BvWidthInvalid (the width token is absent).
+        let result = parse("fn f(a: u64) -> u64 req true ens@ result == 0 fx pure { 0 }");
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, SyntaxError::BvWidthInvalid { .. })),
+            "expected BvWidthInvalid for a bare `@`, got: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn a_malformed_nowrap_modifier_is_a_structured_error() {
+        // `@bv64(foo)` -> the generic unexpected-token error for the `nowrap` slot.
+        let result = parse(&fn_with_ens("@bv64(foo)"));
+        assert!(
+            !result.is_clean(),
+            "`@bv64(foo)` must not parse cleanly: {:?}",
+            result.errors
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, SyntaxError::Unexpected { .. })),
+            "expected an Unexpected error for `(foo)`, got: {:?}",
+            result.errors
+        );
+    }
+}

--- a/thermite-syntax/tests/bv_tag_parse.rs
+++ b/thermite-syntax/tests/bv_tag_parse.rs
@@ -3,20 +3,20 @@
 //! annotation in `thermite-syntax`, parse-gated behind the shadow-flag plumbing.
 //!
 //! The tag (`ens@bvN` / `inv@bvN` / `@bvN(nowrap)`, N ∈ {8, 16, 32, 64}) parses
-//! ONLY when the crate is built with the `bv_shadow` cargo feature — the
+//! ONLY when the crate is built with the `bv` cargo feature — the
 //! structural lock R-BV-1: a build without the plumbing genuinely cannot parse
 //! the tag (the parser code path is `#[cfg]`-removed), so the tag is a structured
 //! syntax error there. This file pins BOTH halves of AC-1, each behind the
 //! matching `cfg`:
 //!
-//! - `#[cfg(not(feature = "bv_shadow"))]` — the negative half: `ens@bv64` fails to
+//! - `#[cfg(not(feature = "bv"))]` — the negative half: `ens@bv64` fails to
 //!   parse with `SyntaxError::BvTagWithoutShadowPlumbing`.
-//! - `#[cfg(feature = "bv_shadow")]` — the positive half: all four widths +
+//! - `#[cfg(feature = "bv")]` — the positive half: all four widths +
 //!   `nowrap` parse with the AST tag recovered and the clause `text` round-trips
 //!   (the tag sits outside the addressing oracle string).
 //!
 //! CI runs `cargo test -p thermite-syntax` (negative half) AND
-//! `cargo test -p thermite-syntax --features bv_shadow` (positive half) so both
+//! `cargo test -p thermite-syntax --features bv` (positive half) so both
 //! configurations are exercised in one run (AC-1's "build-flag test in CI").
 //! R-CHAR-3: shapes hand-derived from the grammar; `tests/` is ungated.
 
@@ -27,11 +27,11 @@ use thermite_syntax::{parse, SyntaxError};
 // error — the feature cannot exist in the build.
 // ===========================================================================
 
-#[cfg(not(feature = "bv_shadow"))]
+#[cfg(not(feature = "bv"))]
 mod plumbing_absent {
     use super::*;
 
-    /// `ens@bv64` in a build WITHOUT `bv_shadow` is a structured syntax error
+    /// `ens@bv64` in a build WITHOUT `bv` is a structured syntax error
     /// pointing at the `@` (the structural lock R-BV-1 / AC-1 negative half).
     #[test]
     fn ens_bv_tag_is_a_parse_error_without_plumbing() {
@@ -71,7 +71,7 @@ mod plumbing_absent {
         }
     }
 
-    /// The error message names the `bv_shadow` feature so the gate is discoverable.
+    /// The error message names the `bv` feature so the gate is discoverable.
     #[test]
     fn the_error_message_points_at_the_feature() {
         let src = "fn f(a: u64) -> u64 req true ens@bv64 result == 0 fx pure { 0 }";
@@ -81,8 +81,8 @@ mod plumbing_absent {
             .find(|e| matches!(e, SyntaxError::BvTagWithoutShadowPlumbing { .. }))
             .expect("a BvTagWithoutShadowPlumbing error");
         assert!(
-            err.to_string().contains("bv_shadow"),
-            "the diagnostic should name the `bv_shadow` feature: {err}"
+            err.to_string().contains("bv"),
+            "the diagnostic should name the `bv` feature: {err}"
         );
     }
 }
@@ -92,7 +92,7 @@ mod plumbing_absent {
 // `nowrap` parse, the AST tag is recovered, and the clause text round-trips.
 // ===========================================================================
 
-#[cfg(feature = "bv_shadow")]
+#[cfg(feature = "bv")]
 mod plumbing_present {
     use super::*;
     use thermite_syntax::{BvWidth, Clause, ForgeItem, Item};

--- a/thermite-tv/src/exec_stmt_encode.rs
+++ b/thermite-tv/src/exec_stmt_encode.rs
@@ -1147,11 +1147,13 @@ mod tests {
                 expr: Expr::BoolLit(true),
                 text: "true".to_string(),
                 span,
+                bv: None,
             }],
             dec: Clause {
                 expr: int(0),
                 text: "0".to_string(),
                 span,
+                bv: None,
             },
             body: Block {
                 stmts: vec![],

--- a/thermite-tv/tests/loop_teeth.rs
+++ b/thermite-tv/tests/loop_teeth.rs
@@ -88,6 +88,7 @@ fn clause(expr: Expr) -> Clause {
         expr,
         text: String::new(),
         span: Span { start: 0, len: 0 },
+        bv: None,
     }
 }
 


### PR DESCRIPTION
Stage-3 REQ-1 — the `@bv` machine-semantics clause tag, **parse-gated** behind compiled-in plumbing. First increment of the Stage-3 tree (umbrella xl #342 / gh #80; spec `.design/stage3-bv-reconstruction.md` REQ-1 / AC-1). Closes #343.

## What ships
- **The tag.** `thermite-syntax` parses `ens@bvN` / `inv@bvN` / `req@bvN` / `@bvN(nowrap)` for N∈{8,16,32,64}; `lemma` items accept it too. New `BvWidth` + `BvTag{width,nowrap,span}` and `Clause.bv: Option<BvTag>` (the language's first clause-level annotation). The tag sits **outside** `Clause.text`, so the semantic-addressing oracle is unchanged.
- **The structural lock (R-BV-1).** The parser path that accepts the tag is `#[cfg(feature = "bv")]`-gated and the feature is **non-default**, so a release build without it *cannot parse* the tag — `ens@bv64` is a structured `SyntaxError::BvTagWithoutShadowPlumbing`, not silently ignored. The feature *is* the visibility machinery; the feature cannot exist without it.
- **Errors.** `BvTagWithoutShadowPlumbing` (feature off) and `BvWidthInvalid` (bad width) are structured, span-carrying variants.

## AC-1 — both halves
- **Negative** (default build): 3 tests — `ens@bv64`, `inv`, and `nowrap` tags are parse errors; the message points at the feature.
- **Positive** (`--features bv`): 9 tests — all four widths, `nowrap`, `inv`, `lemma`, coexistence, and 3 error cases; AST round-trip over `Clause.bv`.
- CI gains a build-flag step running clippy + the positive test suite under `--features bv`; default nextest covers the negative half.

## Notes for reviewers
- The cargo feature is named **`bv`** (per spec); `bv_shadow` is reserved for REQ-3's certificate field. (The kickoff agent initially named it `bv_shadow`; renamed in commit 2 — see #343.)
- `bv: None` is threaded through ~14 cross-crate `Clause` literals (net-additive). Commit 3 re-pins the 21 design docs that ripple drifted (15 content-sha + 6 legacy commit-pin); the commit-pins will need a follow-up re-pin to the squash commit after merge (the known legacy-pin/squash gotcha).

Verified locally: default + `--features bv` test suites green, `cargo build --workspace` clean, `fmt --check` + `clippy -D warnings` clean both configs, `make doc-drift` exit 0.