### PR TITLE
docs(stage3): land resolved design doc + untrack .kickoff-session

### DIFF
--- a/.design/stage3-bv-reconstruction.md
+++ b/.design/stage3-bv-reconstruction.md
@@ -1,156 +1,239 @@
-# Feature: Stage 3 — `@bv` clause mode + reconstruction by default (PROVISIONAL)
+# Feature: Stage 3 — `@bv` clause mode + reconstruction by default
 
-> **STATUS: PROVISIONAL — do not kickoff from this document.**
-> This is an interim reasoning cache for the program's last and
-> last-staged increment. It carries unresolved
-> `<!-- OPEN -->` blocks keyed to inputs that cannot exist before G2,
-> so validation flags it as not-kickoff-ready. When the inputs below
-> are available, re-run the design pass
-> (`/design --continue stage3-bv-reconstruction`) to resolve them
-> against real results, re-validate, and only then `crosslink kickoff`.
->
-> *M0 re-pass note (2026-06-13): the M0 spikes (SPIKE-1/SPIKE-2) do
-> **not** feed this stage — none of its inputs is a spike. Its two OPEN
-> blocks (Q-BVSCOPE, Q-RECON) are keyed to Gate-G2 telemetry and a
-> G2-time lean-smt/cvc5 ecosystem assessment, both ~two gates out, so
-> stage 3 remains genuinely provisional after the stage-2 spike re-pass.*
+> **STATUS: KICKOFF-READY (re-pass 2026-06-21).**
+> Both prior `<!-- OPEN -->` blocks (Q-BVSCOPE, Q-RECON) are RESOLVED
+> against post-G2 evidence — see the Decision Record at the foot of this
+> doc. Baseline re-grounded to current `main @ 2d6c708e` (Stage 2
+> complete, Gate G2 reached). The architecture seams below carry
+> verified `file:line` anchors, not speculation. Next step: open the
+> Stage-3 issue tree (umbrella + increments), structured as Stage 2 was.
 
-| input dependency | what it decides here | produced by |
+| input dependency | what it decided here | resolution |
 |---|---|---|
-| Gate G2 (stage 2 complete, trust flip done) | The per-clause `trust:` migration mechanics this stage reuses; stable schema-v2 certificates | `.design/stage2-stratified-cage.md` REQ-9 |
-| Stage-1/2 review telemetry (`forge review`, program plan §6) | Q-BVSCOPE: whether `@bv` ships full, `nowrap`-only, or lemma-position-only (fallback F-F's ladder) | dashboard from M1 |
-| Lean-SMT / cvc5 replay ecosystem assessment at G2 time | Q-RECON: the reconstruction path's engine and fragment support; whether default-on is viable or F-J (status quo ante) holds | re-pass exploration |
-| `KernelBudget`/`Timeout` telemetry on bv-shaped queries | Whether 64-bit multiplier instances need a dedicated budget profile before the tag ships | stage-1 verdict plumbing |
+| Gate G2 (stage 2 complete, trust flip done) | The per-clause `trust:` migration mechanics this stage reuses; stable schema-v2 certificates | RESOLVED: schema-v2 live (`forge/src/manifest.rs:226-316`); `with_clause_attribution(engine, trust, verdict)` is the migration seam |
+| Stage-1/2 review telemetry (`forge review`) | Q-BVSCOPE: full / `nowrap`-only / lemma-only | RESOLVED → **full tag + 3 locks**. The "bv-density telemetry" input is circular (no bv corpus can exist pre-ship), so REQ-6's density report becomes the *post-ship* F-F tripwire, not a precondition |
+| Lean-SMT / cvc5 replay ecosystem assessment at G2 | Q-RECON: reconstruction engine + fragment support; default-on viability | RESOLVED → **build the Rust→Lean exporter; default-on for QF_LIA + QF_BV**. lean-smt pinned @ `7d1d8239` (vendored cvc5 FFI); `SmtDemo.lean` proves QF_LIA kernel-replay axiom-clean; cvc5 supports QF_BV. The gap was never ecosystem maturity — it is the automated obligation exporter (PoC Tier-3 hand-translation) |
+| `KernelBudget`/`Timeout` telemetry on bv-shaped queries | Whether 64-bit multiplier instances need a dedicated budget profile | RESOLVED → folded into REQ-2: QF_BV 64-bit multiplication is the known cost cliff; it gets a dedicated budget profile and the `Timeout` verdict, never `unknown` |
 
 ## Summary
 
-Stage 3 of the RFC-1 program, two independent halves. (1) The `@bv`
-machine-semantics clause tag (RFC-1 §4): `ens@bvN P` interpreted over
-fixed-width wraparound semantics via Verus's `by(bit_vector)` mode,
-where everything including multiplication is decidable with bit-level
+Stage 3 of the RFC-1 program — its last gate (G3) — in two halves that
+now converge on QF_BV. (1) The `@bv` machine-semantics clause tag
+(RFC-1 §4): `ens@bvN P` / `inv@bvN P` interpreted over fixed-width
+wraparound semantics via Verus's `by(bit_vector)` mode (QF_BV), where
+everything including multiplication is decidable with bit-level
 countermodels — shipped only with its three locks (shadow flag,
 bv-semantics mutation, `nowrap` side obligation) and gate G3's
 structural guarantee that a build without shadow-flag plumbing cannot
-even parse the tag. (2) SMT proof reconstruction flipped to default-on
-where the fragment supports it, migrating cage clauses' trust base from
-solver to kernel without touching their rung — the C4 grid honesty,
-delivered through the `trust:` field. The bv half is the program's one
-permanent semantic fork and its one new gaming vector; it is staged
-last for that reason, and fallback F-F's ladder remains
-open until the re-pass. Umbrella: `.design/thermite2-program.md`
-(REQ-10).
+even *parse* the tag. (2) SMT proof reconstruction flipped to
+default-on, migrating cage clauses' trust base from solver to kernel
+*without touching their rung* — the C4-grid honesty, delivered through
+the `trust:` field. The reconstruction half builds the automated
+Rust→Lean obligation exporter that `SmtDemo.lean`'s Tier-3 PoC stubbed
+as hand-translation, and turns default-on for the QF_LIA scalar
+fragment (PoC-proven) and QF_BV (cvc5-supported) — so a `@bv` clause is
+not only width-decidable but *kernel-checked*, the two halves meeting
+on the bit-vector fragment. The G2 trust residual (rel/array
+EPR-stratified atoms, still z3-model-relative) is migrated *where the
+reconstruction path supports it* and otherwise named in the audit's
+residual-trust statement (fallback F-J: reconstruction was never
+load-bearing for any gate, so an unsupported fragment is free to stay
+labeled). The bv half is the program's one permanent semantic fork and
+its one new gaming vector; it is staged last for that reason, with the
+locks shipping inside the same gate as the feature. Umbrella:
+`.design/thermite2-program.md` (REQ-10).
 
 ## Requirements
 
 - REQ-1 (**the tag, parse-gated**): `thermite-syntax` parses `ens@bvN`
   / `inv@bvN` / `@bvN(nowrap)` for N ∈ {8, 16, 32, 64} **only when the
   shadow-flag plumbing is compiled in**: a build-flag test proves that
-  with the plumbing absent, the tag is a parse error (G3's structural
-  lock — the feature cannot exist without its visibility machinery,
-  R-BV-1). `lemma` items accept the tag under the same gate.
+  with the plumbing absent, the tag is a structured parse error (G3's
+  structural lock — the feature cannot exist without its visibility
+  machinery, R-BV-1). `lemma` items accept the tag under the same gate.
+  The tag is the FIRST clause-level annotation in the language: today
+  `Clause` (`thermite-syntax/src/ast.rs:596`) is `{ expr, text, span }`
+  with no annotation field, and `parse_contract` (`parser.rs:1376`)
+  dispatches req/ens/fx with no tag slot — both grow a `bv: Option<BvTag>`.
+  The gate is a cargo feature on `thermite-syntax` (it has none today,
+  `thermite-syntax/Cargo.toml`); the parser consults
+  `cfg!(feature = "bv")` at the dispatch site so a release build with
+  the feature off rejects the tag at parse time.
 - REQ-2 (**lowering**): tagged clauses lower through Verus
-  `by(bit_vector)` (QF_BV); untagged clauses on the same item lower
-  as before — one function may carry wraparound and unbounded
-  clauses side by side, each labeled (the RFC's mix64 shape: two
-  `@bv64` clauses + one unbounded zero-fixpoint clause). Verdicts ride
-  stage-1 plumbing: bit-level `Counterexample` with the bit pattern
-  attached; `Timeout` for the multiplier cost cliff, budgeted, never
-  `unknown`.
+  `by(bit_vector)` (QF_BV) via a new `EngineName::BitVector` alongside
+  the stage-1 `Nlsat` route (`forge/src/engine.rs`); untagged clauses
+  on the same item lower as before — one function may carry wraparound
+  and unbounded clauses side by side, each labeled (the RFC's mix64
+  shape: two `@bv64` clauses + one unbounded zero-fixpoint clause).
+  Verdicts ride stage-1 plumbing: bit-level `Counterexample` with the
+  bit pattern attached; `Timeout` for the multiplier cost cliff —
+  QF_BV 64-bit multiplication gets a **dedicated budget profile**,
+  reported as `Timeout`/`KernelBudget`, never `unknown` and never a
+  silent downgrade.
 - REQ-3 (**lock 1 — the shadow flag**): every tagged clause's
   certificate carries `bv_shadow { flagged, semantics, nowrap_obligation,
-  note }` (the RFC §9 shape), oracle-included, and greppable at every
+  note }` (the RFC §9 shape) as an additive schema-v2 field on
+  `ObligationResult` (`forge/src/manifest.rs:226`, following the
+  `#[serde(default, skip_serializing_if)]` pattern that keeps v1
+  goldens byte-identical), oracle-included (Q-ORACLE precedent:
+  deterministic + verdict-relevant → included), and greppable at every
   layer `#[slag]` is greppable at (certificate JSON, `forge review`
-  output, audit aggregation).
-- REQ-4 (**lock 2 — bv-semantics mutation**): the mutation battery runs
-  against bv semantics for tagged clauses — the existing frozen
-  operator catalogue with the kill-check oracle evaluated at width
-  (a wrap-exploiting mutant must be killable by a wrap-aware check).
+  output, `forge audit` aggregation).
+- REQ-4 (**lock 2 — bv-semantics mutation**): the mutation battery
+  (`forge/src/mutation.rs`) runs against bv semantics for tagged
+  clauses — the existing frozen operator catalogue is reused unchanged
+  (the stage-1 re-elaboration precedent: only the kill check swaps),
+  with `classify_mutant`'s oracle (`mutation.rs:99`) evaluated *at
+  width* so a wrap-exploiting mutant — equivalent at unbounded
+  semantics, distinguishable at width — must be killable by a
+  wrap-aware check.
 - REQ-5 (**lock 3 — `nowrap`**): `@bvN(nowrap)` additionally emits a
   no-overflow side obligation discharged in-cage; its certificate's
   `bv_shadow.nowrap_obligation` records the obligation's verdict. For
   when machine width is the domain but wrap is not the intent.
-- REQ-6 (**review surface**): `forge review` gains the "semantic forks
-  and definition towers" section (Q9 default, decide-by G3): bv-shadow
-  density per module and the burned-lemma towers — the human-audit
-  surface for the two legibility risks the forge and bv add. This
-  section is also the F-F tripwire: rising shadow-flag density in
-  contract-bearing code is the named retreat trigger.
-- REQ-7 (**reconstruction default-on**): where the obligation's
-  fragment is supported by the reconstruction path, solver results are
-  replayed/checked in the kernel and the clause's `trust:` migrates
-  from `solver(z3)` to the kernel-checked form — same rung, smaller
-  trust base, visible per clause and aggregated by the audit's
-  residual-trust statement. Unsupported fragments keep per-run solver
-  trust, labeled as today (fallback F-J is the free status quo
-  ante; reconstruction was never load-bearing for any gate).
-- REQ-8 (**gate G3**): the three locks demonstrably wired before the
-  tag parses in any release build (REQ-1's build-flag test);
-  reconstruction default-on behind a fragment-support check with the
-  `trust:` migration visible in certificates; README/docs claims change
-  at gate time only (R-GATE-1).
+- REQ-6 (**review surface, the F-F tripwire**): `forge review` /
+  `forge audit` gain a "semantic forks and definition towers" section
+  (the audit infra exists — `forge/src/audit.rs`, `forge/src/meaning.rs`
+  tower analysis, `forge/src/review.rs` burned-lemma surfacing — this
+  section is additive over it): bv-shadow density per module and the
+  burned-lemma tower depths — the human-audit surface for the two
+  legibility risks the forge and bv add. Because no bv corpus exists
+  until the tag ships (the Q-BVSCOPE circularity), this density report
+  is the **post-ship retreat trigger**: rising shadow-flag density in
+  contract-bearing code is the named F-F tripwire down the ladder
+  (full → `nowrap`-only → lemma-only → drop).
+- REQ-7 (**the Rust→Lean obligation exporter**): build the automated
+  exporter that turns a per-clause obligation into the
+  `smt`-dischargeable Lean goal `(P_production) ⟺ (P_reference)` —
+  the step `SmtDemo.lean`'s Tier-3 PoC performs by hand
+  (`lean/Thermite/SmtDemo.lean`, "the hand-translation step is the gap
+  an automated Rust→Lean exporter would close"). The exporter covers
+  the QF_LIA scalar fragment (comparisons + connectives over `int`,
+  the PoC's proven shape) and the QF_BV fragment (the bit-vector
+  clauses REQ-2 produces). Its output is fed to the lean-smt `smt`
+  tactic (pinned @ `7d1d8239`, `lean/lakefile.toml`) and the resulting
+  theorem's `#print axioms` must stay within `{propext,
+  Classical.choice, Quot.sound}` for the fragment to count as
+  reconstruction-supported.
+- REQ-8 (**reconstruction default-on**): where the obligation's
+  fragment is reconstruction-supported (REQ-7's QF_LIA + QF_BV, axiom
+  check passing), solver results are replayed/checked in the kernel and
+  the clause's `trust:` migrates from `solver(z3)` to the
+  kernel-checked form via `with_clause_attribution`
+  (`forge/src/manifest.rs:306`) — same rung, smaller trust base,
+  visible per clause and aggregated by the audit's residual-trust
+  statement. The fragment-support check ADDITIONALLY migrates
+  EPR-stratified rel/array clauses (the G2 residual that left
+  `strat_lowering_faithful`'s rel atoms z3-model-relative) *where the
+  reconstruction path supports them*; unsupported fragments keep
+  per-run solver trust, labeled as today, and the audit names exactly
+  what stayed solver-trusted (fallback F-J is free — reconstruction was
+  never load-bearing for any gate, so no gate regresses if a fragment
+  is unsupported).
+- REQ-9 (**gate G3**): the three locks demonstrably wired before the
+  tag parses in any release build (REQ-1's build-flag test); the
+  exporter + reconstruction default-on behind the fragment-support
+  check with the `trust:` migration visible in certificates and the
+  residual-trust statement honest about what stayed solver-trusted;
+  README/RATIONALE/docs claims about `@bv` and default reconstruction
+  change **at gate time only** (R-GATE-1), as G1 and G2 did.
 
 ## Acceptance Criteria
 
-- [ ] AC-1: A build without shadow-flag plumbing fails to parse
-  `ens@bv64` with a structured syntax error (build-flag test in CI);
-  with plumbing, all four widths + `nowrap` parse with AST round-trip
-  tests. (REQ-1, REQ-8)
+- [ ] AC-1: A build with the `bv` feature off fails to parse `ens@bv64`
+  with a structured syntax error (build-flag test in CI); with the
+  feature on, all four widths + `nowrap` parse with AST round-trip
+  tests over the new `Clause.bv` field. (REQ-1, REQ-9)
 - [ ] AC-2: The mix64 example certifies with three clauses on three
-  mechanisms (two `@bv64`, one unbounded), each clause's certificate
-  naming its engine and semantics; the injectivity lemma discharges at
-  `@bv64` with no proof block. (REQ-2)
+  mechanisms (two `@bv64` via `EngineName::BitVector`, one unbounded),
+  each clause's certificate naming its engine and semantics; the
+  injectivity lemma discharges at `@bv64` with no proof block. (REQ-2)
 - [ ] AC-3: A planted non-injective rotate dies as `Counterexample`
-  with the bit pattern in the certificate; an over-budget multiplier
-  query yields `Timeout`, never `unknown` and never a silent downgrade.
-  (REQ-2)
+  with the bit pattern in the certificate; an over-budget 64-bit
+  multiplier query yields `Timeout` under the dedicated bv budget
+  profile, never `unknown` and never a silent downgrade. (REQ-2)
 - [ ] AC-4: `bv_shadow` appears in the oracle subset for tagged
   clauses; `grep`ing certificates for `bv_shadow` finds every tagged
-  clause and nothing else; `forge review` lists them. (REQ-3, REQ-6)
-- [ ] AC-5: A wrap-exploiting mutant (one that is equivalent at
-  unbounded semantics but distinguishable at width) is killed by the
-  bv-semantics mutation run on a tagged clause — a fixture test.
+  clause and nothing else; `forge review` and `forge audit` list them.
+  (REQ-3, REQ-6)
+- [ ] AC-5: A wrap-exploiting mutant (equivalent at unbounded
+  semantics, distinguishable at width) is killed by the bv-semantics
+  mutation run on a tagged clause; the same mutant survives the
+  unbounded check — a fixture test pinning the width-aware kill.
   (REQ-4)
 - [ ] AC-6: A `@bv64(nowrap)` clause whose body can overflow fails its
   side obligation with a concrete overflowing input; the obligation's
   verdict is recorded in `bv_shadow.nowrap_obligation`. (REQ-5)
-- [ ] AC-7: The review section reports bv-shadow density per module
-  and tower depth for burned lemmas; the numbers match a fixture
-  project's known counts. (REQ-6)
-- [ ] AC-8: A reconstruction-supported clause's certificate shows the
-  kernel-checked `trust:` form while an unsupported clause on the same
-  item retains `solver(z3)`; the audit's residual-trust statement
-  aggregates the split. (REQ-7)
-- [ ] AC-9: All G3 items hold in one CI run before any README/docs
-  claim about `@bv` or default reconstruction merges. (REQ-8)
+- [ ] AC-7: The review section reports bv-shadow density per module and
+  tower depth for burned lemmas; the numbers match a fixture project's
+  known counts; a synthetic density spike trips the named F-F warning.
+  (REQ-6)
+- [ ] AC-8: The exporter emits a `(P_prod) ⟺ (P_ref)` Lean goal for a
+  QF_LIA scalar clause AND a QF_BV `@bv` clause; each is discharged by
+  `smt` and `#print axioms` reports ⊆ `{propext, Classical.choice,
+  Quot.sound}` (no `Smt`-internal oracle, no `ofReduceBool`). (REQ-7)
+- [ ] AC-9: A reconstruction-supported clause (QF_LIA or QF_BV)'s
+  certificate shows the kernel-checked `trust:` form while an
+  unsupported clause on the same item retains `solver(z3)`; the audit's
+  residual-trust statement aggregates the split and names the
+  still-solver-trusted fragments. (REQ-8)
+- [ ] AC-10: All G3 items hold in one CI run before any
+  README/RATIONALE claim about `@bv` or default reconstruction merges
+  (the gate-time flip, R-GATE-1). (REQ-9)
 
 ## Architecture
 
-**Where stage 3 plugs in (recorded now; re-verify at re-pass):**
+**Where stage 3 plugs in (re-grounded against `main @ 2d6c708e`):**
 
-- **Syntax**: the tag is a clause-level annotation through
-  `parse_contract`'s ordered dispatch (`thermite-syntax/src/parser.rs`)
-  — the same seam stage 1 used for new clause forms. The build-flag
-  gate wants the parser to consult a compiled-in capability, which is
-  new for `thermite-syntax` (today it has no feature flags); the
-  re-pass should pick the mechanism (cargo feature vs. a capability
-  struct threaded from forge) with stage-1's final crate layout in
-  view.
-- **Lowering + engine**: a bv route through the existing `Engine`
-  trait (`forge/src/engine.rs`) or a mode flag on the Verus engine —
-  the re-pass decides after seeing how stage 1's relax engine
-  (`nlsat`) landed; the certificate attribution mechanism
-  (`with_engine_attribution`) carries either way.
-- **Mutation at width**: `forge/src/mutation.rs`'s catalogue is reused
-  unchanged (the stage-1 re-elaboration precedent: only the kill check
-  swaps); the bv kill check evaluates the mutant against the tagged
-  clause at width.
-- **Certificates**: `bv_shadow` is an additive schema-v2 field;
-  oracle-inclusion follows the stage-1 Q-ORACLE precedent
-  (deterministic, verdict-relevant → included).
-- **Reconstruction**: the cvc5/lean-smt replay path; the lean-smt SHA
-  pin from the pre-M1 debt items is the dependency anchor. All
-  reconstruction work is trust-field-only — no rung changes, no new
-  verdicts — which is why F-J (don't ship it) is free.
+- **Syntax** (`thermite-syntax`): the tag is the language's first
+  clause-level annotation. `Clause` (`src/ast.rs:596`, today `{ expr,
+  text, span }`) grows `bv: Option<BvTag>` where `BvTag { width:
+  BvWidth, nowrap: bool }`; `parse_contract` (`src/parser.rs:1376`,
+  the req→ens→fx ordered dispatch) grows a tag-parsing step guarded by
+  `cfg!(feature = "bv")`. `thermite-syntax/Cargo.toml` gains its first
+  `[features]` entry (`bv`). The build-flag test compiles the crate
+  twice and asserts the off build rejects `@bvN` at parse time — the
+  R-BV-1 structural lock. Note stage-1/2 added clause *content* as
+  expression-level constructs (`Expr::Quantifier`, `parser.rs:2600`);
+  the tag is genuinely new mechanism, not a copy of that seam.
+- **Lowering + engine** (`forge`): a new `EngineName::BitVector` in
+  `src/engine.rs` (joining `Verus`, `LeanAuto`, `LeanInteractive`,
+  `Nlsat`), lowering tagged clauses through Verus `by(bit_vector)`.
+  Certificate attribution rides the existing
+  `with_clause_attribution(engine, trust, verdict)`
+  (`src/manifest.rs:306`) — the same mechanism stage-1's `Nlsat` route
+  used, so a mixed-mechanism function (mix64) attributes per clause for
+  free. The 64-bit multiplier budget profile is a `BitVector`-specific
+  rlimit/budget setting threaded through the same verdict plumbing that
+  produces `Timeout`/`KernelBudget`.
+- **Mutation at width** (`forge/src/mutation.rs`): the frozen catalogue
+  (`MUTANT_CAP = 64`, `mutation.rs:61`) is reused unchanged; only the
+  kill check swaps — `classify_mutant` (`mutation.rs:99`) evaluates the
+  mutant against the tagged clause *at width*. This is exactly the
+  stage-1 re-elaboration precedent (catalogue fixed, oracle swapped).
+- **Certificates** (`forge/src/manifest.rs`): `bv_shadow` is an
+  additive schema-v2 field on `ObligationResult` (`:226`), using the
+  established `#[serde(default, skip_serializing_if)]` pattern so v1
+  goldens stay byte-identical and the v1 oracle subset is unchanged for
+  untagged clauses.
+- **Reconstruction** (`lean/` + `forge`): lean-smt is pinned @
+  `7d1d8239` with vendored cvc5 over FFI, toolchain v4.29.0 + Mathlib
+  (`lean/lakefile.toml`). `lean/Thermite/SmtDemo.lean` already proves
+  the path works and stays axiom-clean for QF_LIA (Tier 2 toy +
+  Tier 3 one TV obligation, both `smt`-discharged, `#print axioms` ⊆
+  the standard set). The Stage-3 exporter (REQ-7) closes the Tier-3
+  hand-translation gap: a Rust→Lean obligation exporter producing the
+  `(P_prod) ⟺ (P_ref)` goal for QF_LIA and QF_BV. cvc5 supports QF_BV
+  (`lean/.lake/packages/cvc5` exercises `setLogic "QF_BV"`), so the bv
+  half's queries are reconstruction-eligible. All reconstruction work
+  is trust-field-only — no rung changes, no new verdicts — which is why
+  F-J (an unsupported fragment stays labeled solver-trusted) is free.
+- **Audit/review** (`forge/src/{audit,review,meaning}.rs`): the
+  "semantic forks and definition towers" section is additive over the
+  existing audit manifest (functions / project_assurance / tcb /
+  lean_fragment) and the existing tower analysis in `meaning.rs`; it
+  surfaces bv-shadow density and burned-lemma tower depth, and carries
+  the F-F density tripwire.
 
 **Why last, restated from the decision record:** the bv tag is the one
 piece of the program that adds a *permanent* semantic fork and a
@@ -159,39 +242,28 @@ stage it after the pure-win routing (stage 1) and the metatheory-heavy
 cage growth (stage 2), with the locks shipping inside the same gate as
 the feature, not after.
 
-## Open Questions
+## Decision Record (re-pass 2026-06-21, resolves the prior OPEN blocks)
 
-*(Deliberately unresolved — keyed to inputs that cannot exist before
-G2. Resolve at the re-pass, not before.)*
+**D-BVSCOPE (was Q-BVSCOPE) → full tag + three locks.** RFC-1's
+committed shape. The original input — "shadow-flag density telemetry
+from `forge review`" — is circular: no bv clause exists to measure
+until the tag ships. The honest resolution is to ship the full tag
+guarded by its three locks, and make REQ-6's per-module density report
+the *post-ship* F-F tripwire. The ladder (full → `nowrap`-only →
+lemma-only → drop) is preserved as a documented retreat path keyed to
+that live telemetry, not pre-committed downward.
 
-<!-- OPEN: Q-BVSCOPE -->
-### Q-BVSCOPE: Does `@bv` ship full, `nowrap`-only, or lemma-position-only?
-
-Fallback F-F's ladder (full tag → `nowrap`-only → lemma-position-only →
-drop) is selected by evidence that won't exist until stages 1–2 run:
-shadow-flag density telemetry from `forge review`, and whether any
-wrap-weakened clause shows up in practice. RFC-1 commits to the full
-tag with three locks; this doc specs that, but the re-pass must
-re-affirm it against the telemetry or retreat a rung before any
-implementation issue opens.
-**To resolve**: re-run the design pass with the §6 dashboard's bv-risk
-rows in hand.
-<!-- /OPEN -->
-
-<!-- OPEN: Q-RECON -->
-### Q-RECON: Reconstruction engine and fragment support — what does the ecosystem look like at G2?
-
-The replay path (lean-smt maturity, cvc5 proof formats, which of the
-cage's fragments — linear arithmetic, EPR-stratified, QF_BV — have
-practical reconstruction) is an empirical question about external
-tooling at G2 time, roughly two gates away. The pre-M1 lean-smt SHA pin
-fixes the dependency but not the answer. F-J makes failure free, so
-this question never blocks the bv half — but default-on's fragment
-check (REQ-7) cannot be specified until the assessment is
-done.
-**To resolve**: re-run the design pass with a fresh lean-smt/cvc5
-replay assessment as an exploration input.
-<!-- /OPEN -->
+**D-RECON (was Q-RECON) → build the exporter; default-on for QF_LIA +
+QF_BV.** The G2-time ecosystem assessment found the cvc5/lean-smt path
+mature and kernel-clean: `SmtDemo.lean` discharges QF_LIA equivalences
+through `smt` with `#print axioms` inside the standard set, and the
+vendored cvc5 supports QF_BV. The only gap is the automated Rust→Lean
+obligation exporter (the PoC's Tier-3 hand-translation). Stage 3 builds
+it (REQ-7) and turns reconstruction default-on (REQ-8) for QF_LIA and
+QF_BV. The EPR-stratified rel/array residual that G2 left
+solver-model-relative is migrated where the reconstruction path
+supports it and otherwise named honestly in the audit — F-J keeps that
+free, so G3 does not overclaim closing the entire rel/array gap.
 
 ## Out of Scope
 
@@ -203,11 +275,16 @@ replay assessment as an exploration input.
 - Any cage-fragment change — S₂ widenings are stage-2-lineage RFC
   deltas, not stage-3 work.
 - Reconstruction as a gate dependency for anything — F-J is explicitly
-  free; no stage gate cites it.
+  free; no stage gate cites it, and an unsupported fragment never
+  blocks G3.
+- Full kernel-grounding of every rel/array atom — Stage 3 migrates what
+  the reconstruction path supports and names the rest; closing the
+  entire EPR/array residual is bounded by external cvc5/lean-smt
+  reconstruction support, not by this stage.
 
 ---
 
-*Stage-3 spec (PROVISIONAL — reasoning cache; re-run /design before
-kickoff) · child of `.design/thermite2-program.md` (REQ-10) · sources:
-RFC-1 §4/§10/§12, Appendix A §1.4/F-F/F-J · gate: G3 · baseline
-`dollspace-gay/Thermite @ c46da3ac` (re-ground at re-pass).*
+*Stage-3 spec (KICKOFF-READY · re-pass 2026-06-21) · child of
+`.design/thermite2-program.md` (REQ-10) · sources: RFC-1 §4/§10/§12,
+Appendix A §1.4/F-F/F-J · gate: G3 · baseline `dollspace-gay/Thermite @
+2d6c708e`.*

--- a/.design/stage3-bv-reconstruction.pipeline.json
+++ b/.design/stage3-bv-reconstruction.pipeline.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "design_doc": ".design/stage3-bv-reconstruction.md",
-  "doc_hash": "sha256:e1db58e0c6e036236ea51b348cf7de0371bf273c111351acce5aff9f637ca7f6",
+  "doc_hash": "sha256:38d888f2c555c2cdec6f93d8907284236473b70f9c6932c5b93baa02cc8b8d3b",
   "stage": "designed",
   "plans": [],
   "runs": []

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ examples/editor/bin/
 # never committed; the lean-toolchain pin + lakefile.toml reproduce it.
 lean/.lake/
 binary_search_golden
+
+# crosslink kickoff agent-id marker (per-worktree, must not be committed)
+.kickoff-session

--- a/.kickoff-session
+++ b/.kickoff-session
@@ -1,1 +1,0 @@
-5i5F-0Ixw-stage-3-req-1-the-bv-tag-parse-gated-the-first-clause


### PR DESCRIPTION
Pre-REQ-2 housekeeping (closes #352).

**1. Land the resolved Stage-3 design doc.** `main` still carried the `PROVISIONAL` `stage3-bv-reconstruction.md`; this replaces it with the re-pass-resolved version (KICKOFF-READY, baseline `2d6c708e`, REQ-1..9 / AC-1..10). Decision record: D-BVSCOPE = full `@bv` tag + 3 locks (the density-telemetry input is circular → REQ-6 density is the post-ship F-F tripwire); D-RECON = build the Rust→Lean obligation exporter, default-on for QF_LIA + QF_BV. Future Stage-3 increments branch off `main` and must read the resolved spec.

**2. Untrack `.kickoff-session`.** The REQ-1 kickoff agent's `git add -A` committed this per-worktree crosslink agent-id marker (it held the dead `5i5F-0Ixw-…` agent id). Removed from tracking and added to `.gitignore` so future kickoffs don't re-commit it.

No source or governed files change — design doc + `.gitignore` only; doc-drift unaffected.