### PR TITLE
fix(doc-drift): re-pin 6 legacy commit-pins to the #343 squash commit

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-sha: 20ba2d7658d057f83019e957d125f1e4b33d5027 (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and


### PR DESCRIPTION
Follow-up to #81 (#343). The Stage-3 REQ-1 squash-merge (`5581b65f`) carried an in-PR re-pin that pointed six **legacy commit-pinned** design docs at the feature-branch tip (`20ba2d76`). Squash orphaned that commit, so on `main` those six are now `INVALID-PIN` (`not an ancestor of HEAD`) — which would fail doc-drift on the next PR (REQ-2) for drift it didn't cause.

Re-pins them to the squash commit `5581b65f` itself — a real commit on `main`, so it stays an ancestor and is squash-stable going forward. Docs:
- `.design/basis/09-option-result.md`, `11-ergonomics.md`, `12-mutual-recursion.md`
- `.design/forge/check.md`
- `.design/lower/boundary-composition.md`
- `.design/verified/proof-backends.md`

The `bv: None` ripple that drifted them is net-additive (threading the new optional `Clause.bv` tag); the REQs these docs govern are unchanged. `make doc-drift` exit 0 locally.