### PR TITLE
Stage-3 REQ-3: lock 1 — the bv shadow flag (#345)

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: d4e73f3358cb5f56e616beb9c12c4b143cec56423cdc32e37ba8180c5c433f25 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 59b9f4a82b4a823831351a909b9629c4fcb7f4a40864159e68f4951ed39b5b60 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 59b9f4a82b4a823831351a909b9629c4fcb7f4a40864159e68f4951ed39b5b60 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: cbf1aa9af55a46866180aa3233ac63bb46a12d15344c1aa67b4baf079255a99b (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: d4e73f3358cb5f56e616beb9c12c4b143cec56423cdc32e37ba8180c5c433f25 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 59b9f4a82b4a823831351a909b9629c4fcb7f4a40864159e68f4951ed39b5b60 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 59b9f4a82b4a823831351a909b9629c4fcb7f4a40864159e68f4951ed39b5b60 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: cbf1aa9af55a46866180aa3233ac63bb46a12d15344c1aa67b4baf079255a99b (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 2cdc5bf422f3b228f6ed36b26e1e8635c7aa45519c55462ebf870f238b7e8a4c (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 05f5d23dc12bba4ea92e08c90de02cdb3fb7b7b0cefa254c7526d5e3b9bd7162 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 05f5d23dc12bba4ea92e08c90de02cdb3fb7b7b0cefa254c7526d5e3b9bd7162 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 8f8f63b88632da8cf5ec2f32e21d958864297e60f13834bc740059dc93cc4b90 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/forge/audit-manifest.md
+++ b/.design/forge/audit-manifest.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 1cc9d97c6c5d7eab6109561834db77f2ef4b57ab (re-pinned 2026-06-16: forge workflow status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (#274 — lean_fragment membership report; REQ-7..10 SHIPPED, audit.rs verified-current))
-audited-content-sha256: ef967c1b7caecbfdfffcdc2d17f5a398bebe7e7f567796299130e316f2cfe479
+audited-content-sha256: adf1e73cdae4923311fc2bdac210e295850a490f0edacdc1055a810195dc2458
 governs: forge/src/audit.rs
 thesis-refs:
   - thermite-design.md §6

--- a/.design/forge/certificate-manifest.md
+++ b/.design/forge/certificate-manifest.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: a728d95ca3dbd4fbbee1cb496c003f408d82f327 (re-pinned 2026-06-16 for stage-1 increment 2f, REQ-8: the only change to this doc's governed file (manifest.rs) is the additive Level::L4 kernel-grounded rung (REQ-S1-8); the relax route is reached only via --engine nlsat, so the v1 corpus stays L3 and oracle_subset is byte-identical (check_conformance green).)
-audited-content-sha256: 4bca87d2b943edd733ad6eee60f73b9ae0e38a98794e0760a69ae8c16d7e2576
+audited-content-sha256: 4512e86cd008b19d24163772354b51e36caa51934a2280b10d4906bff16aa3c1
 governs: forge/src/manifest.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: a94d42d87aaabafb6a6bcbaf155cbc5e711ada1e4995558087dceb1251d0d88c (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: d7489f8434e725214492c2d767f84f0d8ca60bcbd26235c2c5e82a8b4248212a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: d7489f8434e725214492c2d767f84f0d8ca60bcbd26235c2c5e82a8b4248212a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: f198f7bd8ab4b04c02775d27fcb1b76d7eeb70c243badbdc8d42ef3c4aa6a544 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/cli.md
+++ b/.design/forge/cli.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: shipped
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (content-sha256 re-pinned 2026-06-21 for stage-2 REQ-8 / AC-8 (#330), faithfulness + two-phase TV + the trust flip: the change to this doc's governed file (cli.rs) is the additive `forge strat-faithful-tv [--generated N] [--seed <u64>] [--json]` subcommand (`Command::StratFaithfulTv` → `run_strat_faithful_tv`, the two-phase TV sweep reporting the phase split + the gated trust profile); every other subcommand + flag parse is unchanged. The legacy commit pin stays at the 5ae0816c stable-main ancestor; only the active content-sha256 digest moves. prior: 2026-06-20 stage-2 REQ-4 / AC-4 (#326) `forge strat-tv` + `ForgeError::StratDifferential`; 2026-06-18 umbrella REQ-2c / AC-4 rotating-seed `--seed` flag on `forge tv`; §6 metrics dashboard `--metrics` value)
-audited-content-sha256: a43d79f4a15eaa8d9d04a886e3cb2ca8c1bf6d362269ef05c97396e56462cb1b
+audited-content-sha256: fefedbf24bbda305680c8fb5947123fd1190ce32279fca0fc21b9f6bb8c86b42
 governs: forge/src/cli.rs
 thesis-refs:
   - thermite-design.md §5

--- a/.design/forge/spec-review.md
+++ b/.design/forge/spec-review.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (review.rs) is the additive REQ-9 burned_lemmas partition + BurnedLemma projection (a certified lemma surfaces like any certified item); the v1 intent-reviewable / battery-failing partitions are unchanged (REQ-S1-9). prior: 92396428567edc6940a9e2845217f5ff4c2ea3c6)
-audited-content-sha256: d02debcf91c918fd4af83dd0904dfb5f01eb7b4ebad4bc7863f382484597a59e
+audited-content-sha256: 929464602833eae2da0eaf906b3d9da5ddf659f8a10e08c273d4d3080a585e5a
 governs: forge/src/review.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 05f5d23dc12bba4ea92e08c90de02cdb3fb7b7b0cefa254c7526d5e3b9bd7162 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 8f8f63b88632da8cf5ec2f32e21d958864297e60f13834bc740059dc93cc4b90 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 2cdc5bf422f3b228f6ed36b26e1e8635c7aa45519c55462ebf870f238b7e8a4c (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 05f5d23dc12bba4ea92e08c90de02cdb3fb7b7b0cefa254c7526d5e3b9bd7162 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-content-sha256: 85f496dfa026da6c22e18849c4feb8cf659df26cba80501aa6cdb43eeb739d60 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: d1ed78a72253dfeb97183c00e4897614dc3aed63423ae42c5ca8dd3e9b3334c1 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-content-sha256: d1ed78a72253dfeb97183c00e4897614dc3aed63423ae42c5ca8dd3e9b3334c1 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: f84412061173c800f88813b4805286e48d662d8b48d1313aae9cfe60662b9438 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/conformance/forge/bv_mixed_audit.th
+++ b/conformance/forge/bv_mixed_audit.th
@@ -1,0 +1,27 @@
+// bv_mixed_audit.th — a project that mixes a `@bv` machine-semantics function with an
+// ordinary unbounded Verus-provable function (stage-3 REQ-3 / AC-4 regression).
+//
+// `forge audit` / `forge review` auto-route a program through the bit-vector engine
+// whenever ANY clause is `@bv`-tagged (so the `bv_shadows` section surfaces). The route
+// MUST be a per-item overlay: only the `@bv`-tagged `fn` is re-derived by the bv engine;
+// an ordinary `fn` keeps its base Verus certificate. Otherwise the ordinary function's
+// non-`@bv`, non-relaxable clause is rejected by the bv route and the audit silently
+// DOWNGRADES a genuine L3 function to L0 — the faithfulness bug this fixture pins.
+//
+//   * `wrap_add` — one `@bv64` clause. Decided by the bit-vector route at L4 (caged), its
+//                  clause flagged in `bv_shadows`.
+//   * `plain_add` — an ordinary linear contract, NO `@bv` tag. Verus proves it at L3, and
+//                   the audit must report L3 (NOT L0) even though the project contains
+//                   `@bv` elsewhere.
+
+fn wrap_add(a: u64, b: u64) -> u64
+    req true
+    ens@bv64 a + b == b + a
+    fx pure
+{ a + b }
+
+fn plain_add(a: u64, b: u64) -> u64
+    req a < 100 && b < 100
+    ens result >= a
+    fx pure
+{ a + b }

--- a/forge/src/audit.rs
+++ b/forge/src/audit.rs
@@ -87,6 +87,53 @@ pub struct AuditManifest {
     /// nothing — it changes no exit code and alters no verdict (REQ-10).
     #[serde(default)]
     pub lean_fragment: LeanFragment,
+    /// The `@bv`-tagged clauses' SHADOW FLAGS (`.design/stage3-bv-reconstruction.md`
+    /// REQ-3 / AC-4 — Lock 1): one row per machine-semantics clause aggregated across the
+    /// cert collection, so the audit lists the project's semantic forks the same way the
+    /// `tcb` lists `#[slag]` blocks. A pure projection of each obligation's `bv_shadow`.
+    /// `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so a pre-amendment v1
+    /// document (no `bv_shadows` key, no `@bv` tag) deserializes and re-serializes
+    /// BYTE-IDENTICALLY (`manifest_version` stays `"v1"`; the additive `lean_fragment`
+    /// discipline). The section gates nothing — informational, like `lean_fragment`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bv_shadows: Vec<BvShadowRow>,
+}
+
+/// One `@bv`-tagged clause's shadow-flag row in the audit manifest
+/// (`.design/stage3-bv-reconstruction.md` REQ-3 / AC-4 — Lock 1). A pure projection of an
+/// obligation's [`crate::manifest::BvShadow`]: the owning item, the per-clause obligation
+/// name, and the shadow block. Never recomputed — read verbatim from the cert (REQ-4).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BvShadowRow {
+    /// The owning item (the `fn` / `lemma` whose clause carries the tag).
+    pub item: String,
+    /// The per-clause obligation name.
+    pub clause: String,
+    /// The shadow flag block (`flagged` / `semantics` / `nowrap_obligation` / `note`,
+    /// RFC §9), read verbatim from the obligation.
+    pub shadow: crate::manifest::BvShadow,
+}
+
+impl BvShadowRow {
+    /// Aggregate every `@bv`-tagged clause's shadow flag across a cert collection
+    /// (REQ-3 / AC-4) — one row per obligation that carries a `bv_shadow`, in cert /
+    /// obligation source order. A pure projection (no recompute); the v1 / untagged
+    /// corpus has none, so the section is empty (and omitted).
+    fn from_certificates(certs: &[Certificate]) -> Vec<Self> {
+        let mut rows = Vec::new();
+        for cert in certs {
+            for obl in &cert.obligations {
+                if let Some(shadow) = &obl.bv_shadow {
+                    rows.push(BvShadowRow {
+                        item: cert.item.clone(),
+                        clause: obl.name.clone(),
+                        shadow: shadow.clone(),
+                    });
+                }
+            }
+        }
+        rows
+    }
 }
 
 /// The `manifest_version` serde default (REQ-1): a v1 document that omits the tag
@@ -555,12 +602,16 @@ impl AuditManifest {
         // The #274 informational membership section (REQ-7): one dry-run
         // `export_item` probe per cert, in source order (REQ-8, pure — no lake/fs).
         let lean_fragment = LeanFragment::from_certificates(certs, program);
+        // Lock 1 (stage-3 REQ-3 / AC-4): the project's `@bv` shadow flags, one row per
+        // tagged clause — a pure projection of the certs' obligations.
+        let bv_shadows = BvShadowRow::from_certificates(certs);
         AuditManifest {
             manifest_version: MANIFEST_VERSION.to_string(),
             functions,
             project_assurance,
             tcb,
             lean_fragment,
+            bv_shadows,
         }
     }
 }

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -1598,9 +1598,7 @@ fn bv_check(base: Vec<Certificate>, program: &Program) -> Vec<Certificate> {
     let mut out = Vec::with_capacity(base.len());
     for cert in base {
         match crate::lean_export::find_item(program, &cert.item) {
-            Some(Item::Fn(f)) if fn_has_bv_tag(f) => {
-                out.push(bv_fn_cert(&bv, &nlsat, f, &cert))
-            }
+            Some(Item::Fn(f)) if fn_has_bv_tag(f) => out.push(bv_fn_cert(&bv, &nlsat, f, &cert)),
             _ => out.push(cert),
         }
     }

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -1582,17 +1582,25 @@ fn nlsat_realwitness_cert(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// The `--engine bv` per-clause bit-vector pass (`.design/stage3-bv-reconstruction.md`
-/// REQ-2). Each `fn` item is rebuilt by [`bv_fn_cert`] (its `ens` clauses dispatched by
-/// their `@bv` tag); each `@bv`-tagged `lemma` is discharged directly by the bit-vector
-/// engine ([`bv_lemma_cert`]). A non-`fn`, non-bv-lemma item keeps its base cert. The
-/// v1 corpus carries no `@bv` tag, so its goldens are byte-identical.
+/// REQ-2). Only a `@bv`-TAGGED `fn` is rebuilt by [`bv_fn_cert`] (its `ens` clauses
+/// dispatched by their `@bv` tag); each `@bv`-tagged `lemma` is discharged directly by
+/// the bit-vector engine ([`bv_lemma_cert`]). An UNTAGGED `fn` — and any non-`fn`,
+/// non-bv-lemma item — keeps its base cert UNCHANGED: the bit-vector route is a per-item
+/// overlay, never a wholesale re-route. This matters because the route is auto-selected
+/// by `forge audit`/`forge review` whenever a program contains *any* `@bv` tag (REQ-3 /
+/// AC-4); routing an ordinary Verus-provable `fn` through the bv route would reject its
+/// non-`@bv`, non-relaxable clauses (`BvUntaggedUnsupported`) and silently DOWNGRADE a
+/// genuine L3 function to L0 in the audit — a faithfulness bug. The v1 corpus carries no
+/// `@bv` tag, so its goldens are byte-identical.
 fn bv_check(base: Vec<Certificate>, program: &Program) -> Vec<Certificate> {
     let bv = crate::bitvector::BitVectorEngine::new();
     let nlsat = crate::engine::NlsatEngine::new(program.clone());
     let mut out = Vec::with_capacity(base.len());
     for cert in base {
         match crate::lean_export::find_item(program, &cert.item) {
-            Some(Item::Fn(f)) => out.push(bv_fn_cert(&bv, &nlsat, f, &cert)),
+            Some(Item::Fn(f)) if fn_has_bv_tag(f) => {
+                out.push(bv_fn_cert(&bv, &nlsat, f, &cert))
+            }
             _ => out.push(cert),
         }
     }
@@ -1635,10 +1643,17 @@ fn lemma_has_bv_tag(l: &thermite_syntax::LemmaItem) -> bool {
 /// reads `false` here.
 pub fn program_has_bv_tag(program: &Program) -> bool {
     program.items.iter().any(|item| match item {
-        Item::Fn(f) => f.contract.ens.iter().any(|c| c.bv.is_some()),
+        Item::Fn(f) => fn_has_bv_tag(f),
         Item::Forge(thermite_syntax::ForgeItem::Lemma(l)) => lemma_has_bv_tag(l),
         _ => false,
     })
+}
+
+/// Does this `fn` carry at least one `@bv`-tagged `ens` clause? Only such a `fn` is
+/// re-derived by the bit-vector route (`bv_check`); an untagged `fn` keeps its base
+/// Verus cert so the auto-routed `forge audit`/`review` never downgrades it.
+fn fn_has_bv_tag(f: &thermite_syntax::FnItem) -> bool {
+    f.contract.ens.iter().any(|c| c.bv.is_some())
 }
 
 /// Does `e` reference the `result` keyword (`.design/stage3-bv-reconstruction.md`

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -1626,6 +1626,21 @@ fn lemma_has_bv_tag(l: &thermite_syntax::LemmaItem) -> bool {
     l.ens.iter().any(|c| c.bv.is_some())
 }
 
+/// Does the program carry ANY `@bv`-tagged clause (`.design/stage3-bv-reconstruction.md`
+/// REQ-3 / AC-4)? `true` iff some `fn`'s `ens` or some `lemma`'s `ens` is `@bv`-tagged.
+/// `forge audit` / `forge review` consult this to route a bit-vector project through the
+/// bv engine (so the shadow flags surface), while a tag-free program — every v1 / non-bv
+/// project — keeps the default Verus pipeline byte-identical. A tag only exists when the
+/// `bv` cargo feature is compiled in (REQ-1's parse gate), so a feature-off build always
+/// reads `false` here.
+pub fn program_has_bv_tag(program: &Program) -> bool {
+    program.items.iter().any(|item| match item {
+        Item::Fn(f) => f.contract.ens.iter().any(|c| c.bv.is_some()),
+        Item::Forge(thermite_syntax::ForgeItem::Lemma(l)) => lemma_has_bv_tag(l),
+        _ => false,
+    })
+}
+
 /// Does `e` reference the `result` keyword (`.design/stage3-bv-reconstruction.md`
 /// REQ-2)? A `@bv` clause that names `result` must have it grounded by the body before
 /// it can be a closed QF_BV query over the parameters.
@@ -1696,7 +1711,7 @@ fn bv_fn_cert(
         if let Some(tag) = &ens.bv {
             let clause_expr = match ground_result_in_clause(f, &ens.expr) {
                 Ok(e) => e,
-                Err(reason) => return bv_skip_cert(&f.name, &effects, slag, k, &reason),
+                Err(reason) => return bv_skip_cert(&f.name, &effects, slag, k, tag, &reason),
             };
             match bv.discharge_bv(&vars, Some(req), &clause_expr, tag.width) {
                 BvOutcome::Proved => {
@@ -1720,7 +1735,7 @@ fn bv_fn_cert(
                     );
                 }
                 BvOutcome::Unknown(reason) => {
-                    return bv_skip_cert(&f.name, &effects, slag, k, &reason);
+                    return bv_skip_cert(&f.name, &effects, slag, k, tag, &reason);
                 }
             }
         } else {
@@ -1824,7 +1839,7 @@ fn bv_lemma_cert(
                 );
             }
             BvOutcome::Unknown(reason) => {
-                return bv_skip_cert(&l.name, &effects, false, k, &reason);
+                return bv_skip_cert(&l.name, &effects, false, k, tag, &reason);
             }
         }
     }
@@ -1856,6 +1871,8 @@ fn bv_proved_obl(
         attr.trust_profile.clone(),
         crate::verdict::CertVerdict::Proved,
     )
+    // Lock 1 (REQ-3 / AC-4): the shadow flag rides every tagged clause's obligation.
+    .with_bv_shadow(bv_shadow_for(tag))
 }
 
 /// The per-clause [`ObligationResult`] an untagged (unbounded) nlsat `Proved` records on
@@ -1891,6 +1908,28 @@ fn bv_semantics_label(tag: &thermite_syntax::BvTag) -> String {
     }
 }
 
+/// Build Lock 1 — the bv shadow flag (`.design/stage3-bv-reconstruction.md` REQ-3 /
+/// AC-4, the RFC §9 shape) — for a tagged clause's obligation from its tag. `flagged`
+/// is always true (it IS a tagged clause), `semantics` is the fixed-width label, and
+/// `note` names the fork + lock. `nowrap_obligation` is the RESERVED slot REQ-5 fills
+/// for the `@bvN(nowrap)` spelling (the `ContractQuality` forward-declaration
+/// precedent): `None` here even for a `nowrap` tag, because this increment ships the
+/// flag, not the side obligation. Pure (R-CODE-5).
+fn bv_shadow_for(tag: &thermite_syntax::BvTag) -> crate::manifest::BvShadow {
+    let semantics = bv_semantics_label(tag);
+    crate::manifest::BvShadow {
+        flagged: true,
+        semantics: semantics.clone(),
+        // REQ-5 (`@bvN(nowrap)` side obligation) fills this; until then it is the
+        // schema-reserved slot, `None` for both the bare and the `nowrap` spelling.
+        nowrap_obligation: None,
+        note: format!(
+            "machine-semantics fork: this clause is interpreted over fixed-width {semantics} \
+             (RFC §9 lock 1 — the shadow flag; stage3-bv-reconstruction.md REQ-3)"
+        ),
+    }
+}
+
 /// The bit-level `Counterexample` cert a falsified `@bv` clause produces (`.design/
 /// stage3-bv-reconstruction.md` REQ-2 / AC-3): a non-certified cert whose diagnostic
 /// carries the witnessing **bit pattern** per variable, with the per-clause
@@ -1916,7 +1955,10 @@ fn bv_counterexample_cert(
         bv_semantics_label(tag)
     );
     let witness_obl =
-        ObligationResult::failed(format!("{item}#ens#{k}"), None, Some(detail.clone()));
+        ObligationResult::failed(format!("{item}#ens#{k}"), None, Some(detail.clone()))
+            // Lock 1 (REQ-3 / AC-4): a refuted tagged clause still carries the shadow flag —
+            // a counterexample is a machine-semantics fact, so the fork must stay visible.
+            .with_bv_shadow(bv_shadow_for(tag));
     let cert_verdict = crate::verdict::CertVerdict::Counterexample {
         obligations: vec![witness_obl.clone()],
     };
@@ -1970,7 +2012,10 @@ fn bv_timeout_cert(
             crate::verdict::CertVerdict::Timeout {
                 detail: format!("budget profile `{profile}`: {detail}"),
             },
-        );
+        )
+        // Lock 1 (REQ-3 / AC-4): the shadow flag rides the timeout obligation too — the
+        // multiplier cliff is a machine-semantics fact, so the fork stays greppable.
+        .with_bv_shadow(bv_shadow_for(tag));
     let mut cert = Certificate::rejected(
         item.to_string(),
         effects.to_vec(),
@@ -1986,20 +2031,38 @@ fn bv_timeout_cert(
 
 /// The honest-skip cert a non-rendering / Z3-absent `@bv` clause produces (`.design/
 /// stage3-bv-reconstruction.md` REQ-2): non-certified, naming the reason — never a false
-/// verdict (the nlsat-route `NlsatUnknown` precedent).
-fn bv_skip_cert(item: &str, effects: &[String], slag: bool, k: usize, reason: &str) -> Certificate {
-    Certificate::rejected(
+/// verdict (the nlsat-route `NlsatUnknown` precedent). It still carries Lock 1 — the
+/// shadow flag (REQ-3 / AC-4): a skipped clause is STILL a `@bv`-tagged clause, so the
+/// machine-semantics fork must stay greppable even when the route could not decide it.
+/// The skip obligation records no engine/trust/verdict (nothing was discharged), only
+/// the failure diagnostic and the shadow flag.
+fn bv_skip_cert(
+    item: &str,
+    effects: &[String],
+    slag: bool,
+    k: usize,
+    tag: &thermite_syntax::BvTag,
+    reason: &str,
+) -> Certificate {
+    let detail = format!(
+        "the bit-vector route did not decide `{item}`'s clause `ens#{k}` (Z3 absent / \
+         outside the QF_BV fragment — NOT certified, an honest skip): {reason}"
+    );
+    let mut cert = Certificate::rejected(
         item.to_string(),
         effects.to_vec(),
         slag,
         RejectReason {
             cause: "BvUnknown".to_string(),
-            detail: format!(
-                "the bit-vector route did not decide `{item}`'s clause `ens#{k}` (Z3 absent / \
-                 outside the QF_BV fragment — NOT certified, an honest skip): {reason}"
-            ),
+            detail: detail.clone(),
         },
-    )
+    );
+    cert.obligations =
+        vec![
+            ObligationResult::failed(format!("{item}#ens#{k}"), None, Some(detail))
+                .with_bv_shadow(bv_shadow_for(tag)),
+        ];
+    cert
 }
 
 // The G1 gate route (`.design/stage1-forge-tier.md` REQ-10 / AC-14): the per-clause

--- a/forge/src/cli.rs
+++ b/forge/src/cli.rs
@@ -1808,16 +1808,9 @@ fn run_audit(
     meaning: bool,
     metrics: bool,
 ) -> Result<ExitCode, ForgeError> {
-    // The same default pipeline `forge check` runs (REQ-4 — aggregation, never
-    // re-derivation): `check_file` is the canonical default-config entry (the only
-    // one that serves / populates the shared proof cache). The audit re-runs no
-    // verus, re-scores no mutants — it projects the cert collection this returns.
-    let certs = check::check_file(file)?;
-
     // Parse the file once for the boundary contracts' enforced req/ens/fx (the
-    // §9 per-function contracts the TCB enumerates). A pure read of the parsed AST
-    // — `check_file` already validated it parses clean, so this is re-parse of a
-    // known-good file (deterministic, R-CODE-5), never a re-verification.
+    // §9 per-function contracts the TCB enumerates) AND to decide the route below.
+    // A pure read of the parsed AST (deterministic, R-CODE-5), never a verification.
     let src = std::fs::read_to_string(file).map_err(|e| ForgeError::Io {
         path: file.display().to_string(),
         source: e,
@@ -1826,6 +1819,24 @@ fn run_audit(
     if !parsed.is_clean() {
         return Err(ForgeError::Parse(parsed.errors));
     }
+
+    // The cert collection the audit projects (REQ-4 — aggregation, never re-derivation).
+    // A bit-vector project (any `@bv`-tagged clause, stage-3 REQ-3 / AC-4) routes through
+    // the bv engine so the per-clause shadow flags surface in the audit's `bv_shadows`
+    // section — auditing a machine-semantics clause via the unbounded Verus path would be
+    // wrong. Every tag-free project (the whole v1 corpus) keeps the default `check_file`
+    // pipeline byte-identical (the canonical default-config entry that serves the cache).
+    let certs = if check::program_has_bv_tag(&parsed.program) {
+        check::check_file_with_engine(
+            file,
+            check::CheckOptions {
+                engine: check::EngineSelection::Bv,
+                ..Default::default()
+            },
+        )?
+    } else {
+        check::check_file(file)?
+    };
 
     // The toolchain identity (the irreducible §9 TCB residue): the verus version
     // (the same deterministic sourcing the proof cache uses) + the compile-time
@@ -2734,6 +2745,22 @@ fn render_review(artifact: &ReviewArtifact) -> String {
             ));
         }
     }
+    // Lock 1 — the bv shadow flags (`.design/stage3-bv-reconstruction.md` REQ-3 / AC-4):
+    // every `@bv`-tagged clause's machine-semantics fork, line-oriented and greppable
+    // (the "`grep slag` is the complete inventory" discipline). Omitted when empty.
+    if !artifact.bv_shadows.is_empty() {
+        out.push_str("\nbv shadows (machine-semantics forks — RFC §9 lock 1, the shadow flag):\n");
+        for s in &artifact.bv_shadows {
+            let nowrap = match &s.shadow.nowrap_obligation {
+                Some(v) => format!(" nowrap_obligation={v}"),
+                None => String::new(),
+            };
+            out.push_str(&format!(
+                "  bv_shadow: {} [{}] flagged={} semantics={}{nowrap} — {}\n",
+                s.item, s.clause, s.shadow.flagged, s.shadow.semantics, s.shadow.note
+            ));
+        }
+    }
     out
 }
 
@@ -2960,6 +2987,26 @@ fn render_audit(manifest: &AuditManifest) -> String {
             ));
         }
     }
+
+    // Lock 1 — the bv shadow flags (`.design/stage3-bv-reconstruction.md` REQ-3 / AC-4):
+    // every `@bv`-tagged clause's machine-semantics fork, listed the way the TCB lists
+    // `#[slag]` blocks (a line-oriented, greppable inventory). Always emitted so the
+    // "(none)" line is itself an auditable statement; informational — it gates nothing.
+    out.push_str("bv shadows (machine-semantics forks — RFC §9 lock 1):\n");
+    if manifest.bv_shadows.is_empty() {
+        out.push_str("  bv_shadow: (none) — no @bv-tagged (machine-semantics) clauses\n");
+    } else {
+        for s in &manifest.bv_shadows {
+            let nowrap = match &s.shadow.nowrap_obligation {
+                Some(v) => format!(" nowrap_obligation={v}"),
+                None => String::new(),
+            };
+            out.push_str(&format!(
+                "  bv_shadow: {} [{}] flagged={} semantics={}{nowrap}\n",
+                s.item, s.clause, s.shadow.flagged, s.shadow.semantics
+            ));
+        }
+    }
     out
 }
 
@@ -3009,8 +3056,17 @@ fn render_human(cert: &Certificate) -> String {
     // item / level / effects / slag — the fields the cert-oracle compares — are
     // rendered first, then the non-deterministic `solver_time_ms` labelled as
     // such so a reader does not mistake it for an oracle field.
-    let (item, level, effects, slag, boundary, _scope_end_to_end, _covenant_evidence, _meaning) =
-        cert.oracle_subset();
+    let (
+        item,
+        level,
+        effects,
+        slag,
+        boundary,
+        _scope_end_to_end,
+        _covenant_evidence,
+        _meaning,
+        _bv_shadows,
+    ) = cert.oracle_subset();
     let mut out = String::new();
     out.push_str(&format!("item: {item}\n"));
     out.push_str(&format!("level: {}\n", level_str(level)));

--- a/forge/src/manifest.rs
+++ b/forge/src/manifest.rs
@@ -271,6 +271,47 @@ pub struct ObligationResult {
     /// so the golden oracle is unperturbed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verdict: Option<crate::verdict::CertVerdict>,
+    /// (Schema v2, REQ-3 / AC-4 — `.design/stage3-bv-reconstruction.md`) Lock 1, the
+    /// SHADOW FLAG (RFC §9 shape): present on every `@bv`-tagged clause's obligation,
+    /// absent on every untagged / v1 clause. The machine-semantics fork is then
+    /// impossible to hide — `grep bv_shadow` over the certificates ≡ exactly the set of
+    /// tagged clauses, the same "`grep slag` is the complete inventory" discipline the
+    /// `#[slag]` block follows. Additive, `#[serde(default, skip_serializing_if =
+    /// "Option::is_none")]` (the `engine`/`trust`/`verdict` precedent), so the v1 golden
+    /// certs — which omit it — deserialize unchanged and re-serialize byte-identically.
+    /// Oracle-INCLUDED via [`Certificate::oracle_subset`] (Q-ORACLE: deterministic +
+    /// verdict-relevant → included), unlike the provenance-only `engine`/`trust`: a
+    /// semantic fork changes what the clause MEANS, so the oracle pins it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bv_shadow: Option<BvShadow>,
+}
+
+/// Lock 1, the bv SHADOW FLAG (`.design/stage3-bv-reconstruction.md` REQ-3 / AC-4 — the
+/// RFC §9 shape). Every `@bv`-tagged clause's certificate carries this block, so a
+/// fixed-width machine-semantics clause is loud and greppable at every layer `#[slag]`
+/// is (the certificate JSON, `forge review`, `forge audit`). The first of the three
+/// locks that ship inside gate G3 with the `@bv` feature itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BvShadow {
+    /// Always `true` for a tagged clause — the flag that says "this clause is
+    /// interpreted over a fixed-width machine-semantics fork, not the default unbounded
+    /// integers". The grep anchor: a present `bv_shadow` (with `flagged: true`) marks a
+    /// tagged clause.
+    pub flagged: bool,
+    /// The fixed-width semantics the clause was interpreted over, e.g.
+    /// `"bv64 (wraparound)"` / `"bv32 (nowrap)"` (the `check::bv_semantics_label`
+    /// shape) — the named fork, so a reader sees WHICH machine semantics this clause
+    /// committed to.
+    pub semantics: String,
+    /// The `@bvN(nowrap)` no-overflow side obligation's verdict (REQ-5 / AC-6). `None`
+    /// for a bare `@bvN` (no side obligation requested), and a RESERVED slot until REQ-5
+    /// fills it for the `nowrap` spelling — the schema-reserves-the-slot,
+    /// producer-fills-the-value forward-declaration precedent ([`ContractQuality`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nowrap_obligation: Option<String>,
+    /// A human note naming the fork + the lock (the auditor's one-line "why this block
+    /// is here"). Deterministic (R-CODE-5).
+    pub note: String,
 }
 
 impl ObligationResult {
@@ -286,6 +327,7 @@ impl ObligationResult {
             engine: None,
             trust: Vec::new(),
             verdict: None,
+            bv_shadow: None,
         }
     }
 
@@ -304,6 +346,7 @@ impl ObligationResult {
             engine: None,
             trust: Vec::new(),
             verdict: None,
+            bv_shadow: None,
         }
     }
 
@@ -321,6 +364,17 @@ impl ObligationResult {
         self.engine = Some(engine.into());
         self.trust = trust;
         self.verdict = Some(verdict);
+        self
+    }
+
+    /// Attach Lock 1, the bv shadow flag (REQ-3 / AC-4) — the RFC §9 visibility lock
+    /// every `@bv`-tagged clause's obligation carries. Orthogonal to
+    /// [`ObligationResult::with_clause_attribution`] (engine/trust/verdict are
+    /// provenance; the shadow flag is the semantic-fork marker), so the two compose on a
+    /// single tagged-clause obligation.
+    #[must_use]
+    pub fn with_bv_shadow(mut self, shadow: BvShadow) -> Self {
+        self.bv_shadow = Some(shadow);
         self
     }
 }
@@ -1164,12 +1218,23 @@ impl Certificate {
     /// authoring spend without changing what was proven, so it is oracle-excluded like
     /// `solver_time_ms` — a forge-tier cert and the same cert with its `burn` stripped
     /// compare oracle-equal.
+    ///
+    /// `bv_shadows` is the Lock 1 shadow flag (stage-3 REQ-3 / AC-4, Q-ORACLE:
+    /// deterministic + verdict-relevant → included): the PRESENT `bv_shadow` blocks, in
+    /// obligation source order. It is FILTERED to the tagged clauses (not one slot per
+    /// obligation) so a v1 / untagged cert — whatever its obligation count, including a
+    /// hand-authored golden with no `obligations` key — contributes an EMPTY vec and stays
+    /// oracle-byte-identical (the obligation count was never an oracle field and must not
+    /// become one). A tagged clause's machine-semantics fork is then oracle-visible (a
+    /// semantic fork CHANGES what the clause means — it cannot drift silently, unlike the
+    /// provenance-only `engine`/`trust`, which stay oracle-excluded).
     #[allow(
         clippy::type_complexity,
         reason = "the oracle subset is deliberately a flat positional tuple of the \
                   verdict-relevant fields (item/level/effects/slag/boundary/end_to_end/\
-                  covenant/meaning) — a named struct would obscure that this IS the exact \
-                  comparison surface the cert oracle compares; the tuple is the contract."
+                  covenant/meaning/bv_shadows) — a named struct would obscure that this IS \
+                  the exact comparison surface the cert oracle compares; the tuple is the \
+                  contract."
     )]
     pub fn oracle_subset(
         &self,
@@ -1182,6 +1247,7 @@ impl Certificate {
         bool,
         Option<crate::covenant_engine::CovenantEvidence>,
         Option<crate::meaning::MeaningAudit>,
+        Vec<BvShadow>,
     ) {
         (
             &self.item,
@@ -1192,6 +1258,10 @@ impl Certificate {
             scope_is_end_to_end(&self.assurance_scope),
             self.covenant_evidence,
             self.meaning_audit.clone(),
+            self.obligations
+                .iter()
+                .filter_map(|o| o.bv_shadow.clone())
+                .collect(),
         )
     }
 }
@@ -1544,6 +1614,101 @@ mod tests {
                 && ft_json.contains("\"verdict\"")
                 && ft_json.contains("Proved"),
             "a populated forge-tier clause must serialize the per-clause block: {ft_json}"
+        );
+    }
+
+    // Stage-3 REQ-3 / AC-4 (Lock 1, the shadow flag): the `bv_shadow` field is additive —
+    // a v1 / untagged clause omits it (byte-identical goldens), a tagged clause serializes
+    // the RFC §9 block, and `nowrap_obligation` is the reserved (None → omitted) slot.
+    #[test]
+    fn bv_shadow_is_additive_and_serializes_the_rfc9_shape() {
+        // A v1-shape clause (no shadow) must NOT serialize a `bv_shadow` key — so the v1
+        // goldens stay byte-identical (the `engine`/`trust`/`verdict` discipline).
+        let v1 = Certificate::new(
+            "sum",
+            Level::L3,
+            vec!["pure".to_string()],
+            0,
+            vec![ObligationResult::discharged("sum_check::sum")],
+        );
+        assert!(
+            !serialize(&v1).contains("bv_shadow"),
+            "a clause with no shadow flag must omit `bv_shadow` (skip_serializing_if)"
+        );
+
+        // A tagged clause serializes the RFC §9 block; `nowrap_obligation` is the reserved
+        // slot (None → omitted, never a placeholder — the `suggested_move` precedent).
+        let tagged = Certificate::new(
+            "mix64",
+            Level::L4,
+            vec!["pure".to_string()],
+            0,
+            vec![
+                ObligationResult::discharged("mix64::ens#0").with_bv_shadow(BvShadow {
+                    flagged: true,
+                    semantics: "bv64 (wraparound)".to_string(),
+                    nowrap_obligation: None,
+                    note: "machine-semantics fork".to_string(),
+                }),
+            ],
+        );
+        let json = serialize(&tagged);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        let shadow = &v["obligations"][0]["bv_shadow"];
+        assert_eq!(shadow["flagged"], serde_json::Value::Bool(true));
+        assert_eq!(
+            shadow["semantics"],
+            serde_json::Value::from("bv64 (wraparound)")
+        );
+        assert!(shadow.get("note").is_some(), "the §9 note is present");
+        assert!(
+            shadow.get("nowrap_obligation").is_none(),
+            "the reserved `nowrap_obligation` slot (None) is omitted, not a placeholder \
+             (REQ-5 fills it): {json}"
+        );
+        // Round-trips: deserialize → re-serialize is byte-stable.
+        let back: Certificate = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(serialize(&back), json, "the shadow block round-trips");
+    }
+
+    // Stage-3 REQ-3 / AC-4: the shadow flag is ORACLE-INCLUDED (Q-ORACLE: deterministic +
+    // verdict-relevant → included) — two certs differing ONLY in an obligation's
+    // `bv_shadow` compare oracle-UNEQUAL, unlike the provenance-only engine/trust (which
+    // are oracle-excluded). A semantic fork cannot drift silently.
+    #[test]
+    fn bv_shadow_is_oracle_included() {
+        let bare = Certificate::new(
+            "mix64",
+            Level::L4,
+            vec!["pure".to_string()],
+            0,
+            vec![ObligationResult::discharged("mix64::ens#0")],
+        );
+        let mut shadowed = bare.clone();
+        shadowed.obligations[0] =
+            ObligationResult::discharged("mix64::ens#0").with_bv_shadow(BvShadow {
+                flagged: true,
+                semantics: "bv64 (wraparound)".to_string(),
+                nowrap_obligation: None,
+                note: "machine-semantics fork".to_string(),
+            });
+        assert!(
+            !oracle_eq(&bare, &shadowed),
+            "the oracle must DISTINGUISH a tagged clause from an untagged one (the fork is \
+             verdict-relevant — REQ-3 / AC-4)"
+        );
+        // But engine/trust attribution differences alone stay oracle-EXCLUDED (provenance).
+        let mut attributed = bare.clone();
+        attributed.obligations[0] = ObligationResult::discharged("mix64::ens#0")
+            .with_clause_attribution(
+                "bitvector",
+                vec!["solver Z3 QF_BV".to_string()],
+                crate::verdict::CertVerdict::Proved,
+            );
+        assert!(
+            oracle_eq(&bare, &attributed),
+            "engine/trust attribution is provenance — oracle-excluded (the existing \
+             discipline; only the shadow flag joins the oracle)"
         );
     }
 

--- a/forge/src/review.rs
+++ b/forge/src/review.rs
@@ -240,6 +240,32 @@ pub struct ReviewArtifact {
     /// only, mirroring the cert layer's additive discipline).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub burned_lemmas: Vec<BurnedLemma>,
+    /// The `@bv`-tagged clauses' SHADOW FLAGS (`.design/stage3-bv-reconstruction.md`
+    /// REQ-3 / AC-4 — Lock 1): every machine-semantics clause surfaced for review, so a
+    /// reviewer sees the project's semantic forks alongside the contracts. One entry per
+    /// tagged clause (read from each obligation's `bv_shadow`), in cert/obligation order.
+    /// Omitted (empty) on the default Verus path / the v1 corpus (no `@bv` tag), and
+    /// `#[serde(default, skip_serializing_if)]` so a v1 review artifact serializes
+    /// BYTE-IDENTICALLY (the additive `burned_lemmas` discipline). `grep bv_shadow` over
+    /// `forge review --json` ≡ the project's tagged clauses (AC-4).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bv_shadows: Vec<BvShadowClause>,
+}
+
+/// One `@bv`-tagged clause's shadow flag in the review artifact
+/// (`.design/stage3-bv-reconstruction.md` REQ-3 / AC-4 — Lock 1). A pure projection of an
+/// obligation's [`crate::manifest::BvShadow`]: the owning item, the per-clause obligation
+/// name, and the shadow block (flag + semantics + reserved `nowrap_obligation` + note).
+/// Never fabricated — read verbatim from the cert (R-CODE-5).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BvShadowClause {
+    /// The owning item (the `fn` / `lemma` whose clause carries the tag).
+    pub item: String,
+    /// The per-clause obligation name (e.g. `mix64::ens#0: …` / `mix64#ens#0`).
+    pub clause: String,
+    /// The shadow flag block — `flagged` / `semantics` / `nowrap_obligation` / `note`
+    /// (RFC §9), read verbatim from the obligation.
+    pub shadow: crate::manifest::BvShadow,
 }
 
 /// One burned forge-tier lemma in the review artifact (`.design/stage1-forge-tier.md` REQ-9,
@@ -309,13 +335,9 @@ pub fn review_file(
 ) -> Result<ReviewArtifact, ForgeError> {
     let path = path.as_ref();
 
-    // The same default pipeline `forge check`/`forge audit` run (the battery
-    // verdict; REQ-2). `review` re-runs no verus — it projects this collection.
-    let certs = check::check_file(path)?;
-
-    // Parse the file once for the contract surface (REQ-1). `check_file` already
-    // validated it parses clean, so this is a re-parse of a known-good file
-    // (deterministic, R-CODE-5), never a re-verification — the `audit` precedent.
+    // Parse the file once for the contract surface (REQ-1) AND to decide the route
+    // below. A re-parse of a file `check_file` re-validates (deterministic, R-CODE-5),
+    // never a re-verification — the `audit` precedent.
     let src = std::fs::read_to_string(path).map_err(|e| ForgeError::Io {
         path: path.display().to_string(),
         source: e,
@@ -324,6 +346,23 @@ pub fn review_file(
     if !parsed.is_clean() {
         return Err(ForgeError::Parse(parsed.errors));
     }
+
+    // The battery cert collection `review` projects (REQ-2 — re-runs no verus). A
+    // bit-vector project (any `@bv`-tagged clause, stage-3 REQ-3 / AC-4) routes through
+    // the bv engine so the per-clause shadow flags surface in the artifact's `bv_shadows`
+    // section; every tag-free project (the whole v1 corpus) keeps the default `check_file`
+    // pipeline byte-identical (the same collection `forge check`/`forge audit` project).
+    let certs = if check::program_has_bv_tag(&parsed.program) {
+        check::check_file_with_engine(
+            path,
+            check::CheckOptions {
+                engine: check::EngineSelection::Bv,
+                ..Default::default()
+            },
+        )?
+    } else {
+        check::check_file(path)?
+    };
 
     Ok(project_artifact(&certs, &parsed.program, item_filter))
 }
@@ -360,11 +399,27 @@ fn project_artifact(
     let mut intent_reviewable = Vec::new();
     let mut battery_failing = Vec::new();
     let mut burned_lemmas = Vec::new();
+    let mut bv_shadows = Vec::new();
 
     for cert in certs {
         if let Some(filter) = item_filter {
             if cert.item != filter {
                 continue;
+            }
+        }
+        // Lock 1 (`.design/stage3-bv-reconstruction.md` REQ-3 / AC-4): surface every
+        // `@bv`-tagged clause's shadow flag, read verbatim from its obligations. This is
+        // ORTHOGONAL to the battery partition below (a tagged clause surfaces whether its
+        // item certifies, fails, or is a lemma), so it runs over every cert before the
+        // partition's `continue`s — the machine-semantics fork stays visible regardless of
+        // verdict.
+        for obl in &cert.obligations {
+            if let Some(shadow) = &obl.bv_shadow {
+                bv_shadows.push(BvShadowClause {
+                    item: cert.item.clone(),
+                    clause: obl.name.clone(),
+                    shadow: shadow.clone(),
+                });
             }
         }
         // A BURNED forge-tier lemma surfaces like any certified item (REQ-9, increment 3):
@@ -412,6 +467,7 @@ fn project_artifact(
         intent_reviewable,
         battery_failing,
         burned_lemmas,
+        bv_shadows,
     }
 }
 

--- a/forge/tests/bv_lowering.rs
+++ b/forge/tests/bv_lowering.rs
@@ -365,6 +365,51 @@ fn forge_audit_lists_the_bv_shadows() {
     );
 }
 
+/// REQ-3 / AC-4 regression: the auto-routed bv engine (`forge audit`/`review`) is a
+/// PER-ITEM overlay, never a wholesale re-route. An ordinary Verus-provable `fn` that
+/// merely shares a program with a `@bv` `fn` keeps its true L3 cert — it is NOT downgraded
+/// to L0. (Before the `bv_check` fix, every `fn` was routed through the bv route, whose
+/// untagged-clause branch rejects a non-`@bv`, non-relaxable clause — silently downgrading
+/// `plain_add` from L3 to L0 in the audit.)
+#[test]
+fn audit_of_a_mixed_bv_program_keeps_ordinary_fns_at_their_verus_level() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — the bit-vector route is not run.");
+        return;
+    }
+    let (_code, manifest) = run_forge_json("audit", "bv_mixed_audit.th");
+    let funcs = manifest["functions"]
+        .as_array()
+        .expect("the audit manifest carries a functions section");
+    let level_of = |name: &str| -> String {
+        funcs
+            .iter()
+            .find(|r| r["name"] == name)
+            .unwrap_or_else(|| panic!("function `{name}` is in the audit: {manifest}"))["level"]
+            .as_str()
+            .unwrap_or("")
+            .to_string()
+    };
+    // The `@bv` fn certifies at the caged rung L4 via the bit-vector route.
+    assert_eq!(level_of("wrap_add"), "L4", "the @bv fn is L4: {manifest}");
+    // The ordinary fn KEEPS its Verus L3 — the auto-route must not touch it.
+    assert_eq!(
+        level_of("plain_add"),
+        "L3",
+        "an ordinary Verus-provable fn sharing the file with a @bv fn stays L3, not L0: {manifest}"
+    );
+    // The shadow surface still works — exactly the one tagged clause is listed.
+    let shadows = manifest["bv_shadows"]
+        .as_array()
+        .expect("bv_shadows section present");
+    assert_eq!(
+        shadows.len(),
+        1,
+        "exactly the wrap_add @bv clause is shadowed (plain_add contributes none): {manifest}"
+    );
+    assert_eq!(shadows[0]["item"], "wrap_add");
+}
+
 /// AC-4: `forge review` lists the bv shadows — the spec-intent review artifact's additive
 /// `bv_shadows` section surfaces every tagged clause's machine-semantics fork for the
 /// reviewer.

--- a/forge/tests/bv_lowering.rs
+++ b/forge/tests/bv_lowering.rs
@@ -217,3 +217,176 @@ fn over_budget_multiplier_is_timeout_under_named_profile_never_unknown() {
         );
     }
 }
+
+/// Run a forge subcommand over a conformance example, returning `(exit, parsed JSON)`.
+fn run_forge_json(subcommand: &str, example: &str) -> (Option<i32>, Value) {
+    let th = repo_root().join("conformance/forge").join(example);
+    let out = Command::new(forge_bin())
+        .arg(subcommand)
+        .arg(&th)
+        .arg("--json")
+        .output()
+        .unwrap_or_else(|e| panic!("spawn forge {subcommand}: {e}"));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let value: Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "forge {subcommand} --json must emit one JSON document: {e}\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    (out.status.code(), value)
+}
+
+/// Count the obligations carrying a `bv_shadow` block across a cert array (AC-4 — the
+/// grep-completeness count: `grep bv_shadow` ≡ the tagged clauses).
+fn shadowed_clause_count(certs: &[Value]) -> usize {
+    certs
+        .iter()
+        .flat_map(|c| c["obligations"].as_array().cloned().unwrap_or_default())
+        .filter(|o| o.get("bv_shadow").is_some())
+        .count()
+}
+
+/// AC-4 (Lock 1 — the shadow flag): every `@bv`-tagged clause's certificate carries
+/// `bv_shadow` (the RFC §9 shape) and NOTHING untagged does — `grep bv_shadow` over the
+/// certs ≡ exactly the tagged clauses. `mix64` has two `@bv64` clauses + one unbounded
+/// clause, plus the injectivity lemma's `@bv64` clause: three tagged clauses carry the
+/// flag, the unbounded clause does not. `nowrap_obligation` is the reserved (REQ-5) slot,
+/// absent for a bare `@bv64`.
+#[test]
+fn every_bv_tagged_clause_carries_the_shadow_flag_and_nothing_else() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — the bit-vector route is not run.");
+        return;
+    }
+    let (code, certs) = run_bv("mix64.th");
+    assert_eq!(code, Some(0), "mix64 certifies");
+
+    let m = cert(&certs, "mix64");
+    let obls = m["obligations"].as_array().expect("obligations array");
+    // The two `@bv64` clauses carry the shadow flag naming the wraparound semantics.
+    for k in [0usize, 1] {
+        let s = &obls[k]["bv_shadow"];
+        assert_eq!(
+            s["flagged"],
+            Value::Bool(true),
+            "ens#{k} is flagged as a machine-semantics fork"
+        );
+        let semantics = s["semantics"].as_str().unwrap_or("");
+        assert!(
+            semantics.contains("bv64") && semantics.contains("wraparound"),
+            "ens#{k} names its fixed-width wraparound semantics: {s}"
+        );
+        assert!(s.get("note").is_some(), "ens#{k} carries the §9 note");
+        assert!(
+            s.get("nowrap_obligation").is_none(),
+            "the reserved nowrap_obligation slot (REQ-5) is omitted for a bare @bv64: {s}"
+        );
+    }
+    // The untagged (unbounded) clause carries NO shadow flag — grep finds nothing else.
+    assert!(
+        obls[2].get("bv_shadow").is_none(),
+        "the untagged unbounded clause has no shadow flag: {}",
+        obls[2]
+    );
+
+    // The injectivity lemma's `@bv64` clause carries it too.
+    let l = cert(&certs, "rotl1_injective");
+    let ls = &l["obligations"][0]["bv_shadow"];
+    assert_eq!(
+        ls["flagged"],
+        Value::Bool(true),
+        "the lemma clause is flagged"
+    );
+    assert!(
+        ls["semantics"].as_str().unwrap_or("").contains("bv64"),
+        "the lemma clause names its bv64 semantics: {ls}"
+    );
+
+    // Grep-completeness over the WHOLE cert collection: exactly the three tagged clauses
+    // (mix64::ens#0, mix64::ens#1, rotl1_injective::ens#0) carry bv_shadow.
+    assert_eq!(
+        shadowed_clause_count(&certs),
+        3,
+        "exactly the three @bv-tagged clauses carry bv_shadow (and nothing else)"
+    );
+}
+
+/// AC-4: a refuted `@bv` clause STILL carries the shadow flag — a counterexample is a
+/// machine-semantics fact, so the fork stays greppable even on a hard fail.
+#[test]
+fn a_refuted_bv_clause_still_carries_the_shadow_flag() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — the bit-vector route is not run.");
+        return;
+    }
+    let (_code, certs) = run_bv("bv_shl_not_injective.th");
+    let c = cert(&certs, "shl1_injective_BROKEN");
+    let s = &c["obligations"][0]["bv_shadow"];
+    assert_eq!(
+        s["flagged"],
+        Value::Bool(true),
+        "the refuted clause is still flagged as a machine-semantics fork: {c}"
+    );
+    assert!(s["semantics"].as_str().unwrap_or("").contains("bv64"));
+}
+
+/// AC-4: `forge audit` lists the bv shadows — auditing a bit-vector project routes
+/// through the bv engine, so the manifest's additive `bv_shadows` section enumerates
+/// every tagged clause (the way the TCB enumerates `#[slag]` blocks).
+#[test]
+fn forge_audit_lists_the_bv_shadows() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — forge audit's bv route is not run.");
+        return;
+    }
+    let (_code, manifest) = run_forge_json("audit", "mix64.th");
+    let shadows = manifest["bv_shadows"]
+        .as_array()
+        .expect("the audit manifest carries a bv_shadows section");
+    assert_eq!(
+        shadows.len(),
+        3,
+        "the audit lists all three @bv-tagged clauses: {manifest}"
+    );
+    assert!(
+        shadows
+            .iter()
+            .all(|s| s["shadow"]["flagged"] == Value::Bool(true)),
+        "every listed shadow is flagged"
+    );
+    assert!(
+        shadows.iter().any(|s| s["item"] == "mix64"),
+        "the mix64 fn's tagged clauses are listed"
+    );
+    assert!(
+        shadows.iter().any(|s| s["item"] == "rotl1_injective"),
+        "the lemma's tagged clause is listed"
+    );
+}
+
+/// AC-4: `forge review` lists the bv shadows — the spec-intent review artifact's additive
+/// `bv_shadows` section surfaces every tagged clause's machine-semantics fork for the
+/// reviewer.
+#[test]
+fn forge_review_lists_the_bv_shadows() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — forge review's bv route is not run.");
+        return;
+    }
+    let (_code, artifact) = run_forge_json("review", "mix64.th");
+    let shadows = artifact["bv_shadows"]
+        .as_array()
+        .expect("the review artifact carries a bv_shadows section");
+    assert_eq!(
+        shadows.len(),
+        3,
+        "the review lists all three @bv-tagged clauses: {artifact}"
+    );
+    assert!(
+        shadows
+            .iter()
+            .all(|s| s["shadow"]["flagged"] == Value::Bool(true)),
+        "every reviewed shadow is flagged"
+    );
+}


### PR DESCRIPTION
Stage-3 REQ-3 — lock 1, the `@bv` shadow flag. Closes #345. Child of the Stage-3 tree (umbrella xl #342 / gh #80; spec `.design/stage3-bv-reconstruction.md` REQ-3 / AC-4).

## What ships
- **`bv_shadow { flagged, semantics, nowrap_obligation, note }`** (RFC §9) as an **additive** schema-v2 field on `ObligationResult` — `#[serde(default, skip_serializing_if)]`, so v1 conformance goldens stay byte-identical. Attached to every `@bv`-tagged obligation (proved / counterexample / timeout / skip); untagged clauses carry none.
- **Oracle-included** (Q-ORACLE precedent) — the filtered present-shadows vec, so an untagged cert contributes `[]` regardless of obligation count (fixes an oracle-determinism leak).
- **Greppable everywhere `#[slag]` is**: cert JSON, `forge review`, `forge audit` — both gain an additive `bv_shadows` section; `cli` renders both.

## Orchestrator fix on the kickoff output: per-item overlay (the faithfulness bug)
The agent auto-routed `forge audit`/`review` through the bv engine for any `@bv`-containing program (needed so `bv_shadows` surfaces) — but `bv_check` re-derived **every** fn, and its untagged-clause branch rejects non-`@bv`, non-relaxable clauses. So an ordinary Verus-provable fn sharing a file with a `@bv` fn was **silently downgraded L3 → L0** in the audit.

Fix: `bv_check` re-derives **only `@bv`-tagged fns**; untagged fns keep their base Verus cert (`fn_has_bv_tag`). Verified on a mixed fixture: `wrap_add` L4, `plain_add` **L3** (was L0). Regression test + `conformance/forge/bv_mixed_audit.th` pin it.

## Verification (full env: verus + z3 + Lean spine)
- AC-4: every `@bv` clause carries `bv_shadow`, nothing else does (grep-completeness); refuted clauses stay flagged; `forge audit`/`review` list them. ✅
- The per-item-overlay regression test passes; full `forge` suite green; clippy `-D warnings` + fmt clean both configs; v1 goldens byte-identical; `make doc-drift` exit 0 (10 docs re-pinned — all content-sha now, no commit-pin tax).