### PR TITLE
Stage-3 REQ-2: @bv lowering — EngineName::BitVector (QF_BV, L4) (#344)

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 08611b05f378733afc7685d5e6bbd41a02e185ac (re-pinned 2026-06-22 for #344 Stage-3 REQ-2: governed source gains the @bv bit-vector route (EngineName::BitVector, bitvector.rs) + the @bv L4 rung flip in check.rs; net-additive, governed REQs unchanged.)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 08611b05f378733afc7685d5e6bbd41a02e185ac (re-pinned 2026-06-22 for #344 Stage-3 REQ-2: governed source gains the @bv bit-vector route (EngineName::BitVector, bitvector.rs) + the @bv L4 rung flip in check.rs; net-additive, governed REQs unchanged.)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 08611b05f378733afc7685d5e6bbd41a02e185ac (re-pinned 2026-06-22 for #344 Stage-3 REQ-2: governed source gains the @bv bit-vector route (EngineName::BitVector, bitvector.rs) + the @bv L4 rung flip in check.rs; net-additive, governed REQs unchanged.)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/forge/certificate-manifest.md
+++ b/.design/forge/certificate-manifest.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: a728d95ca3dbd4fbbee1cb496c003f408d82f327 (re-pinned 2026-06-16 for stage-1 increment 2f, REQ-8: the only change to this doc's governed file (manifest.rs) is the additive Level::L4 kernel-grounded rung (REQ-S1-8); the relax route is reached only via --engine nlsat, so the v1 corpus stays L3 and oracle_subset is byte-identical (check_conformance green).)
-audited-content-sha256: 1270e405fbfb3e25ecaef9e739a9e7f7f0a4ef6a229bb267e16f38d9ae05b39c
+audited-content-sha256: 4bca87d2b943edd733ad6eee60f73b9ae0e38a98794e0760a69ae8c16d7e2576
 governs: forge/src/manifest.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 08611b05f378733afc7685d5e6bbd41a02e185ac (re-pinned 2026-06-22 for #344 Stage-3 REQ-2: governed source gains the @bv bit-vector route (EngineName::BitVector, bitvector.rs) + the @bv L4 rung flip in check.rs; net-additive, governed REQs unchanged.)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/cli.md
+++ b/.design/forge/cli.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: shipped
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (content-sha256 re-pinned 2026-06-21 for stage-2 REQ-8 / AC-8 (#330), faithfulness + two-phase TV + the trust flip: the change to this doc's governed file (cli.rs) is the additive `forge strat-faithful-tv [--generated N] [--seed <u64>] [--json]` subcommand (`Command::StratFaithfulTv` → `run_strat_faithful_tv`, the two-phase TV sweep reporting the phase split + the gated trust profile); every other subcommand + flag parse is unchanged. The legacy commit pin stays at the 5ae0816c stable-main ancestor; only the active content-sha256 digest moves. prior: 2026-06-20 stage-2 REQ-4 / AC-4 (#326) `forge strat-tv` + `ForgeError::StratDifferential`; 2026-06-18 umbrella REQ-2c / AC-4 rotating-seed `--seed` flag on `forge tv`; §6 metrics dashboard `--metrics` value)
-audited-content-sha256: a083a61870b7d20c66900093454f0fa2ca7e49685f1c20d8ffb2864a0b8b8d47
+audited-content-sha256: a43d79f4a15eaa8d9d04a886e3cb2ca8c1bf6d362269ef05c97396e56462cb1b
 governs: forge/src/cli.rs
 thesis-refs:
   - thermite-design.md §5

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 08611b05f378733afc7685d5e6bbd41a02e185ac (re-pinned 2026-06-22 for #344 Stage-3 REQ-2: governed source gains the @bv bit-vector route (EngineName::BitVector, bitvector.rs) + the @bv L4 rung flip in check.rs; net-additive, governed REQs unchanged.)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/scaffold/workspace.md
+++ b/.design/scaffold/workspace.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (content-sha256 re-pinned 2026-06-20 for stage-2 REQ-4 / AC-4 (#326), the classifier ops half: the changes to this doc's governed lib roots are additive — `pub mod classifier;` + the classifier re-exports in thermite-spec/src/lib.rs (the new Rust admission classifier), and `mod strat_tv;` in forge/src/main.rs (the differential battery module); the workspace/crate structure is otherwise unchanged. The legacy commit pin stays at the 5ae0816c stable-main ancestor; only the active content-sha256 digest moves. prior: 2026-06-17 umbrella REQ-7 / AC-12 §6 metrics dashboard `mod metrics;`; stage-1 REQ-10/AC-14 G1 gate seven-verdict test module)
-audited-content-sha256: 32826b9803bd5a6a00c0f393f5a34cfb899d1021d057e7ffc06bedc8a60116d5
+audited-content-sha256: 8028435bfe4a6bedcdd68c639756f7097944430a118435134982131b19527154
 governs:
   - Cargo.toml (virtual workspace manifest)
   - rust-toolchain.toml

--- a/.design/stage3-bv-reconstruction.md
+++ b/.design/stage3-bv-reconstruction.md
@@ -20,9 +20,11 @@
 Stage 3 of the RFC-1 program — its last gate (G3) — in two halves that
 now converge on QF_BV. (1) The `@bv` machine-semantics clause tag
 (RFC-1 §4): `ens@bvN P` / `inv@bvN P` interpreted over fixed-width
-wraparound semantics via Verus's `by(bit_vector)` mode (QF_BV), where
-everything including multiplication is decidable with bit-level
-countermodels — shipped only with its three locks (shadow flag,
+wraparound semantics as QF_BV decided by Z3 directly (the same
+bit-blaster Verus's `by(bit_vector)` invokes), where everything
+including multiplication is decidable with bit-level countermodels —
+certifying at the caged rung L4, shipped only with its three locks
+(shadow flag,
 bv-semantics mutation, `nowrap` side obligation) and gate G3's
 structural guarantee that a build without shadow-flag plumbing cannot
 even *parse* the tag. (2) SMT proof reconstruction flipped to
@@ -59,17 +61,28 @@ locks shipping inside the same gate as the feature. Umbrella:
   `thermite-syntax/Cargo.toml`); the parser consults
   `cfg!(feature = "bv")` at the dispatch site so a release build with
   the feature off rejects the tag at parse time.
-- REQ-2 (**lowering**): tagged clauses lower through Verus
-  `by(bit_vector)` (QF_BV) via a new `EngineName::BitVector` alongside
-  the stage-1 `Nlsat` route (`forge/src/engine.rs`); untagged clauses
-  on the same item lower as before — one function may carry wraparound
-  and unbounded clauses side by side, each labeled (the RFC's mix64
-  shape: two `@bv64` clauses + one unbounded zero-fixpoint clause).
-  Verdicts ride stage-1 plumbing: bit-level `Counterexample` with the
-  bit pattern attached; `Timeout` for the multiplier cost cliff —
-  QF_BV 64-bit multiplication gets a **dedicated budget profile**,
-  reported as `Timeout`/`KernelBudget`, never `unknown` and never a
-  silent downgrade.
+- REQ-2 (**lowering**): tagged clauses lower to **QF_BV decided by Z3
+  directly** — the same decision procedure Verus's `by(bit_vector)`
+  invokes (Z3's bit-blaster), reached as its own `EngineName::BitVector`
+  route exactly as the stage-1 `Nlsat` route reaches Z3's nlsat directly
+  rather than through a Verus VC round-trip (`forge/src/engine.rs`,
+  `forge/src/bitvector.rs`). Direct emission is deliberate: the rendered
+  SMT-LIB2 QF_BV query *is* the artifact REQ-8 reconstruction replays, so
+  this route hands off cleanly to the kernel-grounding half. Untagged
+  clauses on the same item lower as before — one function may carry
+  wraparound and unbounded clauses side by side, each labeled (the RFC's
+  mix64 shape: two `@bv64` clauses + one unbounded zero-fixpoint clause).
+  A `@bv` clause certifies at **L4** (the caged rung — decidable, complete
+  bit-pattern countermodels per RFC §2/§4; never degraded), with its
+  SOLVER trust base (`solver Z3 QF_BV`) recorded **separately** in the
+  per-clause attribution — rung and trust are orthogonal axes, and REQ-8
+  shrinks the trust at the same rung. (The general Verus/Z3 cage still
+  certifies at L3 in code pending its own L4 promotion — a tracked
+  follow-up, not this increment.) Verdicts ride stage-1 plumbing:
+  bit-level `Counterexample` with the bit pattern attached; `Timeout` for
+  the multiplier cost cliff — QF_BV 64-bit multiplication gets a
+  **dedicated budget profile**, reported as `Timeout`/`KernelBudget`,
+  never `unknown` and never a silent downgrade.
 - REQ-3 (**lock 1 — the shadow flag**): every tagged clause's
   certificate carries `bv_shadow { flagged, semantics, nowrap_obligation,
   note }` (the RFC §9 shape) as an additive schema-v2 field on
@@ -129,7 +142,15 @@ locks shipping inside the same gate as the feature. Umbrella:
   per-run solver trust, labeled as today, and the audit names exactly
   what stayed solver-trusted (fallback F-J is free — reconstruction was
   never load-bearing for any gate, so no gate regresses if a fragment
-  is unsupported).
+  is unsupported). **REQ-8 owns the `render_bv_prop` faithfulness
+  obligation:** because REQ-2 emits QF_BV via a *direct* SMT-LIB2 render
+  (`forge/src/bitvector.rs`) rather than through the Verus lowering, that
+  render is a new translation NOT covered by the existing Verus-path
+  translation validation — it enters the TCB until reconstruction
+  replays forge's *actual rendered query* in the kernel. Closing that
+  bv-render trust gap (replaying the real query, not a re-derivation) is
+  an explicit REQ-8 acceptance condition, so the gap is tracked, not
+  silent.
 - REQ-9 (**gate G3**): the three locks demonstrably wired before the
   tag parses in any release build (REQ-1's build-flag test); the
   exporter + reconstruction default-on behind the fragment-support
@@ -198,8 +219,11 @@ locks shipping inside the same gate as the feature. Umbrella:
   the tag is genuinely new mechanism, not a copy of that seam.
 - **Lowering + engine** (`forge`): a new `EngineName::BitVector` in
   `src/engine.rs` (joining `Verus`, `LeanAuto`, `LeanInteractive`,
-  `Nlsat`), lowering tagged clauses through Verus `by(bit_vector)`.
-  Certificate attribution rides the existing
+  `Nlsat`), rendering tagged clauses to SMT-LIB2 QF_BV and deciding them
+  with Z3 directly (`src/bitvector.rs`) — the procedure `by(bit_vector)`
+  invokes, reached as its own route per the `Nlsat` precedent. A `Proved`
+  clause certifies at `Level::L4` (caged rung; trust `solver Z3 QF_BV`
+  recorded separately). Certificate attribution rides the existing
   `with_clause_attribution(engine, trust, verdict)`
   (`src/manifest.rs:306`) — the same mechanism stage-1's `Nlsat` route
   used, so a mixed-mechanism function (mix64) attributes per clause for

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-sha: 5581b65f69e481ac74c2d2d107eda121e761f3aa (re-pinned 2026-06-21 for #343 Stage-3 REQ-1: governed source gains net-additive `bv: None` field-inits threading the new optional Clause.bv tag; the REQs this doc governs are unchanged.)
+audited-sha: 08611b05f378733afc7685d5e6bbd41a02e185ac (re-pinned 2026-06-22 for #344 Stage-3 REQ-2: governed source gains the @bv bit-vector route (EngineName::BitVector, bitvector.rs) + the @bv L4 rung flip in check.rs; net-additive, governed REQs unchanged.)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/conformance/forge/bv_mul64_budget.th
+++ b/conformance/forge/bv_mul64_budget.th
@@ -1,0 +1,13 @@
+// The 64-bit multiplier COST CLIFF (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-3 —
+// "an over-budget 64-bit multiplier query yields `Timeout` under the dedicated bv budget
+// profile, never `unknown` and never a silent downgrade"). The clause asserts that the
+// product of two non-trivial bounded factors never equals a fixed 61-bit Mersenne prime
+// (2^61 − 1) — a VALIDITY that requires proving the prime has no factors in range, i.e.
+// the full 64×64 bit-blast: the known QF_BV cost cliff. Because the clause carries a
+// `var * var` multiplication at width 64, the route selects the dedicated `bv64-multiplier`
+// budget profile; the over-budget query is reported as `Timeout` under that named profile,
+// NEVER a bare `unknown`.
+lemma mul64_no_factor(a: u64, b: u64)
+    req a > 1 && a < 4294967296 && b > 1 && b < 4294967296
+    ens@bv64 a * b != 2305843009213693951
+    proof { }

--- a/conformance/forge/bv_shl_not_injective.th
+++ b/conformance/forge/bv_shl_not_injective.th
@@ -1,0 +1,11 @@
+// A PLANTED non-injective shift (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-3 —
+// "a planted non-injective rotate dies as `Counterexample` with the bit pattern"). Unlike
+// the genuine rotate (`rotl1_injective` in `mix64.th`, which RE-INSERTS the shifted-out
+// bit), a bare left-shift-by-1 DISCARDS the top bit, so it is NOT injective: any two
+// 64-bit words differing only in bit 63 collide after `<< 1`. The bit-vector route finds
+// the witnessing assignment and reports a bit-level `Counterexample` carrying the bit
+// pattern (e.g. `x = 0b1000…0000, y = 0b0000…0000`, both mapping to `0`).
+lemma shl1_injective_BROKEN(x: u64, y: u64)
+    req x != y
+    ens@bv64 x << 1 != y << 1
+    proof { }

--- a/conformance/forge/mix64.th
+++ b/conformance/forge/mix64.th
@@ -6,15 +6,18 @@
 //   * `ens@bv64  a + b == b + a`          — wraparound-add COMMUTATIVITY. Interpreted
 //                                           over fixed-width (2's-complement) machine
 //                                           semantics, discharged by the bit-vector route
-//                                           (`EngineName::BitVector`, QF_BV via Verus
-//                                           `by(bit_vector)`) at the SOLVER rung **L3**.
+//                                           (`EngineName::BitVector`, QF_BV via Z3
+//                                           directly — the procedure `by(bit_vector)`
+//                                           invokes) at the caged rung **L4** (decidable,
+//                                           complete bit-pattern countermodels;
+//                                           solver-trusted Z3 QF_BV).
 //                                           No `var * var` multiplication, so the default
 //                                           budget profile (a cheap bit-blast).
 //
 //   * `ens@bv64  a ^ b ^ b == a`          — xor SELF-INVERSE (the one-time-pad identity):
 //                                           xoring twice by the same mask is the identity.
 //                                           A genuine machine-semantics fact, decided by
-//                                           the bit-vector route at **L3**.
+//                                           the bit-vector route at **L4**.
 //
 //   * `ens       a * 0 == 0`              — the UNBOUNDED zero-fixpoint (multiplicative
 //                                           zero). NOT `@bv`-tagged, so it lowers as before
@@ -22,7 +25,8 @@
 //                                           stage-1 nlsat relax route at the kernel-grounded
 //                                           **L4** (`engine: nlsat`).
 //
-// The item certifies at the MIN over the clauses — **L3** (L3, L3, L4). One function, two
+// The item certifies at the MIN over the clauses — **L4** (L4, L4, L4); all three are the
+// caged rung (two @bv64 decidable QF_BV + one nlsat real-relaxation). One function, two
 // mechanisms (`bitvector` ×2, `nlsat` ×1), each clause's certificate naming its engine and
 // its semantics (fixed-width wraparound vs unbounded). `forge check --engine bv` (with the
 // `bv` shadow-flag plumbing compiled in) drives the per-clause route; z3 (bundled with
@@ -39,7 +43,7 @@ fn mix64(a: u64, b: u64) -> u64
 // block"). Rotate-left-by-1 — `(x << 1) | (x >> 63)` — is a bijection on 64-bit words, so
 // distinct inputs rotate to distinct outputs. A `lemma` carries no `result` and no body;
 // the single `@bv64` clause is a closed QF_BV query over the parameters under `req x != y`,
-// decided directly by the bit-vector route at **L3** with NO author proof effort — the
+// decided directly by the bit-vector route at **L4** with NO author proof effort — the
 // `proof { }` block is empty (the lemma grammar requires the keyword; the QF_BV solver,
 // not the author, discharges it).
 // (`<<`/`>>`/`|` all bind tighter than `!=`, so the rotate inequality needs no outer

--- a/conformance/forge/mix64.th
+++ b/conformance/forge/mix64.th
@@ -1,0 +1,51 @@
+// The `mix64` example (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-2 — the
+// stage-3 bit-vector route's centerpiece). A SINGLE `fn` whose certificate exhibits the
+// RFC's MIX64 shape: wraparound (`@bv64`) clauses and an unbounded clause side by side,
+// each lowered through the engine that grounds it and labeled per clause.
+//
+//   * `ens@bv64  a + b == b + a`          — wraparound-add COMMUTATIVITY. Interpreted
+//                                           over fixed-width (2's-complement) machine
+//                                           semantics, discharged by the bit-vector route
+//                                           (`EngineName::BitVector`, QF_BV via Verus
+//                                           `by(bit_vector)`) at the SOLVER rung **L3**.
+//                                           No `var * var` multiplication, so the default
+//                                           budget profile (a cheap bit-blast).
+//
+//   * `ens@bv64  a ^ b ^ b == a`          — xor SELF-INVERSE (the one-time-pad identity):
+//                                           xoring twice by the same mask is the identity.
+//                                           A genuine machine-semantics fact, decided by
+//                                           the bit-vector route at **L3**.
+//
+//   * `ens       a * 0 == 0`              — the UNBOUNDED zero-fixpoint (multiplicative
+//                                           zero). NOT `@bv`-tagged, so it lowers as before
+//                                           — a relaxable polynomial discharged by the
+//                                           stage-1 nlsat relax route at the kernel-grounded
+//                                           **L4** (`engine: nlsat`).
+//
+// The item certifies at the MIN over the clauses — **L3** (L3, L3, L4). One function, two
+// mechanisms (`bitvector` ×2, `nlsat` ×1), each clause's certificate naming its engine and
+// its semantics (fixed-width wraparound vs unbounded). `forge check --engine bv` (with the
+// `bv` shadow-flag plumbing compiled in) drives the per-clause route; z3 (bundled with
+// verus) decides both the QF_BV and the QF_NRA queries.
+fn mix64(a: u64, b: u64) -> u64
+    req true
+    ens@bv64 a + b == b + a
+    ens@bv64 a ^ b ^ b == a
+    ens a * 0 == 0
+    fx pure
+{ a + b }
+
+// The INJECTIVITY lemma (AC-2: "the injectivity lemma discharges at `@bv64` with no proof
+// block"). Rotate-left-by-1 — `(x << 1) | (x >> 63)` — is a bijection on 64-bit words, so
+// distinct inputs rotate to distinct outputs. A `lemma` carries no `result` and no body;
+// the single `@bv64` clause is a closed QF_BV query over the parameters under `req x != y`,
+// decided directly by the bit-vector route at **L3** with NO author proof effort — the
+// `proof { }` block is empty (the lemma grammar requires the keyword; the QF_BV solver,
+// not the author, discharges it).
+// (`<<`/`>>`/`|` all bind tighter than `!=`, so the rotate inequality needs no outer
+// parens — and a `@bvN` clause cannot open with `(`, which the REQ-1 tag grammar reads as
+// the `(nowrap)` modifier.)
+lemma rotl1_injective(x: u64, y: u64)
+    req x != y
+    ens@bv64 x << 1 | x >> 63 != y << 1 | y >> 63
+    proof { }

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -32,6 +32,16 @@ serde_json = "1"
 # REQ-1).
 sha2 = "0.10"
 
+# Stage-3 REQ-2 (`.design/stage3-bv-reconstruction.md`): the `@bv` shadow-flag
+# plumbing. Enabling forge's `bv` feature turns on `thermite-syntax/bv` so the
+# parser accepts `ens@bvN` / `@bvN(nowrap)` tags (REQ-1's structural lock), making the
+# `--engine bv` bit-vector route reachable end to end. NON-DEFAULT and loud: a release
+# build without it cannot parse the tag (gate G3, R-BV-1). The route code is always
+# compiled (it reads the always-present `Clause.bv: Option<BvTag>`), so only the parse
+# gate is feature-conditional.
+[features]
+bv = ["thermite-syntax/bv"]
+
 # epic #60 (self-verification, REQ-7/REQ-8): the Verus-verified soundness-critical
 # core. A DEV-dependency only — the in-module `verus_anchor` tests in `degrade.rs`
 # (the ladder anti-cheat decision) and `sandbox.rs` (the seccomp allowlist

--- a/forge/src/bitvector.rs
+++ b/forge/src/bitvector.rs
@@ -1,0 +1,955 @@
+//! `forge/src/bitvector.rs` — the QF_BV lowering for `@bv`-tagged clauses
+//! (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-2 / AC-3, stage-3 increment).
+//!
+//! A `@bvN`-tagged clause is interpreted over fixed-width wraparound (machine)
+//! semantics: every variable is an `N`-bit bit-vector and every operator is its
+//! `2`'s-complement / unsigned machine counterpart, so addition, multiplication
+//! and the bitwise/shift operators all overflow exactly as the hardware does. The
+//! clause is decided by Verus's `by(bit_vector)` mode — which is, mechanically, a
+//! QF_BV solver query (Z3's bit-blaster). Following the stage-1 [`crate::engine::
+//! NlsatEngine`] precedent (which reaches Z3's nlsat tactic *directly* for QF_NRA
+//! rather than through a Verus VC round-trip), this engine renders the clause to an
+//! SMT-LIB2 `QF_BV` query and runs Z3 directly: the same decision procedure
+//! `by(bit_vector)` invokes, reached as its own [`crate::engine::EngineName::
+//! BitVector`] route so a mixed-mechanism function (the RFC's `mix64` shape — two
+//! `@bv64` clauses beside one unbounded clause) attributes each clause to the engine
+//! that grounds it.
+//!
+//! ## The three deliverables of REQ-2
+//!
+//! - **The lowering.** [`render_bv_prop`] / [`render_bv_term`] translate the
+//!   arithmetic / comparison / bitwise / boolean clause fragment into QF_BV at the
+//!   tag's width. A clause valid for *every* `N`-bit assignment (the negation is
+//!   `unsat`) is [`BvOutcome::Proved`]; a satisfiable negation yields a
+//!   [`BvOutcome::Counterexample`] carrying the witnessing **bit pattern** per
+//!   variable (REQ-2 / AC-3 — "bit-level `Counterexample` with the bit pattern
+//!   attached").
+//! - **The dedicated 64-bit multiplier budget profile.** A 64-bit bit-vector
+//!   *multiplication between two non-constant terms* is the known QF_BV cost cliff
+//!   (full 64×64 bit-blasting). [`BvBudgetProfile::for_query`] routes such a query
+//!   through a deliberately bounded `rlimit`/timeout profile so an over-budget
+//!   multiplier query is reported as [`BvOutcome::Timeout`] under the named profile —
+//!   **never** a silent `unknown` and never a silent downgrade (REQ-2 / AC-3).
+//! - **The verdict plumbing.** The engine implements the four-slot [`crate::engine::
+//!   Engine`] interface; the rich [`BvOutcome`] (which the three-arm `Verdict` cannot
+//!   represent — a budget `Timeout` is distinct from an undecided `Unknown`) is the
+//!   route's real entry point, mapped down for the generic trait caller.
+//!
+//! A `@bv` clause certifies at the SOLVER rung [`crate::manifest::Level::L3`]: its
+//! trust base is the QF_BV decision procedure. Kernel-grounding the bit-vector
+//! discharge (proof reconstruction) is REQ-7/REQ-8, a strictly later increment; this
+//! module is the lowering only.
+
+use std::collections::BTreeMap;
+
+use thermite_syntax::{BinOp, BvWidth, Expr, UnaryOp};
+
+/// The outcome of a `@bv` clause discharge over fixed-width QF_BV semantics
+/// (`.design/stage3-bv-reconstruction.md` REQ-2). Richer than the three-arm
+/// [`crate::engine::Verdict`]: a budget [`BvOutcome::Timeout`] (the 64-bit multiplier
+/// cost cliff) is held DISTINCT from an honest [`BvOutcome::Unknown`] skip (Z3 absent
+/// / the clause outside the renderable fragment), so the route never launders the
+/// multiplier cliff into a silent `unknown` (AC-3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BvOutcome {
+    /// `unsat` over QF_BV: the clause holds for every `N`-bit assignment satisfying
+    /// the precondition → the clause is machine-valid at width `N` → certify at the
+    /// solver rung (L3).
+    Proved,
+    /// `sat` over QF_BV: a concrete `N`-bit assignment falsifies the clause — a
+    /// bit-level countermodel. Carries the witnessing bit pattern per variable
+    /// (the AC-3 "bit pattern in the certificate").
+    Counterexample {
+        /// The falsifying bit pattern, one entry per declared variable.
+        bits: Vec<BvBitPattern>,
+    },
+    /// The query exhausted its dedicated budget (the 64-bit multiplier cost cliff,
+    /// AC-3). Carries the named budget profile and the Z3 detail; reported as
+    /// `Timeout`, NEVER `unknown` and never a silent downgrade.
+    Timeout {
+        /// The budget profile that bounded the query (e.g. `bv64-multiplier`).
+        profile: String,
+        /// The Z3 rlimit/timeout detail (the captured signal head).
+        detail: String,
+    },
+    /// An honest skip: Z3 is absent, the clause is outside the renderable QF_BV
+    /// fragment, or the query did not render. NEVER a false verdict — and NEVER the
+    /// image of a budget exhaustion (that is [`BvOutcome::Timeout`]).
+    Unknown(String),
+}
+
+/// One variable's falsifying bit pattern in a QF_BV countermodel
+/// (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-3). Carries the width, the
+/// numeric value, and the rendered binary + hex bit strings so the certificate shows
+/// the actual bits the hardware would hold.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BvBitPattern {
+    /// The variable name.
+    pub var: String,
+    /// The bit width (`N` of the `@bvN` tag).
+    pub width: u32,
+    /// The numeric value of the bit pattern (`value < 2^width`).
+    pub value: u128,
+    /// The binary rendering, zero-padded to `width` bits (e.g. `0b0000…0011`).
+    pub bits: String,
+}
+
+impl BvBitPattern {
+    /// Render the bit pattern as a single human line (the certificate diagnostic
+    /// fragment): `a = 0b…0011 (0x…3, bv64)`. Deterministic (R-CODE-5).
+    #[must_use]
+    pub fn render(&self) -> String {
+        let hex_width = self.width.div_ceil(4) as usize;
+        format!(
+            "{} = {} (0x{:0width$x}, bv{})",
+            self.var,
+            self.bits,
+            self.value,
+            self.width,
+            width = hex_width
+        )
+    }
+}
+
+/// A QF_BV budget profile (`.design/stage3-bv-reconstruction.md` REQ-2 — the
+/// dedicated 64-bit multiplier profile). The `rlimit` bounds Z3's bit-blasting work
+/// and `timeout_secs` is the wall-clock cap; an over-budget query returns `unknown`
+/// from Z3 WITH a budget set, which the engine reports as [`BvOutcome::Timeout`]
+/// (never a bare `unknown`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BvBudgetProfile {
+    /// The profile name (recorded in the `Timeout` verdict).
+    pub name: String,
+    /// The Z3 `rlimit` (resource budget). `0` = unbounded (the default profile).
+    pub rlimit: u64,
+    /// The wall-clock timeout in seconds (the `-T:` flag).
+    pub timeout_secs: u64,
+}
+
+impl BvBudgetProfile {
+    /// The default profile: generous, for the cheap fragment (bitwise / shift / add /
+    /// non-64-bit multiply). A scalar QF_BV query bit-blasts cheaply, so the default
+    /// is unbounded `rlimit` with the same 10s wall cap the nlsat route uses.
+    #[must_use]
+    pub fn default_profile() -> Self {
+        BvBudgetProfile {
+            name: "bv-default".to_string(),
+            rlimit: 0,
+            timeout_secs: 10,
+        }
+    }
+
+    /// The dedicated 64-bit multiplier profile (REQ-2 / AC-3): a 64×64 bit-blast is
+    /// the QF_BV cost cliff, so a 64-bit multiplication between two non-constant
+    /// terms is bounded by a tight `rlimit` and a short wall cap. An over-budget
+    /// multiplier query then returns `unknown` (rlimit/timeout) and is reported as
+    /// [`BvOutcome::Timeout`] under THIS profile — the loud, non-silent failure REQ-2
+    /// requires.
+    #[must_use]
+    pub fn multiplier64_profile() -> Self {
+        BvBudgetProfile {
+            // A deliberately bounded resource budget. 64×64 multiplication
+            // bit-blasts into a quadratic adder network whose validity queries
+            // routinely exceed a modest rlimit; the bound makes the cliff a
+            // deterministic `Timeout` rather than an unbounded hang.
+            name: "bv64-multiplier".to_string(),
+            rlimit: 2_000_000,
+            timeout_secs: 5,
+        }
+    }
+
+    /// Select the budget profile for a clause query (`.design/stage3-bv-reconstruction.md`
+    /// REQ-2). The dedicated 64-bit multiplier profile applies iff the tag width is 64
+    /// AND the clause contains a multiplication whose two operands are both
+    /// non-constant (a genuine 64-bit multiplier, the cost cliff); every other query
+    /// — including a multiply by a literal, which bit-blasts as a cheap shift/add —
+    /// takes the default profile.
+    #[must_use]
+    pub fn for_query(width: BvWidth, exprs: &[&Expr]) -> Self {
+        if width == BvWidth::W64 && exprs.iter().any(|e| contains_variable_multiply(e)) {
+            Self::multiplier64_profile()
+        } else {
+            Self::default_profile()
+        }
+    }
+}
+
+/// Does `e` contain a multiplication whose BOTH operands are non-constant
+/// (`.design/stage3-bv-reconstruction.md` REQ-2 — the 64-bit multiplier cost-cliff
+/// detector)? A `var * var` (or `var * (expr-with-a-var)`) is the expensive 64×64
+/// bit-blast; a `var * 8` is a cheap shift/add and does NOT trip the dedicated
+/// profile.
+#[must_use]
+pub fn contains_variable_multiply(e: &Expr) -> bool {
+    match e {
+        Expr::Binary {
+            op: BinOp::Mul,
+            lhs,
+            rhs,
+        } if !is_constant(lhs) && !is_constant(rhs) => true,
+        Expr::Binary { lhs, rhs, .. } => {
+            contains_variable_multiply(lhs) || contains_variable_multiply(rhs)
+        }
+        Expr::Unary { expr, .. } => contains_variable_multiply(expr),
+        _ => false,
+    }
+}
+
+/// Is `e` a constant (a literal, or an arithmetic combination only of literals)
+/// over the renderable fragment? Used by the cost-cliff detector to tell a cheap
+/// `var * 8` (shift/add) from an expensive `var * var` (full multiplier).
+fn is_constant(e: &Expr) -> bool {
+    match e {
+        Expr::IntLit { .. } | Expr::BoolLit(_) => true,
+        Expr::Path(_) => false,
+        Expr::Binary { lhs, rhs, .. } => is_constant(lhs) && is_constant(rhs),
+        Expr::Unary { expr, .. } => is_constant(expr),
+        _ => false,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The QF_BV lowering (REQ-2 — render the clause fragment at a fixed width).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Render an arithmetic / bitwise TERM to an SMT-LIB2 `(_ BitVec width)` expression
+/// at a fixed `width` (`.design/stage3-bv-reconstruction.md` REQ-2). Every operator is
+/// its fixed-width machine counterpart, so the encoding is faithful to wraparound
+/// semantics: `+`→`bvadd`, `*`→`bvmul`, `-`→`bvsub`, `/`→`bvudiv`, `%`→`bvurem`,
+/// `<<`→`bvshl`, `>>`→`bvlshr` (unsigned — the scalar types are all unsigned), the
+/// bitwise ops to `bvand`/`bvor`/`bvxor`, and prefix `!` (on a term) to `bvnot`. An
+/// integer literal renders as the width-`N` bit-vector constant. `Err` names the
+/// out-of-fragment construct (an honest skip reason, never a silent mis-render).
+pub fn render_bv_term(e: &Expr, width: u32) -> Result<String, String> {
+    match e {
+        Expr::IntLit { value, .. } => Ok(format!("(_ bv{} {width})", value % (modulus(width)))),
+        Expr::Path(segs) if segs.len() == 1 => Ok(segs[0].clone()),
+        Expr::Binary { op, lhs, rhs } => {
+            let sym = match op {
+                BinOp::Add => "bvadd",
+                BinOp::Sub => "bvsub",
+                BinOp::Mul => "bvmul",
+                BinOp::Div => "bvudiv",
+                BinOp::Rem => "bvurem",
+                BinOp::Shl => "bvshl",
+                BinOp::Shr => "bvlshr",
+                BinOp::BitAnd => "bvand",
+                BinOp::BitOr => "bvor",
+                BinOp::BitXor => "bvxor",
+                other => {
+                    return Err(format!(
+                        "`{other:?}` is not a QF_BV term operator (it is a comparison/connective)"
+                    ))
+                }
+            };
+            let l = render_bv_term(lhs, width)?;
+            let r = render_bv_term(rhs, width)?;
+            Ok(format!("({sym} {l} {r})"))
+        }
+        Expr::Unary {
+            op: UnaryOp::Not,
+            expr,
+        } => Ok(format!("(bvnot {})", render_bv_term(expr, width)?)),
+        Expr::Cast { expr, .. } => render_bv_term(expr, width),
+        other => Err(format!(
+            "`{other:?}` is outside the QF_BV term fragment (only integer literals, \
+             single-segment variables, the arithmetic/bitwise/shift operators, and `!` \
+             lower to bit-vectors)"
+        )),
+    }
+}
+
+/// Render a PROPOSITION to an SMT-LIB2 `Bool` over fixed-width bit-vectors
+/// (`.design/stage3-bv-reconstruction.md` REQ-2). Comparisons over the unsigned
+/// scalar types map to the unsigned bit-vector relations (`<`→`bvult`, `<=`→`bvule`,
+/// `>`→`bvugt`, `>=`→`bvuge`); `==`→`=`, `!=`→`(not (= …))`; the connectives to
+/// `and`/`or`/`not`. `Err` names the out-of-fragment construct (an honest skip).
+pub fn render_bv_prop(e: &Expr, width: u32) -> Result<String, String> {
+    match e {
+        Expr::BoolLit(b) => Ok(if *b { "true" } else { "false" }.to_string()),
+        Expr::Binary { op, lhs, rhs } => match op {
+            BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge => {
+                let l = render_bv_term(lhs, width)?;
+                let r = render_bv_term(rhs, width)?;
+                let rel = match op {
+                    BinOp::Eq | BinOp::Ne => "=",
+                    BinOp::Lt => "bvult",
+                    BinOp::Le => "bvule",
+                    BinOp::Gt => "bvugt",
+                    BinOp::Ge => "bvuge",
+                    _ => unreachable!("the outer match fixed the comparison set"),
+                };
+                let cmp = format!("({rel} {l} {r})");
+                Ok(if matches!(op, BinOp::Ne) {
+                    format!("(not {cmp})")
+                } else {
+                    cmp
+                })
+            }
+            BinOp::And => Ok(format!(
+                "(and {} {})",
+                render_bv_prop(lhs, width)?,
+                render_bv_prop(rhs, width)?
+            )),
+            BinOp::Or => Ok(format!(
+                "(or {} {})",
+                render_bv_prop(lhs, width)?,
+                render_bv_prop(rhs, width)?
+            )),
+            other => Err(format!(
+                "`{other:?}` is an arithmetic/bitwise operator, not a proposition — a \
+                 `@bv` clause must be a comparison or a boolean connective at its root"
+            )),
+        },
+        Expr::Unary {
+            op: UnaryOp::Not,
+            expr,
+        } => Ok(format!("(not {})", render_bv_prop(expr, width)?)),
+        other => Err(format!(
+            "`{other:?}` is outside the QF_BV proposition fragment (a `@bv` clause is a \
+             comparison / boolean connective over the bit-vector term fragment)"
+        )),
+    }
+}
+
+/// `2^width` as a `u128` (`width ≤ 64`, so this never overflows). The literal-reduction
+/// modulus for [`render_bv_term`].
+fn modulus(width: u32) -> u128 {
+    1u128 << width
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The engine (REQ-2 — the BitVector route's discharge entry point).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The QF_BV bit-vector engine (`.design/stage3-bv-reconstruction.md` REQ-2): the
+/// [`crate::engine::EngineName::BitVector`] route. Stateless beyond Z3 discovery (the
+/// route passes the rendered clause pieces), mirroring the stateless shape the
+/// stage-1 [`crate::engine::NlsatEngine`] exposes through [`BitVectorEngine::
+/// discharge_bv`].
+#[derive(Debug, Clone, Default)]
+pub struct BitVectorEngine;
+
+impl BitVectorEngine {
+    /// Construct a BitVector engine. Production consumer: the `--engine bv` per-clause
+    /// route (`check::bv_check`).
+    #[must_use]
+    pub fn new() -> Self {
+        BitVectorEngine
+    }
+
+    /// Is `z3` invocable? The skip-guard for the live BitVector tests — CI shards
+    /// without z3 SKIP rather than fail (the sibling `NlsatEngine::z3_present`
+    /// precedent). No production caller — [`BitVectorEngine::run_z3`] handles
+    /// z3-absence inline (a graceful [`BvOutcome::Unknown`] skip).
+    #[allow(
+        dead_code,
+        reason = "REQ-2 live-test skip-guard: the in-crate live BitVector tests call it \
+                  (CI shards without z3 SKIP); discharge_bv handles z3-absence inline in \
+                  production"
+    )]
+    #[must_use]
+    pub fn z3_present() -> bool {
+        std::process::Command::new("z3")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Discharge one `@bvN` clause over fixed-width QF_BV semantics
+    /// (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-2 / AC-3). The query asserts
+    /// the precondition (if any) and the NEGATION of the clause over width-`N`
+    /// bit-vectors, then asks Z3:
+    ///
+    /// - `unsat` → [`BvOutcome::Proved`] (machine-valid at width `N`);
+    /// - `sat` → [`BvOutcome::Counterexample`] carrying the witnessing bit pattern;
+    /// - `unknown` WITH a budget set → [`BvOutcome::Timeout`] under the named profile
+    ///   (the 64-bit multiplier cliff — never a bare `unknown`);
+    /// - Z3 absent / unrenderable clause → [`BvOutcome::Unknown`] (an honest skip).
+    ///
+    /// `vars` are the variables in scope (parameters, plus `result` for a function
+    /// whose clause has already had `result` grounded by the body); `req` is the
+    /// optional precondition.
+    #[must_use]
+    pub fn discharge_bv(
+        &self,
+        vars: &[String],
+        req: Option<&Expr>,
+        clause: &Expr,
+        width: BvWidth,
+    ) -> BvOutcome {
+        let n = width.bits();
+        // Render the clause first — an unrenderable clause is an honest skip, never a
+        // false verdict (and never a spurious counterexample from a dropped guard).
+        let clause_smt = match render_bv_prop(clause, n) {
+            Ok(s) => s,
+            Err(reason) => {
+                return BvOutcome::Unknown(format!(
+                    "the `@bv{n}` clause did not render to QF_BV: {reason}"
+                ))
+            }
+        };
+        // The precondition becomes a hypothesis. If it is present but unrenderable we
+        // SKIP (Unknown) rather than drop it — dropping a guard could mint a spurious
+        // counterexample at an assignment the precondition rules out (R-CODE-4).
+        let req_smt = match req {
+            Some(r) => match render_bv_prop(r, n) {
+                Ok(s) => Some(s),
+                Err(reason) => {
+                    return BvOutcome::Unknown(format!(
+                        "the `@bv{n}` clause's precondition did not render to QF_BV (skipping \
+                         rather than dropping the guard): {reason}"
+                    ))
+                }
+            },
+            None => None,
+        };
+
+        let profile = BvBudgetProfile::for_query(
+            width,
+            &req.into_iter()
+                .chain(std::iter::once(clause))
+                .collect::<Vec<_>>(),
+        );
+        let query = build_bv_query(vars, req_smt.as_deref(), &clause_smt, n, &profile);
+
+        match Self::run_z3(&query, profile.timeout_secs) {
+            Ok((result, model)) => match result.as_str() {
+                "unsat" => BvOutcome::Proved,
+                "sat" => BvOutcome::Counterexample {
+                    bits: parse_bv_model(&model, vars, n),
+                },
+                // `unknown` under a bounded profile is the budget cliff (AC-3): a
+                // resource-limited multiplier query. Reported as `Timeout`, NEVER a
+                // bare `unknown`. The default profile is unbounded, so an `unknown`
+                // there is a genuine (rare for decidable QF_BV) solver event we still
+                // surface as a wall-timeout rather than a false verdict.
+                "unknown" => BvOutcome::Timeout {
+                    profile: profile.name.clone(),
+                    detail: format!(
+                        "Z3 returned `unknown` under the `{}` budget profile (rlimit {}, \
+                         {}s) — the QF_BV query exhausted its dedicated budget (the 64-bit \
+                         multiplier cost cliff); reported as Timeout, never a silent unknown",
+                        profile.name, profile.rlimit, profile.timeout_secs
+                    ),
+                },
+                other => BvOutcome::Unknown(format!(
+                    "Z3 returned an unexpected result `{other}` on the `@bv{n}` query"
+                )),
+            },
+            Err(reason) => BvOutcome::Unknown(reason),
+        }
+    }
+
+    /// Run Z3 over an SMT-LIB2 `query` (fed on stdin), returning `(result, model)`.
+    /// `Err` on Z3 absent / spawn failure / no result token (an honest skip reason,
+    /// never a silent success — R-CODE-4). Mirrors [`crate::engine::NlsatEngine`]'s
+    /// `run_z3`, parameterized by the budget profile's wall timeout.
+    fn run_z3(query: &str, timeout_secs: u64) -> Result<(String, String), String> {
+        use std::io::Write as _;
+        use std::process::{Command, Stdio};
+        let mut child = Command::new("z3")
+            .arg("-smt2")
+            .arg("-in")
+            .arg(format!("-T:{timeout_secs}"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    "z3 is not on PATH (the BitVector QF_BV route needs the bundled z3) — \
+                     skipping"
+                        .to_string()
+                } else {
+                    format!("could not spawn z3: {e}")
+                }
+            })?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(query.as_bytes())
+                .map_err(|e| format!("could not write the QF_BV query to z3: {e}"))?;
+        }
+        let out = child
+            .wait_with_output()
+            .map_err(|e| format!("z3 did not complete: {e}"))?;
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let result = stdout
+            .split_whitespace()
+            .next()
+            .map(str::to_string)
+            .ok_or_else(|| {
+                format!(
+                    "z3 produced no result token (stderr head: {})",
+                    String::from_utf8_lossy(&out.stderr)
+                        .chars()
+                        .take(200)
+                        .collect::<String>()
+                )
+            })?;
+        Ok((result, stdout.into_owned()))
+    }
+}
+
+/// Build the SMT-LIB2 `QF_BV` query whose satisfiability decides a `@bvN` clause
+/// (`.design/stage3-bv-reconstruction.md` REQ-2). Declares each variable as an
+/// `N`-bit bit-vector, sets the budget profile's `rlimit` (when bounded — the 64-bit
+/// multiplier cliff), asserts the precondition and the NEGATION of the clause, and
+/// asks for a model (the bit-pattern witness on `sat`).
+#[must_use]
+pub fn build_bv_query(
+    vars: &[String],
+    req_smt: Option<&str>,
+    clause_smt: &str,
+    width: u32,
+    profile: &BvBudgetProfile,
+) -> String {
+    let mut s = String::new();
+    s.push_str("(set-logic QF_BV)\n");
+    // A bounded profile's rlimit is the 64-bit multiplier budget (AC-3): an
+    // over-budget query returns `unknown`, reported as `Timeout`.
+    if profile.rlimit > 0 {
+        s.push_str(&format!("(set-option :rlimit {})\n", profile.rlimit));
+    }
+    for v in vars {
+        s.push_str(&format!("(declare-const {v} (_ BitVec {width}))\n"));
+    }
+    if let Some(req) = req_smt {
+        s.push_str(&format!("(assert {req})\n"));
+    }
+    // The clause is valid at width N iff `req ∧ ¬clause` is unsatisfiable.
+    s.push_str(&format!("(assert (not {clause_smt}))\n"));
+    s.push_str("(check-sat)\n");
+    s.push_str("(get-model)\n");
+    s
+}
+
+/// Parse Z3's `(get-model)` output into the falsifying bit pattern per variable
+/// (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-3). Extracts each `(define-fun
+/// NAME () (_ BitVec W) VALUE)` and decodes VALUE — a hex `#x…`, a binary `#b…`, or a
+/// `(_ bvK W)` literal — into a [`BvBitPattern`]. A variable Z3 omits (unconstrained)
+/// is recorded as all-zeros (a concrete representative of the free choice).
+#[must_use]
+pub fn parse_bv_model(model: &str, vars: &[String], width: u32) -> Vec<BvBitPattern> {
+    let parsed = collect_define_funs(model);
+    vars.iter()
+        .map(|v| {
+            let value = parsed.get(v).copied().unwrap_or(0) % modulus(width);
+            BvBitPattern {
+                var: v.clone(),
+                width,
+                value,
+                bits: render_bits(value, width),
+            }
+        })
+        .collect()
+}
+
+/// Collect the `(define-fun NAME () (_ BitVec W) VALUE)` bindings of a Z3 model into a
+/// `name → value` map. The value decoder handles the three Z3 bit-vector renderings
+/// (`#x…` hex, `#b…` binary, `(_ bvK W)` literal). A binding whose value does not
+/// decode is skipped (the variable then reads as all-zeros — a conservative concrete
+/// witness, never a panic, R-CODE-2).
+fn collect_define_funs(model: &str) -> BTreeMap<String, u128> {
+    let mut out = BTreeMap::new();
+    let needle = "(define-fun ";
+    let mut search = 0;
+    while let Some(rel) = model[search..].find(needle) {
+        let open = search + rel;
+        let after = open + needle.len();
+        let rest = &model[after..];
+        let name_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+        let name = rest[..name_end].trim().to_string();
+        match matching_paren(model, open) {
+            Some(close) => {
+                let inner = &model[after..close];
+                if let Some(value) = decode_bv_value(inner) {
+                    if !name.is_empty() {
+                        out.insert(name, value);
+                    }
+                }
+                search = close + 1;
+            }
+            None => search = after,
+        }
+    }
+    out
+}
+
+/// Decode the VALUE of a `(define-fun NAME () (_ BitVec W) VALUE)` body into a
+/// numeric bit pattern. The body is `NAME () (_ BitVec W) VALUE`; the value is the
+/// trailing token(s) after the `(_ BitVec W)` sort. Handles `#x…`, `#b…`, and the
+/// `(_ bvK W)` literal form.
+fn decode_bv_value(inner: &str) -> Option<u128> {
+    // Anchor past the declared `(_ BitVec W)` sort; the remainder is the value.
+    let value_text = match inner.find("BitVec") {
+        Some(pos) => {
+            let after_sort = &inner[pos + "BitVec".len()..];
+            // skip the width and the closing `)` of the sort
+            match after_sort.find(')') {
+                Some(rp) => after_sort[rp + 1..].trim(),
+                None => after_sort.trim(),
+            }
+        }
+        None => inner.trim(),
+    };
+    parse_bv_literal(value_text)
+}
+
+/// Parse a single Z3 bit-vector literal (`#x3`, `#b0011`, or `(_ bv3 64)`) to a
+/// `u128`. `None` on an unrecognized form (the variable then reads as all-zeros).
+fn parse_bv_literal(text: &str) -> Option<u128> {
+    let text = text.trim();
+    if let Some(hex) = text.strip_prefix("#x") {
+        return u128::from_str_radix(hex.trim(), 16).ok();
+    }
+    if let Some(bin) = text.strip_prefix("#b") {
+        return u128::from_str_radix(bin.trim(), 2).ok();
+    }
+    if let Some(rest) = text.strip_prefix("(_") {
+        // `(_ bvK W)` — take the `bvK` token.
+        let tok = rest.split_whitespace().next()?;
+        let k = tok.strip_prefix("bv")?;
+        return k.parse::<u128>().ok();
+    }
+    None
+}
+
+/// The index of the `)` matching the `(` at `open` in `s`, or `None` if unbalanced (a
+/// defensive skip, never a panic — R-CODE-2). Mirrors the nlsat model parser.
+fn matching_paren(s: &str, open: usize) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    for (i, &b) in bytes.iter().enumerate().skip(open) {
+        if b == b'(' {
+            depth += 1;
+        } else if b == b')' {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+/// Render a numeric value as a zero-padded `0b…` binary string of exactly `width`
+/// bits (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-3 — the bit pattern).
+fn render_bits(value: u128, width: u32) -> String {
+    let mut bits = String::with_capacity(width as usize + 2);
+    bits.push_str("0b");
+    for i in (0..width).rev() {
+        bits.push(if (value >> i) & 1 == 1 { '1' } else { '0' });
+    }
+    bits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use thermite_syntax::{BinOp, Expr};
+
+    fn var(name: &str) -> Expr {
+        Expr::Path(vec![name.to_string()])
+    }
+
+    fn lit(value: u128) -> Expr {
+        Expr::IntLit {
+            value,
+            raw: value.to_string(),
+        }
+    }
+
+    fn bin(op: BinOp, l: Expr, r: Expr) -> Expr {
+        Expr::Binary {
+            op,
+            lhs: Box::new(l),
+            rhs: Box::new(r),
+        }
+    }
+
+    #[test]
+    fn term_lowers_arithmetic_and_bitwise_to_fixed_width_ops() {
+        // a + b * 2  →  (bvadd a (bvmul b (_ bv2 64)))
+        let e = bin(BinOp::Add, var("a"), bin(BinOp::Mul, var("b"), lit(2)));
+        assert_eq!(
+            render_bv_term(&e, 64).unwrap(),
+            "(bvadd a (bvmul b (_ bv2 64)))"
+        );
+        // a ^ b & c  parses as (a ^ b) & c per precedence in the AST we are handed;
+        // here we build it explicitly to pin the bitwise mnemonics.
+        let e = bin(BinOp::BitXor, var("a"), var("b"));
+        assert_eq!(render_bv_term(&e, 32).unwrap(), "(bvxor a b)");
+        // prefix ! on a term is bitwise-not.
+        let e = Expr::Unary {
+            op: UnaryOp::Not,
+            expr: Box::new(var("a")),
+        };
+        assert_eq!(render_bv_term(&e, 8).unwrap(), "(bvnot a)");
+    }
+
+    #[test]
+    fn literal_reduces_modulo_width() {
+        // 256 ≡ 0 (mod 2^8); 255 stays.
+        assert_eq!(render_bv_term(&lit(256), 8).unwrap(), "(_ bv0 8)");
+        assert_eq!(render_bv_term(&lit(255), 8).unwrap(), "(_ bv255 8)");
+    }
+
+    #[test]
+    fn prop_uses_unsigned_relations_and_connectives() {
+        // a <= b  →  unsigned bvule (the scalar types are all unsigned).
+        let e = bin(BinOp::Le, var("a"), var("b"));
+        assert_eq!(render_bv_prop(&e, 64).unwrap(), "(bvule a b)");
+        // a != b  →  (not (= a b)).
+        let e = bin(BinOp::Ne, var("a"), var("b"));
+        assert_eq!(render_bv_prop(&e, 64).unwrap(), "(not (= a b))");
+        // a == b && c < d  →  (and (= a b) (bvult c d)).
+        let e = bin(
+            BinOp::And,
+            bin(BinOp::Eq, var("a"), var("b")),
+            bin(BinOp::Lt, var("c"), var("d")),
+        );
+        assert_eq!(render_bv_prop(&e, 64).unwrap(), "(and (= a b) (bvult c d))");
+    }
+
+    #[test]
+    fn out_of_fragment_term_and_prop_are_honest_errors() {
+        // A method call is outside the term fragment.
+        let mc = Expr::MethodCall {
+            receiver: Box::new(var("a")),
+            name: "len".to_string(),
+            args: vec![],
+        };
+        assert!(render_bv_term(&mc, 64).is_err());
+        // A bare arithmetic term is not a proposition.
+        let e = bin(BinOp::Add, var("a"), var("b"));
+        assert!(render_bv_prop(&e, 64).is_err());
+    }
+
+    #[test]
+    fn cost_cliff_detector_distinguishes_var_mul_from_literal_mul() {
+        // var * var → trips the 64-bit multiplier profile.
+        assert!(contains_variable_multiply(&bin(
+            BinOp::Mul,
+            var("a"),
+            var("b")
+        )));
+        // var * 8 → cheap shift/add, does NOT trip.
+        assert!(!contains_variable_multiply(&bin(
+            BinOp::Mul,
+            var("a"),
+            lit(8)
+        )));
+        // nested var*var inside an add still trips.
+        assert!(contains_variable_multiply(&bin(
+            BinOp::Add,
+            var("c"),
+            bin(BinOp::Mul, var("a"), var("b"))
+        )));
+    }
+
+    #[test]
+    fn budget_profile_selection_is_width64_and_variable_multiply() {
+        let var_mul = bin(BinOp::Eq, bin(BinOp::Mul, var("a"), var("b")), var("c"));
+        // width 64 + var*var → the dedicated multiplier profile (bounded rlimit).
+        let p = BvBudgetProfile::for_query(BvWidth::W64, &[&var_mul]);
+        assert_eq!(p.name, "bv64-multiplier");
+        assert!(p.rlimit > 0, "the multiplier profile is rlimit-bounded");
+        // width 32 + var*var → default profile (the cliff is the 64-bit case).
+        let p = BvBudgetProfile::for_query(BvWidth::W32, &[&var_mul]);
+        assert_eq!(p.name, "bv-default");
+        // width 64 + a literal multiply → default profile (cheap shift/add).
+        let lit_mul = bin(BinOp::Eq, bin(BinOp::Mul, var("a"), lit(8)), var("c"));
+        let p = BvBudgetProfile::for_query(BvWidth::W64, &[&lit_mul]);
+        assert_eq!(p.name, "bv-default");
+    }
+
+    #[test]
+    fn query_declares_bitvecs_negates_clause_and_sets_rlimit_when_bounded() {
+        let q = build_bv_query(
+            &["a".to_string(), "b".to_string()],
+            None,
+            "(= (bvmul a b) (bvmul b a))",
+            64,
+            &BvBudgetProfile::multiplier64_profile(),
+        );
+        assert!(q.contains("(set-logic QF_BV)"));
+        assert!(
+            q.contains("(set-option :rlimit 2000000)"),
+            "bounded profile sets rlimit"
+        );
+        assert!(q.contains("(declare-const a (_ BitVec 64))"));
+        assert!(q.contains("(assert (not (= (bvmul a b) (bvmul b a))))"));
+        assert!(q.contains("(check-sat)"));
+        // The default (unbounded) profile sets NO rlimit.
+        let q = build_bv_query(
+            &["a".to_string()],
+            None,
+            "(= a a)",
+            32,
+            &BvBudgetProfile::default_profile(),
+        );
+        assert!(!q.contains("rlimit"), "the default profile is unbounded");
+    }
+
+    #[test]
+    fn model_parser_decodes_hex_binary_and_bv_literal_to_bit_patterns() {
+        let model = "(model\n  (define-fun a () (_ BitVec 64) #x0000000000000003)\n  \
+                     (define-fun b () (_ BitVec 8) #b00000101)\n  \
+                     (define-fun c () (_ BitVec 64) (_ bv7 64))\n)";
+        let bits = parse_bv_model(
+            model,
+            &["a".to_string(), "b".to_string(), "c".to_string()],
+            64,
+        );
+        assert_eq!(bits[0].var, "a");
+        assert_eq!(bits[0].value, 3);
+        assert!(
+            bits[0].bits.ends_with("0011"),
+            "a's low bits are 0011: {}",
+            bits[0].bits
+        );
+        assert_eq!(bits[1].value, 5, "b = #b00000101 = 5");
+        assert_eq!(bits[2].value, 7, "c = (_ bv7 64) = 7");
+        // The render line carries the bits + hex + width.
+        assert!(bits[0].render().contains("bv64"));
+        assert!(bits[0].render().contains("0x"));
+    }
+
+    #[test]
+    fn unconstrained_variable_reads_as_all_zeros() {
+        // A variable Z3 omits from the model is a concrete all-zeros witness.
+        let bits = parse_bv_model("(model)", &["z".to_string()], 16);
+        assert_eq!(bits[0].value, 0);
+        assert_eq!(bits[0].bits, "0b0000000000000000");
+    }
+
+    #[test]
+    fn render_bits_is_zero_padded_to_width() {
+        assert_eq!(render_bits(3, 8), "0b00000011");
+        assert_eq!(render_bits(0, 4), "0b0000");
+    }
+
+    // ── Live QF_BV tests (REQ-2 / AC-2 / AC-3). z3 ships beside the verus
+    // distribution; a CI shard without z3 SKIPS rather than fails (the nlsat-route
+    // precedent). These exercise `discharge_bv` directly against the real solver.
+
+    fn bv_skip() -> bool {
+        if BitVectorEngine::z3_present() {
+            return false;
+        }
+        eprintln!("SKIP: z3 absent — the live QF_BV BitVector tests need the bundled z3.");
+        true
+    }
+
+    /// AC-2 (engine level): a machine-valid `@bv64` clause is `Proved`. `a + b == b + a`
+    /// is the wraparound-add commutativity the bit-vector route discharges with no proof
+    /// block.
+    #[test]
+    fn live_machine_valid_clause_is_proved() {
+        if bv_skip() {
+            return;
+        }
+        let engine = BitVectorEngine::new();
+        let clause = bin(
+            BinOp::Eq,
+            bin(BinOp::Add, var("a"), var("b")),
+            bin(BinOp::Add, var("b"), var("a")),
+        );
+        let out = engine.discharge_bv(
+            &["a".to_string(), "b".to_string()],
+            None,
+            &clause,
+            BvWidth::W64,
+        );
+        assert_eq!(out, BvOutcome::Proved, "bvadd commutes at width 64");
+    }
+
+    /// AC-3 (engine level): a planted non-injective shift dies as a `Counterexample`
+    /// carrying the bit pattern. `x << 1` loses the top bit, so two distinct inputs
+    /// collide — z3 returns the witnessing bits.
+    #[test]
+    fn live_non_injective_shift_yields_counterexample_with_bits() {
+        if bv_skip() {
+            return;
+        }
+        let engine = BitVectorEngine::new();
+        // req x != y ; ens@bv64 (x << 1) != (y << 1)  — FALSE (shl-by-1 is not injective).
+        let req = bin(BinOp::Ne, var("x"), var("y"));
+        let clause = bin(
+            BinOp::Ne,
+            bin(BinOp::Shl, var("x"), lit(1)),
+            bin(BinOp::Shl, var("y"), lit(1)),
+        );
+        let out = engine.discharge_bv(
+            &["x".to_string(), "y".to_string()],
+            Some(&req),
+            &clause,
+            BvWidth::W64,
+        );
+        match out {
+            BvOutcome::Counterexample { bits } => {
+                assert_eq!(bits.len(), 2, "a bit pattern per variable");
+                assert!(bits.iter().all(|b| b.width == 64));
+                // The witness genuinely falsifies: x != y but x<<1 == y<<1.
+                assert_ne!(bits[0].value, bits[1].value, "x != y in the witness");
+                assert_eq!(
+                    (bits[0].value << 1) & u64::MAX as u128,
+                    (bits[1].value << 1) & u64::MAX as u128,
+                    "x<<1 == y<<1 at width 64 (the collision)"
+                );
+            }
+            other => panic!("expected a bit-level Counterexample, got {other:?}"),
+        }
+    }
+
+    /// AC-3 (engine level): an over-budget 64-bit multiplier query is reported under the
+    /// dedicated budget profile and is NEVER a silent `unknown`. A factoring-style
+    /// validity (`a * b != <prime>` with non-trivial bounded factors) forces the full
+    /// 64×64 bit-blast — the cost cliff — so the bounded profile reports `Timeout`. The
+    /// robust invariant asserted here (across z3 versions): the outcome is never
+    /// `Unknown`; when it IS a `Timeout`, it names the `bv64-multiplier` profile.
+    #[test]
+    fn live_multiplier_budget_is_never_silent_unknown() {
+        if bv_skip() {
+            return;
+        }
+        let engine = BitVectorEngine::new();
+        // req a>1 && a<2^32 && b>1 && b<2^32 ; ens@bv64 a*b != 2^61-1 (a Mersenne prime).
+        let req = bin(
+            BinOp::And,
+            bin(
+                BinOp::And,
+                bin(BinOp::Gt, var("a"), lit(1)),
+                bin(BinOp::Lt, var("a"), lit(1u128 << 32)),
+            ),
+            bin(
+                BinOp::And,
+                bin(BinOp::Gt, var("b"), lit(1)),
+                bin(BinOp::Lt, var("b"), lit(1u128 << 32)),
+            ),
+        );
+        let clause = bin(
+            BinOp::Ne,
+            bin(BinOp::Mul, var("a"), var("b")),
+            lit((1u128 << 61) - 1),
+        );
+        let out = engine.discharge_bv(
+            &["a".to_string(), "b".to_string()],
+            Some(&req),
+            &clause,
+            BvWidth::W64,
+        );
+        assert!(
+            !matches!(out, BvOutcome::Unknown(_)),
+            "the 64-bit multiplier cliff is NEVER a silent unknown (AC-3): {out:?}"
+        );
+        if let BvOutcome::Timeout { profile, .. } = &out {
+            assert_eq!(
+                profile, "bv64-multiplier",
+                "the dedicated budget profile is named"
+            );
+        }
+    }
+}

--- a/forge/src/bitvector.rs
+++ b/forge/src/bitvector.rs
@@ -35,10 +35,13 @@
 //!   represent — a budget `Timeout` is distinct from an undecided `Unknown`) is the
 //!   route's real entry point, mapped down for the generic trait caller.
 //!
-//! A `@bv` clause certifies at the SOLVER rung [`crate::manifest::Level::L3`]: its
-//! trust base is the QF_BV decision procedure. Kernel-grounding the bit-vector
-//! discharge (proof reconstruction) is REQ-7/REQ-8, a strictly later increment; this
-//! module is the lowering only.
+//! A `@bv` clause certifies at the caged rung [`crate::manifest::Level::L4`]: it is
+//! decidable QF_BV with complete bit-pattern countermodels — the L4 refutation quality
+//! (RFC-1 §2/§4), never degraded. Rung and trust base are orthogonal: the rung records
+//! refutation quality, while the trust base (the QF_BV decision procedure, SOLVER) is
+//! recorded separately in the attribution. Kernel-grounding the bit-vector discharge
+//! (proof reconstruction) is REQ-7/REQ-8, which shrinks that trust base at the SAME
+//! rung; this module is the lowering only.
 
 use std::collections::BTreeMap;
 
@@ -54,7 +57,8 @@ use thermite_syntax::{BinOp, BvWidth, Expr, UnaryOp};
 pub enum BvOutcome {
     /// `unsat` over QF_BV: the clause holds for every `N`-bit assignment satisfying
     /// the precondition → the clause is machine-valid at width `N` → certify at the
-    /// solver rung (L3).
+    /// caged rung (L4): decidable, complete bit-pattern countermodels; the SOLVER trust
+    /// base (Z3 QF_BV) is recorded separately in the attribution.
     Proved,
     /// `sat` over QF_BV: a concrete `N`-bit assignment falsifies the clause — a
     /// bit-level countermodel. Carries the witnessing bit pattern per variable

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -254,6 +254,21 @@ pub enum EngineSelection {
     /// all four forge-tier evidence blocks. The v1 corpus never selects this route, so
     /// its goldens stay byte-identical.
     Forge,
+    /// `--engine bv` (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-2 / AC-3 —
+    /// stage-3): the PER-CLAUSE bit-vector route (the RFC's `mix64` shape). Each `ens`
+    /// clause is dispatched by its `@bvN` tag: a TAGGED clause lowers to fixed-width
+    /// QF_BV and is decided by the [`crate::bitvector::BitVectorEngine`] (a `Proved`
+    /// certifies at the SOLVER rung [`Level::L3`]; a falsified clause yields a bit-level
+    /// `Counterexample` with the bit pattern; an over-budget 64-bit multiplier yields a
+    /// `Timeout` under the dedicated budget profile, never `unknown`). An UNTAGGED
+    /// clause lowers as before — routed to the [`crate::engine::NlsatEngine`] when it is
+    /// a relaxable polynomial (the unbounded side, certifying at [`Level::L4`]), else an
+    /// honest skip. One function thus carries wraparound and unbounded clauses side by
+    /// side, each labeled with its engine and semantics; the item level is the MIN over
+    /// the clauses. A `@bv`-tagged `lemma` is discharged directly by the bit-vector
+    /// engine with no author proof block. The v1 corpus carries no `@bv` tag, so its
+    /// goldens stay byte-identical.
+    Bv,
 }
 
 impl Default for CheckOptions {
@@ -1036,6 +1051,16 @@ pub fn check_file_with_engine(
         return Ok(forge_gate_check(base, &parsed.program, &src));
     }
 
+    // Stage-3 REQ-2 (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-2 / AC-3): the
+    // `--engine bv` PER-CLAUSE bit-vector route (the `mix64` shape). `@bv`-tagged
+    // clauses lower to fixed-width QF_BV via the BitVectorEngine; untagged clauses
+    // lower as before (relaxable → nlsat L4, else honest skip). Returns early like the
+    // nlsat/forge routes; the v1 Verus path and the lean/auto paths are untouched, so
+    // the v1 corpus (which carries no `@bv` tag) stays byte-identical.
+    if selection == EngineSelection::Bv {
+        return Ok(bv_check(base, &parsed.program));
+    }
+
     let lean = crate::engine::LeanEngine::new(parsed.program.clone(), lean_package_root());
 
     let mut out = Vec::with_capacity(base.len());
@@ -1543,6 +1568,430 @@ fn nlsat_realwitness_cert(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// Stage-3 REQ-2 (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-2 / AC-3): the
+// `--engine bv` PER-CLAUSE bit-vector route (the RFC's `mix64` shape). A `@bvN`-tagged
+// clause lowers to fixed-width QF_BV via the BitVectorEngine (the `EngineName::
+// BitVector` route alongside stage-1's `Nlsat`); an untagged clause lowers as before
+// (relaxable polynomial → nlsat L4, else an honest skip). One function thus carries
+// wraparound and unbounded clauses side by side, each labeled per engine; the item
+// level is the MIN over the clauses. A `@bv`-tagged `lemma` is discharged directly by
+// the bit-vector engine with no author proof block (AC-2).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The `--engine bv` per-clause bit-vector pass (`.design/stage3-bv-reconstruction.md`
+/// REQ-2). Each `fn` item is rebuilt by [`bv_fn_cert`] (its `ens` clauses dispatched by
+/// their `@bv` tag); each `@bv`-tagged `lemma` is discharged directly by the bit-vector
+/// engine ([`bv_lemma_cert`]). A non-`fn`, non-bv-lemma item keeps its base cert. The
+/// v1 corpus carries no `@bv` tag, so its goldens are byte-identical.
+fn bv_check(base: Vec<Certificate>, program: &Program) -> Vec<Certificate> {
+    let bv = crate::bitvector::BitVectorEngine::new();
+    let nlsat = crate::engine::NlsatEngine::new(program.clone());
+    let mut out = Vec::with_capacity(base.len());
+    for cert in base {
+        match crate::lean_export::find_item(program, &cert.item) {
+            Some(Item::Fn(f)) => out.push(bv_fn_cert(&bv, &nlsat, f, &cert)),
+            _ => out.push(cert),
+        }
+    }
+    // A clean `@bv`-tagged `lemma` is absent from `base` (the base path skips a hole-free
+    // forge item, REQ-3), so it is minted here; a holed/battery-refused lemma already
+    // carries its reject in `out` and is not re-discharged (the forge-route precedent).
+    for item in &program.items {
+        if let Item::Forge(thermite_syntax::ForgeItem::Lemma(l)) = item {
+            if lemma_has_bv_tag(l) && !out.iter().any(|c| c.item == l.name) {
+                out.push(bv_lemma_cert(&bv, l));
+            }
+        }
+    }
+    out
+}
+
+/// The [`crate::engine::EngineAttribution`] a bit-vector discharge records: the
+/// `bitvector` engine tag + its QF_BV solver trust base (REQ-2). Centralized so the
+/// per-clause block and the item-level attribution agree.
+fn bv_attribution() -> crate::engine::EngineAttribution {
+    crate::engine::EngineAttribution {
+        engine: crate::engine::EngineName::BitVector.tag().to_string(),
+        trust_profile: crate::engine::bv_trust_profile().items,
+    }
+}
+
+/// Does the lemma carry a `@bv`-tagged `ens` clause (`.design/stage3-bv-reconstruction.md`
+/// REQ-2 / AC-2)? The bit-vector route discharges such a lemma directly, with no author
+/// proof block.
+fn lemma_has_bv_tag(l: &thermite_syntax::LemmaItem) -> bool {
+    l.ens.iter().any(|c| c.bv.is_some())
+}
+
+/// Does `e` reference the `result` keyword (`.design/stage3-bv-reconstruction.md`
+/// REQ-2)? A `@bv` clause that names `result` must have it grounded by the body before
+/// it can be a closed QF_BV query over the parameters.
+fn expr_mentions_result(e: &thermite_syntax::Expr) -> bool {
+    use thermite_syntax::Expr as E;
+    match e {
+        E::Path(segs) => segs.len() == 1 && segs[0] == "result",
+        E::Binary { lhs, rhs, .. } => expr_mentions_result(lhs) || expr_mentions_result(rhs),
+        E::Unary { expr, .. } | E::Cast { expr, .. } => expr_mentions_result(expr),
+        _ => false,
+    }
+}
+
+/// Ground a `@bv` clause's `result` by the function body (`.design/stage3-bv-reconstruction.md`
+/// REQ-2). A clause that names `result` is rewritten with `result := body` (the
+/// forge-route precedent, [`substitute_result_with_body`]) so the QF_BV query is closed
+/// over the parameters; a clause naming `result` on a body-less `fn` is an honest skip
+/// (`Err`) rather than a query with a free, unconstrained `result` (which could mint a
+/// spurious counterexample).
+fn ground_result_in_clause(
+    f: &thermite_syntax::FnItem,
+    expr: &thermite_syntax::Expr,
+) -> Result<thermite_syntax::Expr, String> {
+    if !expr_mentions_result(expr) {
+        return Ok(expr.clone());
+    }
+    let body = f
+        .body
+        .as_ref()
+        .and_then(effective_result_expr)
+        .ok_or_else(|| {
+            format!(
+                "the `@bv` clause names `result` but `{}` has no in-language body to ground it",
+                f.name
+            )
+        })?;
+    Ok(substitute_result_with_body(expr, &body))
+}
+
+/// Build one `fn`'s `--engine bv` certificate (`.design/stage3-bv-reconstruction.md`
+/// REQ-2 / AC-2 / AC-3 — the `mix64` shape). Each `ens` clause is dispatched by its
+/// `@bv` tag: a TAGGED clause → the [`crate::bitvector::BitVectorEngine`] (QF_BV at the
+/// tag width); an UNTAGGED clause → the [`crate::engine::NlsatEngine`] when it is a
+/// relaxable polynomial (the unbounded side), else an honest skip. A `Proved` tagged
+/// clause certifies at the SOLVER rung [`Level::L3`], an nlsat `Proved` at [`Level::L4`];
+/// the item level is the MIN. The FIRST non-certifying clause (a bit-level
+/// counterexample, an over-budget multiplier timeout, an undecided/unsupported clause)
+/// short-circuits to its honest non-certified cert.
+fn bv_fn_cert(
+    bv: &crate::bitvector::BitVectorEngine,
+    nlsat: &crate::engine::NlsatEngine,
+    f: &thermite_syntax::FnItem,
+    base: &Certificate,
+) -> Certificate {
+    use crate::bitvector::BvOutcome;
+    use crate::engine::NlsatOutcome;
+    let effects = base.effects.clone();
+    let slag = f.slag.is_some();
+    let vars: Vec<String> = f.params.iter().map(|p| p.name.clone()).collect();
+    let req = &f.contract.req.expr;
+    let bv_attr = bv_attribution();
+    let mut obligations = Vec::with_capacity(f.contract.ens.len());
+    let mut item_level = Level::L4;
+    let mut item_attr: Option<crate::engine::EngineAttribution> = None;
+
+    for (k, ens) in f.contract.ens.iter().enumerate() {
+        if let Some(tag) = &ens.bv {
+            let clause_expr = match ground_result_in_clause(f, &ens.expr) {
+                Ok(e) => e,
+                Err(reason) => return bv_skip_cert(&f.name, &effects, slag, k, &reason),
+            };
+            match bv.discharge_bv(&vars, Some(req), &clause_expr, tag.width) {
+                BvOutcome::Proved => {
+                    obligations.push(bv_proved_obl(&f.name, k, tag, &bv_attr));
+                    item_level = item_level.min(Level::L3);
+                    item_attr.get_or_insert_with(|| bv_attr.clone());
+                }
+                BvOutcome::Counterexample { bits } => {
+                    return bv_counterexample_cert(
+                        &f.name, &effects, slag, k, tag, &bits, &bv_attr,
+                    );
+                }
+                BvOutcome::Timeout { profile, detail } => {
+                    return bv_timeout_cert(
+                        &f.name, &effects, slag, k, tag, &profile, &detail, &bv_attr,
+                    );
+                }
+                BvOutcome::Unknown(reason) => {
+                    return bv_skip_cert(&f.name, &effects, slag, k, &reason);
+                }
+            }
+        } else {
+            // Untagged → the unbounded side: nlsat when the clause is a relaxable
+            // polynomial, else an honest skip (this route lowers only the bit-vector
+            // clauses and the relaxable unbounded clauses).
+            let synth = single_ens_fn(f, ens);
+            if crate::relax::classify_fn(&synth).is_relaxable() {
+                match nlsat.discharge_relax(&synth) {
+                    NlsatOutcome::Proved => {
+                        let attr = crate::engine::attribution_for(nlsat);
+                        obligations.push(bv_untagged_nlsat_obl(&f.name, k, &attr));
+                        item_level = item_level.min(Level::L4);
+                        item_attr.get_or_insert(attr);
+                    }
+                    other => {
+                        return Certificate::rejected(
+                            f.name.clone(),
+                            effects,
+                            slag,
+                            RejectReason {
+                                cause: "BvUntaggedUndecided".to_string(),
+                                detail: format!(
+                                    "the bit-vector route could not certify `{}`'s untagged \
+                                     (unbounded) clause `ens#{k}` via the nlsat side (NOT \
+                                     certified, an honest skip): {other:?}",
+                                    f.name
+                                ),
+                            },
+                        );
+                    }
+                }
+            } else {
+                return Certificate::rejected(
+                    f.name.clone(),
+                    effects,
+                    slag,
+                    RejectReason {
+                        cause: "BvUntaggedUnsupported".to_string(),
+                        detail: format!(
+                            "`{}`'s untagged clause `ens#{k}` is neither `@bv`-tagged nor a \
+                             relaxable polynomial, so the bit-vector route does not lower it \
+                             (an honest skip — tag it `@bvN` for machine semantics, or use a \
+                             route that lowers it)",
+                            f.name
+                        ),
+                    },
+                );
+            }
+        }
+    }
+
+    let attribution = item_attr.unwrap_or(bv_attr);
+    Certificate::new(f.name.clone(), item_level, effects, 0, obligations)
+        .graduate_triage_clean()
+        .with_engine_attribution(attribution)
+}
+
+/// Build a `@bv`-tagged `lemma`'s bit-vector certificate (`.design/stage3-bv-reconstruction.md`
+/// REQ-2 / AC-2 — "the injectivity lemma discharges at `@bv64` with no proof block").
+/// A lemma carries no `result` and no body: each `@bv`-tagged `ens` clause is a closed
+/// QF_BV query over the parameters under the lemma's `req`. A non-tagged lemma clause is
+/// an honest skip (this route lowers only the bit-vector clauses). The lemma certifies
+/// at [`Level::L3`] (the solver rung); a counterexample / timeout short-circuits.
+fn bv_lemma_cert(
+    bv: &crate::bitvector::BitVectorEngine,
+    l: &thermite_syntax::LemmaItem,
+) -> Certificate {
+    use crate::bitvector::BvOutcome;
+    let effects = vec!["pure".to_string()];
+    let vars: Vec<String> = l.params.iter().map(|p| p.name.clone()).collect();
+    let req = &l.req.expr;
+    let bv_attr = bv_attribution();
+    let mut obligations = Vec::with_capacity(l.ens.len());
+
+    for (k, ens) in l.ens.iter().enumerate() {
+        let Some(tag) = &ens.bv else {
+            return Certificate::rejected(
+                l.name.clone(),
+                effects,
+                false,
+                RejectReason {
+                    cause: "BvUntaggedUnsupported".to_string(),
+                    detail: format!(
+                        "the bit-vector route lowers only `@bv`-tagged lemma clauses; `{}`'s \
+                         `ens#{k}` carries no tag (an honest skip)",
+                        l.name
+                    ),
+                },
+            );
+        };
+        match bv.discharge_bv(&vars, Some(req), &ens.expr, tag.width) {
+            BvOutcome::Proved => obligations.push(bv_proved_obl(&l.name, k, tag, &bv_attr)),
+            BvOutcome::Counterexample { bits } => {
+                return bv_counterexample_cert(&l.name, &effects, false, k, tag, &bits, &bv_attr);
+            }
+            BvOutcome::Timeout { profile, detail } => {
+                return bv_timeout_cert(
+                    &l.name, &effects, false, k, tag, &profile, &detail, &bv_attr,
+                );
+            }
+            BvOutcome::Unknown(reason) => {
+                return bv_skip_cert(&l.name, &effects, false, k, &reason);
+            }
+        }
+    }
+
+    Certificate::new(l.name.clone(), Level::L3, effects, 0, obligations)
+        .graduate_triage_clean()
+        .with_engine_attribution(bv_attr)
+}
+
+/// The per-clause [`ObligationResult`] a bit-vector `Proved` records (`.design/
+/// stage3-bv-reconstruction.md` REQ-2 / AC-2): the engine (`bitvector`), the QF_BV
+/// solver trust base, the `Proved` verdict, and a name that states the engine AND the
+/// fixed-width semantics ("each clause's certificate naming its engine and semantics").
+fn bv_proved_obl(
+    item: &str,
+    k: usize,
+    tag: &thermite_syntax::BvTag,
+    attr: &crate::engine::EngineAttribution,
+) -> ObligationResult {
+    ObligationResult::discharged(format!(
+        "{item}::ens#{k}: discharged by the bit-vector route over {} (fixed-width \
+         wraparound machine semantics; QF_BV-valid by Verus `by(bit_vector)` — L3 \
+         solver rung; stage3-bv-reconstruction.md REQ-2)",
+        bv_semantics_label(tag)
+    ))
+    .with_clause_attribution(
+        attr.engine.clone(),
+        attr.trust_profile.clone(),
+        crate::verdict::CertVerdict::Proved,
+    )
+}
+
+/// The per-clause [`ObligationResult`] an untagged (unbounded) nlsat `Proved` records on
+/// the bit-vector route (`.design/stage3-bv-reconstruction.md` REQ-2 — the `mix64`
+/// shape's third, unbounded clause). It carries the `nlsat` engine + the L4 kernel-
+/// grounded trust base, so the mixed-mechanism function attributes each clause to the
+/// engine that grounds it.
+fn bv_untagged_nlsat_obl(
+    item: &str,
+    k: usize,
+    attr: &crate::engine::EngineAttribution,
+) -> ObligationResult {
+    ObligationResult::discharged(format!(
+        "{item}::ens#{k}: untagged (unbounded) clause discharged by the nlsat relax route \
+         (unbounded-integer semantics; QF_NRA-valid → integer-valid by the kernel-checked \
+         r_relax_sound — L4 kernel-grounded; stage1-forge-tier.md REQ-8)"
+    ))
+    .with_clause_attribution(
+        attr.engine.clone(),
+        attr.trust_profile.clone(),
+        crate::verdict::CertVerdict::Proved,
+    )
+}
+
+/// The `bvN` (`nowrap`) semantics label of a tag (`.design/stage3-bv-reconstruction.md`
+/// REQ-2). Names the fixed width and whether the `nowrap` modifier is present.
+fn bv_semantics_label(tag: &thermite_syntax::BvTag) -> String {
+    let width = tag.width.bits();
+    if tag.nowrap {
+        format!("bv{width} (nowrap)")
+    } else {
+        format!("bv{width} (wraparound)")
+    }
+}
+
+/// The bit-level `Counterexample` cert a falsified `@bv` clause produces (`.design/
+/// stage3-bv-reconstruction.md` REQ-2 / AC-3): a non-certified cert whose diagnostic
+/// carries the witnessing **bit pattern** per variable, with the per-clause
+/// [`crate::verdict::CertVerdict::Counterexample`].
+fn bv_counterexample_cert(
+    item: &str,
+    effects: &[String],
+    slag: bool,
+    k: usize,
+    tag: &thermite_syntax::BvTag,
+    bits: &[crate::bitvector::BvBitPattern],
+    attr: &crate::engine::EngineAttribution,
+) -> Certificate {
+    let pattern = bits
+        .iter()
+        .map(crate::bitvector::BvBitPattern::render)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let detail = format!(
+        "the bit-vector route found a {} counterexample to `{item}`'s clause `ens#{k}`: \
+         the bit pattern {pattern} falsifies it at fixed width (stage3-bv-reconstruction.md \
+         REQ-2 / AC-3)",
+        bv_semantics_label(tag)
+    );
+    let witness_obl =
+        ObligationResult::failed(format!("{item}#ens#{k}"), None, Some(detail.clone()));
+    let cert_verdict = crate::verdict::CertVerdict::Counterexample {
+        obligations: vec![witness_obl.clone()],
+    };
+    let mut cert = Certificate::rejected(
+        item.to_string(),
+        effects.to_vec(),
+        slag,
+        RejectReason {
+            cause: "Counterexample".to_string(),
+            detail,
+        },
+    );
+    cert.obligations = vec![witness_obl.with_clause_attribution(
+        attr.engine.clone(),
+        attr.trust_profile.clone(),
+        cert_verdict,
+    )];
+    cert.with_engine_attribution(attr.clone())
+}
+
+/// The `Timeout` cert an over-budget 64-bit multiplier query produces (`.design/
+/// stage3-bv-reconstruction.md` REQ-2 / AC-3): a non-certified cert naming the dedicated
+/// budget profile, with the per-clause [`crate::verdict::CertVerdict::Timeout`] — never
+/// `unknown` and never a silent downgrade.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the timeout cert threads the item/effects/slag identity, the clause index \
+              + tag, and the budget profile + Z3 detail; each is a distinct datum the \
+              non-silent Timeout verdict records"
+)]
+fn bv_timeout_cert(
+    item: &str,
+    effects: &[String],
+    slag: bool,
+    k: usize,
+    tag: &thermite_syntax::BvTag,
+    profile: &str,
+    detail: &str,
+    attr: &crate::engine::EngineAttribution,
+) -> Certificate {
+    let full = format!(
+        "`{item}`'s {} clause `ens#{k}` exhausted the dedicated `{profile}` budget profile \
+         (the 64-bit multiplier cost cliff): {detail}. Reported as Timeout, NEVER unknown \
+         and never a silent downgrade (stage3-bv-reconstruction.md REQ-2 / AC-3).",
+        bv_semantics_label(tag)
+    );
+    let obl = ObligationResult::failed(format!("{item}#ens#{k}"), None, Some(full.clone()))
+        .with_clause_attribution(
+            attr.engine.clone(),
+            attr.trust_profile.clone(),
+            crate::verdict::CertVerdict::Timeout {
+                detail: format!("budget profile `{profile}`: {detail}"),
+            },
+        );
+    let mut cert = Certificate::rejected(
+        item.to_string(),
+        effects.to_vec(),
+        slag,
+        RejectReason {
+            cause: "BvBudgetTimeout".to_string(),
+            detail: full,
+        },
+    );
+    cert.obligations = vec![obl];
+    cert.with_engine_attribution(attr.clone())
+}
+
+/// The honest-skip cert a non-rendering / Z3-absent `@bv` clause produces (`.design/
+/// stage3-bv-reconstruction.md` REQ-2): non-certified, naming the reason — never a false
+/// verdict (the nlsat-route `NlsatUnknown` precedent).
+fn bv_skip_cert(item: &str, effects: &[String], slag: bool, k: usize, reason: &str) -> Certificate {
+    Certificate::rejected(
+        item.to_string(),
+        effects.to_vec(),
+        slag,
+        RejectReason {
+            cause: "BvUnknown".to_string(),
+            detail: format!(
+                "the bit-vector route did not decide `{item}`'s clause `ens#{k}` (Z3 absent / \
+                 outside the QF_BV fragment — NOT certified, an honest skip): {reason}"
+            ),
+        },
+    )
+}
+
 // The G1 gate route (`.design/stage1-forge-tier.md` REQ-10 / AC-14): the per-clause
 // hybrid discharge that exercises the whole forge tier end to end on a covenant-routed
 // `fn`. Each `ens` clause is classified by `relax::classify_fn` (the same fragment gate
@@ -2060,6 +2509,11 @@ fn lean_engine_cert(
         // before this per-item Lean helper runs), so this arm is never reached; it keeps
         // the Verus base cert defensively (R-APG-1 — no panic on a future wiring change).
         EngineSelection::Forge => Ok(verus_cert),
+        // The bit-vector route (`.design/stage3-bv-reconstruction.md` REQ-2) is dispatched
+        // in `check_file_with_engine` (it returns early before this per-item Lean helper
+        // runs), so this arm is never reached; it keeps the Verus base cert defensively
+        // (R-APG-1 — no panic on a future wiring change).
+        EngineSelection::Bv => Ok(verus_cert),
         EngineSelection::Auto => {
             // Verus first: a Verus `Proven` (L3, no reject) is kept — Lean is not run
             // (no cost on the common case, no spurious disagreement). Only an

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -258,7 +258,9 @@ pub enum EngineSelection {
     /// stage-3): the PER-CLAUSE bit-vector route (the RFC's `mix64` shape). Each `ens`
     /// clause is dispatched by its `@bvN` tag: a TAGGED clause lowers to fixed-width
     /// QF_BV and is decided by the [`crate::bitvector::BitVectorEngine`] (a `Proved`
-    /// certifies at the SOLVER rung [`Level::L3`]; a falsified clause yields a bit-level
+    /// certifies at the caged rung [`Level::L4`] — decidable with complete bit-pattern
+    /// countermodels (RFC-1 §2/§4), solver-trusted (Z3 QF_BV) until REQ-7/8 kernel-
+    /// grounds it; a falsified clause yields a bit-level
     /// `Counterexample` with the bit pattern; an over-budget 64-bit multiplier yields a
     /// `Timeout` under the dedicated budget profile, never `unknown`). An UNTAGGED
     /// clause lowers as before — routed to the [`crate::engine::NlsatEngine`] when it is
@@ -1668,7 +1670,8 @@ fn ground_result_in_clause(
 /// `@bv` tag: a TAGGED clause → the [`crate::bitvector::BitVectorEngine`] (QF_BV at the
 /// tag width); an UNTAGGED clause → the [`crate::engine::NlsatEngine`] when it is a
 /// relaxable polynomial (the unbounded side), else an honest skip. A `Proved` tagged
-/// clause certifies at the SOLVER rung [`Level::L3`], an nlsat `Proved` at [`Level::L4`];
+/// clause certifies at the caged rung [`Level::L4`] (decidable, complete bit-pattern
+/// countermodels; solver-trusted Z3 QF_BV), as does an nlsat `Proved`;
 /// the item level is the MIN. The FIRST non-certifying clause (a bit-level
 /// counterexample, an over-budget multiplier timeout, an undecided/unsupported clause)
 /// short-circuits to its honest non-certified cert.
@@ -1698,7 +1701,12 @@ fn bv_fn_cert(
             match bv.discharge_bv(&vars, Some(req), &clause_expr, tag.width) {
                 BvOutcome::Proved => {
                     obligations.push(bv_proved_obl(&f.name, k, tag, &bv_attr));
-                    item_level = item_level.min(Level::L3);
+                    // A `@bv` clause is decidable QF_BV with COMPLETE bit-pattern
+                    // countermodels — the L4 (caged) refutation quality, RFC-1 §2/§4.
+                    // The rung is the refutation quality; the SOLVER trust base
+                    // (`solver Z3 QF_BV`) is recorded separately in the attribution and
+                    // kernel-grounded by REQ-7/8 (same rung, smaller trust).
+                    item_level = item_level.min(Level::L4);
                     item_attr.get_or_insert_with(|| bv_attr.clone());
                 }
                 BvOutcome::Counterexample { bits } => {
@@ -1776,7 +1784,8 @@ fn bv_fn_cert(
 /// A lemma carries no `result` and no body: each `@bv`-tagged `ens` clause is a closed
 /// QF_BV query over the parameters under the lemma's `req`. A non-tagged lemma clause is
 /// an honest skip (this route lowers only the bit-vector clauses). The lemma certifies
-/// at [`Level::L3`] (the solver rung); a counterexample / timeout short-circuits.
+/// at [`Level::L4`] (the caged rung — decidable, complete bit-pattern countermodels;
+/// solver-trusted Z3 QF_BV); a counterexample / timeout short-circuits.
 fn bv_lemma_cert(
     bv: &crate::bitvector::BitVectorEngine,
     l: &thermite_syntax::LemmaItem,
@@ -1820,7 +1829,7 @@ fn bv_lemma_cert(
         }
     }
 
-    Certificate::new(l.name.clone(), Level::L3, effects, 0, obligations)
+    Certificate::new(l.name.clone(), Level::L4, effects, 0, obligations)
         .graduate_triage_clean()
         .with_engine_attribution(bv_attr)
 }
@@ -1837,8 +1846,9 @@ fn bv_proved_obl(
 ) -> ObligationResult {
     ObligationResult::discharged(format!(
         "{item}::ens#{k}: discharged by the bit-vector route over {} (fixed-width \
-         wraparound machine semantics; QF_BV-valid by Verus `by(bit_vector)` — L3 \
-         solver rung; stage3-bv-reconstruction.md REQ-2)",
+         wraparound machine semantics; QF_BV-decidable with complete bit-pattern \
+         countermodels — L4 caged rung, solver-trusted (Z3 QF_BV); \
+         stage3-bv-reconstruction.md REQ-2)",
         bv_semantics_label(tag)
     ))
     .with_clause_attribution(

--- a/forge/src/cli.rs
+++ b/forge/src/cli.rs
@@ -633,7 +633,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                         let value = iter.next().ok_or_else(|| {
                             ForgeError::Usage(
                                 "`--engine` requires a value (`verus`, `lean`, `auto`, \
-                                 `nlsat`, or `forge`)"
+                                 `nlsat`, `forge`, or `bv`)"
                                     .to_string(),
                             )
                         })?;
@@ -643,10 +643,11 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                             "auto" => check::EngineSelection::Auto,
                             "nlsat" => check::EngineSelection::Nlsat,
                             "forge" => check::EngineSelection::Forge,
+                            "bv" => check::EngineSelection::Bv,
                             other => {
                                 return Err(ForgeError::Usage(format!(
                                     "unknown `--engine` value `{other}` (expected `verus`, \
-                                     `lean`, `auto`, `nlsat`, or `forge`)"
+                                     `lean`, `auto`, `nlsat`, `forge`, or `bv`)"
                                 )));
                             }
                         };

--- a/forge/src/engine.rs
+++ b/forge/src/engine.rs
@@ -89,6 +89,16 @@ pub enum EngineName {
     /// — its trust profile is `solver(nlsat) + spine-lemma(kernel)` (the real→integer
     /// soundness bridge is the kernel-checked `r_relax_sound`, `lean/Thermite/Relax.lean`).
     Nlsat,
+    /// The QF_BV bit-vector engine (`.design/stage3-bv-reconstruction.md` REQ-2,
+    /// stage-3): an `@bvN`-tagged clause lowered to fixed-width wraparound (machine)
+    /// semantics and decided by Verus's `by(bit_vector)` mode — mechanically a QF_BV
+    /// solver query, reached directly (the [`Nlsat`](EngineName::Nlsat) precedent for
+    /// QF_NRA). It joins the stage-1 `Nlsat` route so a mixed-mechanism function (the
+    /// RFC's `mix64` shape) attributes each clause per engine. A `Proven` bit-vector
+    /// discharge certifies at the SOLVER rung [`crate::manifest::Level::L3`]: its trust
+    /// base is the QF_BV decision procedure (kernel-grounding it is REQ-7/REQ-8, a
+    /// later increment). The implementation is [`crate::bitvector::BitVectorEngine`].
+    BitVector,
 }
 
 impl EngineName {
@@ -101,7 +111,25 @@ impl EngineName {
             EngineName::LeanAuto => "lean-auto",
             EngineName::LeanInteractive => "lean-interactive",
             EngineName::Nlsat => "nlsat",
+            EngineName::BitVector => "bitvector",
         }
+    }
+}
+
+/// The named trust base a [`EngineName::BitVector`] discharge adds on a `Proven`
+/// (`.design/stage3-bv-reconstruction.md` REQ-2). The QF_BV decision procedure is the
+/// whole solver base — a single named item — at the SOLVER rung (L3). It is strictly
+/// smaller than the Verus base (no VC-gen, no lowering theorem): the clause is a
+/// direct, ground QF_BV query. Kernel-grounding it (proof reconstruction) is REQ-7/8;
+/// until then the bit-vector discharge is solver-trusted, named here for the auditor.
+#[must_use]
+pub fn bv_trust_profile() -> TrustProfile {
+    TrustProfile {
+        items: vec![
+            "Z3 QF_BV (fixed-width bit-vector decision; the procedure Verus `by(bit_vector)` \
+             invokes)"
+                .to_string(),
+        ],
     }
 }
 

--- a/forge/src/engine.rs
+++ b/forge/src/engine.rs
@@ -95,9 +95,11 @@ pub enum EngineName {
     /// solver query, reached directly (the [`Nlsat`](EngineName::Nlsat) precedent for
     /// QF_NRA). It joins the stage-1 `Nlsat` route so a mixed-mechanism function (the
     /// RFC's `mix64` shape) attributes each clause per engine. A `Proven` bit-vector
-    /// discharge certifies at the SOLVER rung [`crate::manifest::Level::L3`]: its trust
-    /// base is the QF_BV decision procedure (kernel-grounding it is REQ-7/REQ-8, a
-    /// later increment). The implementation is [`crate::bitvector::BitVectorEngine`].
+    /// discharge certifies at the caged rung [`crate::manifest::Level::L4`] (decidable,
+    /// complete bit-pattern countermodels — RFC-1 §2/§4); the SOLVER trust base (the
+    /// QF_BV decision procedure) is recorded separately and kernel-grounded by
+    /// REQ-7/REQ-8 at the same rung. The implementation is
+    /// [`crate::bitvector::BitVectorEngine`].
     BitVector,
 }
 
@@ -118,10 +120,14 @@ impl EngineName {
 
 /// The named trust base a [`EngineName::BitVector`] discharge adds on a `Proven`
 /// (`.design/stage3-bv-reconstruction.md` REQ-2). The QF_BV decision procedure is the
-/// whole solver base — a single named item — at the SOLVER rung (L3). It is strictly
-/// smaller than the Verus base (no VC-gen, no lowering theorem): the clause is a
-/// direct, ground QF_BV query. Kernel-grounding it (proof reconstruction) is REQ-7/8;
-/// until then the bit-vector discharge is solver-trusted, named here for the auditor.
+/// whole solver base — a single named item. The clause certifies at the caged rung
+/// [`crate::manifest::Level::L4`] (decidable, complete bit-pattern countermodels — the
+/// L4 refutation quality, RFC-1 §2/§4); rung and trust are orthogonal axes, so this
+/// SOLVER trust base is recorded here regardless of the rung. It is strictly smaller
+/// than the Verus base (no VC-gen, no lowering theorem): the clause is a direct, ground
+/// QF_BV query. Kernel-grounding it (proof reconstruction) is REQ-7/8, which shrinks
+/// this trust base at the SAME rung; until then the bit-vector discharge is
+/// solver-trusted, named here for the auditor.
 #[must_use]
 pub fn bv_trust_profile() -> TrustProfile {
     TrustProfile {

--- a/forge/src/main.rs
+++ b/forge/src/main.rs
@@ -27,6 +27,7 @@
 mod accessibility;
 mod audit;
 mod battery;
+mod bitvector;
 mod body_tv;
 mod build;
 mod burn;

--- a/forge/src/manifest.rs
+++ b/forge/src/manifest.rs
@@ -180,16 +180,24 @@ fn scope_is_end_to_end(scope: &Option<AssuranceScope>) -> bool {
 /// assurance-manifest aggregate uses for the min-over-functions project headline.
 /// The aggregate depends on this discriminant order.
 ///
-/// L4 is the **kernel-grounded** rung the Stage-1 forge tier's relax route adds
-/// (`.design/stage1-forge-tier.md` REQ-8, RFC-1 / GH #2): where L3 is a Verus/Z3
-/// SOLVER proof, L4 is a clause whose trust profile is `solver(nlsat) +
-/// spine-lemma(kernel)` — the nlsat real-relaxation discharge, sound by the
-/// kernel-checked spine lemmas `r_relax_sound` + `rencode_sound`
-/// (`lean/Thermite/Relax.lean`). Out-of-cage clauses no longer degrade DOWN the
-/// ladder — they escalate UP to the forge, and a relax-discharged clause certifies
-/// at L4 above L3. Adding L4 is additive: the v1 conformance corpus stays at L3
-/// (the relax route is a NEW engine route reached only via `--engine nlsat`, never
-/// the default Verus path), so the v1 `oracle_subset` is byte-identical.
+/// L4 is the **caged** rung — RFC-1 §2: a clause decidable by an admission test,
+/// push-button, *every failure a concrete countermodel* (finite structure, integer
+/// point, or bit pattern), never degraded. RUNG and TRUST BASE are orthogonal axes:
+/// the rung records refutation quality; what is trusted is recorded separately per
+/// clause in the engine attribution. Two L4 routes exist today, same rung, different
+/// trust bases:
+///
+/// - the **nlsat real-relaxation** discharge (Stage-1 REQ-8, `--engine nlsat`):
+///   trust `solver(nlsat) + spine-lemma(kernel)`, the ℝ→ℤ bridge sound by the
+///   kernel-checked `r_relax_sound` + `rencode_sound` (`lean/Thermite/Relax.lean`);
+/// - the **`@bv` machine-width** discharge (Stage-3 REQ-2, `--engine bv`): trust
+///   `solver(Z3 QF_BV)`, kernel-grounded by REQ-7/8 reconstruction at the SAME rung.
+///
+/// (The general Verus/Z3 cage still certifies at L3 in code pending its own promotion
+/// — a follow-up; the RFC ladder eventually places the whole decidable cage at L4.)
+/// Adding L4 is additive: the v1 conformance corpus stays at L3 (the L4 routes are NEW
+/// engine routes reached only via `--engine nlsat`/`--engine bv`, never the default
+/// Verus path), so the v1 `oracle_subset` is byte-identical.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Level {
     /// L0 — unverified / `#[slag]` escape hatch (§6, §8).
@@ -201,12 +209,13 @@ pub enum Level {
     /// L3 — SMT proof: the contract holds for all inputs (§6). The Verus/Z3 SOLVER
     /// rung.
     L3,
-    /// L4 — KERNEL-GROUNDED proof (`.design/stage1-forge-tier.md` REQ-8, RFC-1 /
-    /// GH #2, increment 2f): the relax route's nlsat (QF_NRA) real-relaxation
-    /// discharge, whose trust profile is `solver(nlsat) + spine-lemma(kernel)` — the
-    /// real→integer soundness bridge is the kernel-checked spine lemma
-    /// `r_relax_sound` (`lean/Thermite/Relax.lean`). Above L3 on the ladder; reached
-    /// only by the new relax engine route (`--engine nlsat`), so v1 items are
+    /// L4 — CAGED (RFC-1 §2): decidable, push-button, every failure a concrete
+    /// countermodel; never degraded. The rung is refutation quality; the trust base is
+    /// recorded separately per clause. Two routes today (same rung, different trust):
+    /// nlsat real-relaxation (`--engine nlsat`, trust `solver(nlsat) +
+    /// spine-lemma(kernel)`, `r_relax_sound`); and `@bv` machine-width (`--engine bv`,
+    /// trust `solver(Z3 QF_BV)`, kernel-grounded by REQ-7/8 at the same rung). Above L3
+    /// on the ladder; reached only by these new engine routes, so v1 items are
     /// unperturbed.
     L4,
 }

--- a/forge/tests/bv_lowering.rs
+++ b/forge/tests/bv_lowering.rs
@@ -1,0 +1,216 @@
+//! The stage-3 bit-vector route (`.design/stage3-bv-reconstruction.md` REQ-2 / AC-2 /
+//! AC-3): `forge check --engine bv` over the `mix64` example and the two AC-3 fixtures,
+//! end to end through the binary. The route lowers `@bv`-tagged clauses to fixed-width
+//! QF_BV (the [`EngineName::BitVector`] route) alongside the stage-1 nlsat route, so a
+//! mixed-mechanism function attributes each clause to the engine that grounds it.
+//!
+//! The whole suite is gated on the `bv` cargo feature (the shadow-flag plumbing — without
+//! it the `@bv` tag is a structured parse error, REQ-1's R-BV-1 lock) AND on `verus`/z3
+//! being reachable (the route reuses the Verus base pass and reaches z3 for the QF_BV and
+//! QF_NRA queries). A shard without them SKIPS — the CI lean/verus job is the authoritative
+//! gate, mirroring `g1_gate.rs` and `nlsat_relax_conformance.rs`.
+
+#![cfg(feature = "bv")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn forge_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_forge"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("forge crate has a parent workspace dir")
+        .to_path_buf()
+}
+
+/// `verus` is reachable (the same skip-guard `g1_gate.rs` uses). z3 ships alongside the
+/// verus distribution, so a present verus implies a usable QF_BV / QF_NRA solver.
+fn verus_present() -> bool {
+    if let Ok(p) = std::env::var("VERUS_BIN") {
+        if Path::new(&p).exists() {
+            return true;
+        }
+    }
+    if let Ok(out) = Command::new("which").arg("verus").output() {
+        if out.status.success() && !String::from_utf8_lossy(&out.stdout).trim().is_empty() {
+            return true;
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        if PathBuf::from(home).join(".local/bin/verus").exists() {
+            return true;
+        }
+    }
+    false
+}
+
+fn run_bv(example: &str) -> (Option<i32>, Vec<Value>) {
+    let th = repo_root().join("conformance/forge").join(example);
+    let out = Command::new(forge_bin())
+        .arg("check")
+        .arg("--engine")
+        .arg("bv")
+        .arg(&th)
+        .arg("--json")
+        .output()
+        .unwrap_or_else(|e| panic!("spawn forge: {e}"));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "forge --json must emit one JSON document: {e}\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    let arr = value
+        .as_array()
+        .unwrap_or_else(|| panic!("forge --json must emit a JSON array of certs: {value}"))
+        .clone();
+    (out.status.code(), arr)
+}
+
+fn cert<'a>(certs: &'a [Value], item: &str) -> &'a Value {
+    certs
+        .iter()
+        .find(|c| c["item"].as_str() == Some(item))
+        .unwrap_or_else(|| panic!("no certificate for `{item}` in {certs:?}"))
+}
+
+/// AC-2: the `mix64` example certifies at L3 with three clauses on two mechanisms — two
+/// `@bv64` clauses via `EngineName::BitVector` and one unbounded clause via nlsat — each
+/// clause's certificate naming its engine and semantics; the injectivity lemma discharges
+/// at `@bv64` with no author proof (an empty `proof { }`).
+#[test]
+fn mix64_certifies_with_two_bitvector_clauses_and_one_unbounded() {
+    if !verus_present() {
+        eprintln!(
+            "SKIP: verus (z3) absent — the bit-vector route is not run (set VERUS_BIN; the CI \
+             verus job is the gate)."
+        );
+        return;
+    }
+    let (code, certs) = run_bv("mix64.th");
+    assert_eq!(code, Some(0), "the mix64 example must certify (exit 0)");
+
+    // (1) The fn `mix64` — L3 (the MIN over L3, L3, L4), three per-clause obligations.
+    let m = cert(&certs, "mix64");
+    assert_eq!(
+        m["level"],
+        Value::from("L3"),
+        "item level is the min over clauses"
+    );
+    assert!(
+        m.get("reject").is_none() || m["reject"].is_null(),
+        "a certified item has no reject"
+    );
+    let obls = m["obligations"].as_array().expect("obligations array");
+    assert_eq!(
+        obls.len(),
+        3,
+        "three ens clauses, three per-clause obligations"
+    );
+    assert_eq!(
+        obls[0]["engine"],
+        Value::from("bitvector"),
+        "ens#0 → bitvector"
+    );
+    assert_eq!(
+        obls[1]["engine"],
+        Value::from("bitvector"),
+        "ens#1 → bitvector"
+    );
+    assert_eq!(
+        obls[2]["engine"],
+        Value::from("nlsat"),
+        "ens#2 → nlsat (unbounded)"
+    );
+    for (k, o) in obls.iter().enumerate() {
+        assert_eq!(
+            o["verdict"]["kind"],
+            Value::from("Proved"),
+            "clause ens#{k} is Proved"
+        );
+        assert!(
+            !o["trust"].as_array().map(Vec::is_empty).unwrap_or(true),
+            "clause ens#{k} names its trust base"
+        );
+    }
+    // The two bit-vector clauses name the fixed-width semantics; the unbounded one does not.
+    assert!(
+        obls[0]["name"].as_str().unwrap_or("").contains("bv64"),
+        "the bit-vector clause names its bv64 semantics"
+    );
+    assert!(
+        obls[2]["name"].as_str().unwrap_or("").contains("unbounded"),
+        "the unbounded clause names its unbounded semantics"
+    );
+
+    // (2) The injectivity lemma — L3 via the bit-vector engine, no author proof.
+    let l = cert(&certs, "rotl1_injective");
+    assert_eq!(
+        l["level"],
+        Value::from("L3"),
+        "the @bv64 lemma certifies at L3"
+    );
+    let lobls = l["obligations"].as_array().expect("lemma obligations");
+    assert_eq!(
+        lobls[0]["engine"],
+        Value::from("bitvector"),
+        "the lemma → bitvector"
+    );
+    assert_eq!(lobls[0]["verdict"]["kind"], Value::from("Proved"));
+}
+
+/// AC-3 (first half): a planted non-injective shift dies as a `Counterexample` with the
+/// bit pattern in the certificate.
+#[test]
+fn planted_non_injective_shift_is_a_counterexample_with_bit_pattern() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — the bit-vector route is not run.");
+        return;
+    }
+    let (code, certs) = run_bv("bv_shl_not_injective.th");
+    assert_ne!(code, Some(0), "a refuted clause does not certify");
+    let c = cert(&certs, "shl1_injective_BROKEN");
+    assert_eq!(c["reject"]["cause"], Value::from("Counterexample"));
+    let obl = &c["obligations"][0];
+    assert_eq!(obl["verdict"]["kind"], Value::from("Counterexample"));
+    let diag = obl["diagnostic"].as_str().unwrap_or("");
+    assert!(
+        diag.contains("0b"),
+        "the certificate carries the falsifying bit pattern (`0b…`): {diag}"
+    );
+}
+
+/// AC-3 (second half): an over-budget 64-bit multiplier query yields `Timeout` under the
+/// dedicated budget profile — NEVER `unknown` and never a silent downgrade. The robust
+/// invariant (across z3 versions): the clause never lands a silent `BvUnknown` skip; when
+/// it IS a timeout, the cert names the `bv64-multiplier` profile.
+#[test]
+fn over_budget_multiplier_is_timeout_under_named_profile_never_unknown() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — the bit-vector route is not run.");
+        return;
+    }
+    let (_code, certs) = run_bv("bv_mul64_budget.th");
+    let c = cert(&certs, "mul64_no_factor");
+    let cause = c["reject"]["cause"].as_str().unwrap_or("");
+    assert_ne!(
+        cause, "BvUnknown",
+        "the 64-bit multiplier cliff is NEVER a silent unknown (AC-3)"
+    );
+    // The expected outcome is the dedicated-profile Timeout; assert it names the profile.
+    if cause == "BvBudgetTimeout" {
+        let obl = &c["obligations"][0];
+        assert_eq!(obl["verdict"]["kind"], Value::from("Timeout"));
+        let detail = obl["verdict"]["detail"].as_str().unwrap_or("");
+        assert!(
+            detail.contains("bv64-multiplier"),
+            "the Timeout names the dedicated budget profile: {detail}"
+        );
+    }
+}

--- a/forge/tests/bv_lowering.rs
+++ b/forge/tests/bv_lowering.rs
@@ -80,10 +80,13 @@ fn cert<'a>(certs: &'a [Value], item: &str) -> &'a Value {
         .unwrap_or_else(|| panic!("no certificate for `{item}` in {certs:?}"))
 }
 
-/// AC-2: the `mix64` example certifies at L3 with three clauses on two mechanisms — two
-/// `@bv64` clauses via `EngineName::BitVector` and one unbounded clause via nlsat — each
-/// clause's certificate naming its engine and semantics; the injectivity lemma discharges
-/// at `@bv64` with no author proof (an empty `proof { }`).
+/// AC-2: the `mix64` example certifies at L4 with three clauses on two mechanisms — two
+/// `@bv64` clauses via `EngineName::BitVector` (decidable QF_BV, complete bit-pattern
+/// countermodels) and one unbounded clause via nlsat — each clause's certificate naming
+/// its engine and semantics; the injectivity lemma discharges at `@bv64` with no author
+/// proof (an empty `proof { }`). Both mechanisms certify at the caged rung L4, so the
+/// item (the MIN over its clauses) is L4; the `@bv` clauses' SOLVER trust base is
+/// recorded in the per-clause attribution (kernel-grounded by REQ-7/8, same rung).
 #[test]
 fn mix64_certifies_with_two_bitvector_clauses_and_one_unbounded() {
     if !verus_present() {
@@ -96,12 +99,12 @@ fn mix64_certifies_with_two_bitvector_clauses_and_one_unbounded() {
     let (code, certs) = run_bv("mix64.th");
     assert_eq!(code, Some(0), "the mix64 example must certify (exit 0)");
 
-    // (1) The fn `mix64` — L3 (the MIN over L3, L3, L4), three per-clause obligations.
+    // (1) The fn `mix64` — L4 (the MIN over L4, L4, L4), three per-clause obligations.
     let m = cert(&certs, "mix64");
     assert_eq!(
         m["level"],
-        Value::from("L3"),
-        "item level is the min over clauses"
+        Value::from("L4"),
+        "item level is the min over clauses (two @bv64 + one nlsat, all caged L4)"
     );
     assert!(
         m.get("reject").is_none() || m["reject"].is_null(),
@@ -149,12 +152,12 @@ fn mix64_certifies_with_two_bitvector_clauses_and_one_unbounded() {
         "the unbounded clause names its unbounded semantics"
     );
 
-    // (2) The injectivity lemma — L3 via the bit-vector engine, no author proof.
+    // (2) The injectivity lemma — L4 via the bit-vector engine, no author proof.
     let l = cert(&certs, "rotl1_injective");
     assert_eq!(
         l["level"],
-        Value::from("L3"),
-        "the @bv64 lemma certifies at L3"
+        Value::from("L4"),
+        "the @bv64 lemma certifies at the caged rung L4 (decidable QF_BV)"
     );
     let lobls = l["obligations"].as_array().expect("lemma obligations");
     assert_eq!(


### PR DESCRIPTION
Stage-3 REQ-2 — lower `@bv`-tagged clauses to QF_BV. Closes #344. Child of the Stage-3 tree (umbrella xl #342 / gh #80; spec `.design/stage3-bv-reconstruction.md` REQ-2 / AC-2, AC-3).

## What ships
- **`EngineName::BitVector`** + a QF_BV engine (`forge/src/bitvector.rs`): tagged clauses render to SMT-LIB2 QF_BV and are decided by **Z3 directly** — the bit-blaster `by(bit_vector)` invokes, reached as its own route per the stage-1 `NlsatEngine` precedent. Direct emission is deliberate: the rendered query *is* the artifact REQ-8 reconstruction replays.
- **Per-clause mixed-mechanism** (the RFC `mix64` shape): one function carries `@bv64` clauses beside an unbounded nlsat clause, each attributed to its engine.
- **64-bit multiplier budget profile**: a `var*var` QF_BV multiply is the cost cliff → reported as `Timeout` under the named profile, never `unknown`, never a silent downgrade.
- **Bit-level `Counterexample`** carrying the witnessing bit pattern.

## Rung: `@bv` certifies at **L4** (orchestrator fix on the kickoff output)
The kickoff agent's cut certified `@bv` at L3. Per RFC-1 §2/§4 a machine-width clause is **L4** (caged): decidable, *complete* bit-pattern countermodels, never degraded — the L3 label conflated rung with trust. This PR flips `@bv` (clauses + lemmas) to `Level::L4` and records the SOLVER trust base (`solver Z3 QF_BV`) **separately** in the per-clause attribution. Rung and trust are orthogonal axes; REQ-8 reconstruction later shrinks the trust at the same rung. `manifest.rs` `Level` docs updated to describe L4 as the caged rung with two routes (nlsat + bv) at different trust bases.

The general Verus/Z3 cage still certifies at L3 in code pending its own promotion — tracked as **#354** (decouple rung from trust; promote the decidable cage to L4). Transient inconsistency until then (`@bv` L4 beside L3 decidable cage clauses), called out in the docs.

## Verification (local, full env: verus + z3 + Lean spine)
- AC-2: `mix64` certifies **L4** with three clauses on two mechanisms (`bitvector` ×2, `nlsat` ×1) ✅
- AC-3: planted non-injective shift → `Counterexample` + bit pattern; over-budget multiplier → `Timeout` under the named profile ✅
- Full `forge` suite green (default + `--features bv`); clippy `-D warnings` + fmt clean both configs; v1 conformance goldens byte-identical; `make doc-drift` exit 0 (9 docs re-pinned).

Commit pins re-pinned to the branch tip; they'll need the usual follow-up re-pin to the squash commit after merge.