### PR TITLE
Stage-3 REQ-5: lock 3 — the nowrap side obligation (#347)

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: c696c12acddb7b4656b97509485896c0eb59988eec493945544f430e37f3929b (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 0be0416df846c149e4d5b6feaf22596d7ab912906bd992184cb63eec8d0e9723 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: c696c12acddb7b4656b97509485896c0eb59988eec493945544f430e37f3929b (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 0be0416df846c149e4d5b6feaf22596d7ab912906bd992184cb63eec8d0e9723 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 2fa3810e9114664162a12a484d3cdafd46714c1b99ea702ae39a0c23e390c51b (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: d0c4fbe0d63a277d88f9ef408d7500b52adfdd614a1e0a898fd6fcb9e291787a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/forge/certificate-manifest.md
+++ b/.design/forge/certificate-manifest.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: a728d95ca3dbd4fbbee1cb496c003f408d82f327 (re-pinned 2026-06-16 for stage-1 increment 2f, REQ-8: the only change to this doc's governed file (manifest.rs) is the additive Level::L4 kernel-grounded rung (REQ-S1-8); the relax route is reached only via --engine nlsat, so the v1 corpus stays L3 and oracle_subset is byte-identical (check_conformance green).)
-audited-content-sha256: 4512e86cd008b19d24163772354b51e36caa51934a2280b10d4906bff16aa3c1
+audited-content-sha256: 2cdf497e1e3d46002eea1f9a3e3142ef65c13727ff3b9bdd345c3b4db159ec2a
 governs: forge/src/manifest.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 9e6c9f5b3ffa1b99a11d1ca47fd95664175cf01a0adeb33db70649ad89b3bcc0 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 55156905add8adc25c30958b13c9136079c53e8c7393b35049e67da7bb22b420 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/spec-review.md
+++ b/.design/forge/spec-review.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (review.rs) is the additive REQ-9 burned_lemmas partition + BurnedLemma projection (a certified lemma surfaces like any certified item); the v1 intent-reviewable / battery-failing partitions are unchanged (REQ-S1-9). prior: 92396428567edc6940a9e2845217f5ff4c2ea3c6)
-audited-content-sha256: 929464602833eae2da0eaf906b3d9da5ddf659f8a10e08c273d4d3080a585e5a
+audited-content-sha256: 835a51237e78d06896155aff194ef58091b658ed34a04ea32f7b9e13f4de1c3c
 governs: forge/src/review.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 2fa3810e9114664162a12a484d3cdafd46714c1b99ea702ae39a0c23e390c51b (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: d0c4fbe0d63a277d88f9ef408d7500b52adfdd614a1e0a898fd6fcb9e291787a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-content-sha256: 02412a963dde52cfbed20b13cb248003a731a901584f2f12e157270b5ae2a222 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: cd64cc22d9664c34eb90cd34874004d0d7d9d96af09f5210433ff2d157816c2a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/conformance/forge/bv_nowrap.th
+++ b/conformance/forge/bv_nowrap.th
@@ -1,0 +1,24 @@
+// bv_nowrap.th — the `@bvN(nowrap)` lock-3 no-overflow side obligation (stage-3 REQ-5 /
+// AC-6). `@bv64(nowrap)` means: interpret over fixed-width machine semantics, but `nowrap`
+// declares that wrap is NOT the intent — so forge additionally discharges, in-cage, a
+// QF_BV obligation that no operation in the clause overflows at the width. A witnessed
+// overflow is a broken promise: the clause is REJECTED (`BvNowrapOverflow`) with the
+// concrete overflowing bit pattern, never silently certified.
+//
+//   * `add_overflows` — `req true`, so `a + b` can exceed 2^64-1 (e.g. a = MAX, b = 1).
+//                       The side obligation FAILS → rejected with the overflow witness.
+//   * `add_bounded`   — `req a < 100 && b < 100` bounds `a + b < 200`, so it can never
+//                       overflow at bv64 → the obligation HOLDS in-cage and the clause
+//                       certifies L4, its verdict recorded in `bv_shadow.nowrap_obligation`.
+
+fn add_overflows(a: u64, b: u64) -> u64
+    req true
+    ens@bv64(nowrap) result == a + b
+    fx pure
+{ a + b }
+
+fn add_bounded(a: u64, b: u64) -> u64
+    req a < 100 && b < 100
+    ens@bv64(nowrap) result == a + b
+    fx pure
+{ a + b }

--- a/forge/src/bitvector.rs
+++ b/forge/src/bitvector.rs
@@ -446,6 +446,111 @@ impl BitVectorEngine {
         }
     }
 
+    /// Discharge the `@bvN(nowrap)` no-overflow SIDE OBLIGATION over fixed-width QF_BV
+    /// semantics (`.design/stage3-bv-reconstruction.md` REQ-5 / AC-6 — lock 3). A
+    /// `nowrap` tag declares that, although the clause is interpreted at machine width,
+    /// wrap is NOT the author's intent: every wrap-prone arithmetic operation in the
+    /// clause body (`+`, `-`, `*`) must stay within `N` bits for every input satisfying
+    /// the precondition. The obligation is itself a QF_BV query — "does some operation
+    /// overflow at width `N`?" — asked the OPPOSITE way round to the main clause: it
+    /// asserts the precondition AND the disjunction of the per-operation overflow
+    /// conditions (NOT negated, since we are hunting for an overflowing assignment).
+    ///
+    /// - `unsat` → no input overflows → [`BvOutcome::Proved`] (the obligation holds);
+    /// - `sat` → a concrete overflowing input → [`BvOutcome::Counterexample`] carrying
+    ///   the witnessing bit pattern (AC-6 — "fails with a concrete overflowing input");
+    /// - `unknown` under a bounded profile → [`BvOutcome::Timeout`] (the multiplier
+    ///   cliff — the overflow query zero-extends a 64-bit multiply to 128 bits, so it
+    ///   inherits the same dedicated budget; never a bare `unknown`);
+    /// - Z3 absent / an out-of-fragment operand → [`BvOutcome::Unknown`] (an honest skip).
+    ///
+    /// A clause whose body carries NO wrap-prone operation (a pure comparison such as
+    /// `result == a`) has nothing that could overflow, so the obligation holds VACUOUSLY
+    /// ([`BvOutcome::Proved`]) without a solver round-trip. `vars` / `req` mirror
+    /// [`BitVectorEngine::discharge_bv`] (the `result`-grounded clause closed over the
+    /// parameters).
+    #[must_use]
+    pub fn discharge_nowrap(
+        &self,
+        vars: &[String],
+        req: Option<&Expr>,
+        clause: &Expr,
+        width: BvWidth,
+    ) -> BvOutcome {
+        let n = width.bits();
+        // Collect the per-operation overflow conditions. An out-of-fragment operand is an
+        // honest skip (never a silent pass) — the obligation is not quietly dropped.
+        let mut conds = Vec::new();
+        if let Err(reason) = collect_overflow_conditions(clause, n, &mut conds) {
+            return BvOutcome::Unknown(format!(
+                "the `@bv{n}(nowrap)` side obligation did not render to QF_BV: {reason}"
+            ));
+        }
+        // No wrap-prone arithmetic → nothing can overflow → the obligation holds
+        // vacuously, with no solver query (and no spurious `unknown` when Z3 is absent).
+        if conds.is_empty() {
+            return BvOutcome::Proved;
+        }
+        // The precondition is a hypothesis on the overflowing assignment. As in
+        // `discharge_bv`, an unrenderable `req` is a SKIP, never a dropped guard — dropping
+        // it could mint an overflow witness at an assignment the precondition rules out.
+        let req_smt = match req {
+            Some(r) => match render_bv_prop(r, n) {
+                Ok(s) => Some(s),
+                Err(reason) => {
+                    return BvOutcome::Unknown(format!(
+                        "the `@bv{n}(nowrap)` obligation's precondition did not render to QF_BV \
+                         (skipping rather than dropping the guard): {reason}"
+                    ))
+                }
+            },
+            None => None,
+        };
+
+        let overflow_smt = if conds.len() == 1 {
+            conds.remove(0)
+        } else {
+            format!("(or {})", conds.join(" "))
+        };
+        // The overflow query reuses the clause's budget profile: a 64-bit variable
+        // multiply zero-extends to a 128-bit `bvmul` here, an even costlier bit-blast, so
+        // it deserves the dedicated multiplier budget exactly as the main query does.
+        let profile = BvBudgetProfile::for_query(
+            width,
+            &req.into_iter()
+                .chain(std::iter::once(clause))
+                .collect::<Vec<_>>(),
+        );
+        let query = build_nowrap_query(vars, req_smt.as_deref(), &overflow_smt, n, &profile);
+
+        match Self::run_z3(&query, profile.timeout_secs) {
+            Ok((result, model)) => match result.as_str() {
+                // No assignment overflows → the no-overflow obligation holds.
+                "unsat" => BvOutcome::Proved,
+                // A concrete overflowing input → the obligation FAILS, witnessed by the
+                // bit pattern (AC-6).
+                "sat" => BvOutcome::Counterexample {
+                    bits: parse_bv_model(&model, vars, n),
+                },
+                // The 128-bit multiplier bit-blast cliff: reported as Timeout under the
+                // named profile, never a bare `unknown` (the `discharge_bv` precedent).
+                "unknown" => BvOutcome::Timeout {
+                    profile: profile.name.clone(),
+                    detail: format!(
+                        "Z3 returned `unknown` under the `{}` budget profile (rlimit {}, {}s) \
+                         on the `@bv{n}(nowrap)` overflow query — reported as Timeout, never a \
+                         silent unknown",
+                        profile.name, profile.rlimit, profile.timeout_secs
+                    ),
+                },
+                other => BvOutcome::Unknown(format!(
+                    "Z3 returned an unexpected result `{other}` on the `@bv{n}(nowrap)` query"
+                )),
+            },
+            Err(reason) => BvOutcome::Unknown(reason),
+        }
+    }
+
     /// Run Z3 over an SMT-LIB2 `query` (fed on stdin), returning `(result, model)`.
     /// `Err` on Z3 absent / spawn failure / no result token (an honest skip reason,
     /// never a silent success — R-CODE-4). Mirrors [`crate::engine::NlsatEngine`]'s
@@ -524,6 +629,111 @@ pub fn build_bv_query(
     }
     // The clause is valid at width N iff `req ∧ ¬clause` is unsatisfiable.
     s.push_str(&format!("(assert (not {clause_smt}))\n"));
+    s.push_str("(check-sat)\n");
+    s.push_str("(get-model)\n");
+    s
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The `nowrap` no-overflow side obligation (REQ-5 — lock 3).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Collect the per-operation no-overflow side conditions of a `@bvN(nowrap)` clause
+/// body (`.design/stage3-bv-reconstruction.md` REQ-5 / AC-6). For every wrap-prone
+/// arithmetic operation in `e` — addition, subtraction, multiplication — push the
+/// SMT-LIB2 `Bool` that is TRUE exactly when THAT operation overflows `width` bits, with
+/// its operands rendered as the actual width-`N` machine terms fed into it. The walk
+/// recurses through the whole expression (propositions, connectives, comparisons, and
+/// the operand sub-terms), so a nested `(a + b) * c` emits a condition for both the
+/// inner add and the outer multiply. The disjunction of the collected conditions is
+/// satisfiable iff some input overflows. `Err` names an out-of-fragment operand — an
+/// honest skip, so the obligation is never silently dropped. Pure (R-CODE-5).
+fn collect_overflow_conditions(e: &Expr, width: u32, out: &mut Vec<String>) -> Result<(), String> {
+    match e {
+        Expr::Binary { op, lhs, rhs } => {
+            if let Some(cond) = overflow_condition(*op, lhs, rhs, width)? {
+                out.push(cond);
+            }
+            collect_overflow_conditions(lhs, width, out)?;
+            collect_overflow_conditions(rhs, width, out)
+        }
+        Expr::Unary { expr, .. } | Expr::Cast { expr, .. } => {
+            collect_overflow_conditions(expr, width, out)
+        }
+        _ => Ok(()),
+    }
+}
+
+/// The SMT-LIB2 `Bool` that holds exactly when the `op` of `lhs op rhs` overflows
+/// `width` bits (`.design/stage3-bv-reconstruction.md` REQ-5 / AC-6), or `Ok(None)` when
+/// `op` is not a wrap-prone arithmetic operator (comparisons, connectives, bitwise/shift
+/// and division never overflow the unsigned width — a shift/bitwise result is defined
+/// at width, and unsigned `udiv`/`urem` only shrink). The three overflow tests are the
+/// textbook unsigned ones:
+///
+/// - `+` overflows iff the sum carries out — equivalently the width-`N` result is LESS
+///   than an operand: `(bvult (bvadd l r) l)`;
+/// - `-` underflows iff it would go below zero — i.e. `l < r`: `(bvult l r)`;
+/// - `*` overflows iff the true `2N`-bit product has any high-half bit set: zero-extend
+///   both operands to `2N`, multiply, and check the top `N` bits are non-zero.
+///
+/// `Err` propagates an out-of-fragment operand from [`render_bv_term`].
+fn overflow_condition(
+    op: BinOp,
+    lhs: &Expr,
+    rhs: &Expr,
+    width: u32,
+) -> Result<Option<String>, String> {
+    if !matches!(op, BinOp::Add | BinOp::Sub | BinOp::Mul) {
+        return Ok(None);
+    }
+    let l = render_bv_term(lhs, width)?;
+    let r = render_bv_term(rhs, width)?;
+    let cond = match op {
+        BinOp::Add => format!("(bvult (bvadd {l} {r}) {l})"),
+        BinOp::Sub => format!("(bvult {l} {r})"),
+        BinOp::Mul => {
+            let hi = 2 * width - 1;
+            format!(
+                "(not (= ((_ extract {hi} {width}) \
+                 (bvmul ((_ zero_extend {width}) {l}) ((_ zero_extend {width}) {r}))) \
+                 (_ bv0 {width})))"
+            )
+        }
+        _ => unreachable!("the guard fixed the wrap-prone operator set"),
+    };
+    Ok(Some(cond))
+}
+
+/// Build the SMT-LIB2 `QF_BV` query whose satisfiability decides a `@bvN(nowrap)`
+/// no-overflow side obligation (`.design/stage3-bv-reconstruction.md` REQ-5 / AC-6).
+/// Unlike [`build_bv_query`] (which asserts the NEGATED clause to seek a falsifying
+/// model), this asserts the precondition and the overflow disjunction DIRECTLY — a `sat`
+/// model is a concrete OVERFLOWING input (the obligation fails), `unsat` means no input
+/// overflows (the obligation holds). Sets the budget profile's `rlimit` when bounded
+/// (the 64-bit multiplier cliff, now widened to a 128-bit `bvmul`).
+#[must_use]
+pub fn build_nowrap_query(
+    vars: &[String],
+    req_smt: Option<&str>,
+    overflow_smt: &str,
+    width: u32,
+    profile: &BvBudgetProfile,
+) -> String {
+    let mut s = String::new();
+    s.push_str("(set-logic QF_BV)\n");
+    if profile.rlimit > 0 {
+        s.push_str(&format!("(set-option :rlimit {})\n", profile.rlimit));
+    }
+    for v in vars {
+        s.push_str(&format!("(declare-const {v} (_ BitVec {width}))\n"));
+    }
+    if let Some(req) = req_smt {
+        s.push_str(&format!("(assert {req})\n"));
+    }
+    // The obligation FAILS iff `req ∧ (some operation overflows)` is satisfiable — so the
+    // overflow disjunction is asserted directly (NOT negated, unlike the main clause).
+    s.push_str(&format!("(assert {overflow_smt})\n"));
     s.push_str("(check-sat)\n");
     s.push_str("(get-model)\n");
     s
@@ -955,5 +1165,237 @@ mod tests {
                 "the dedicated budget profile is named"
             );
         }
+    }
+
+    // ── The `nowrap` no-overflow side obligation (REQ-5 / AC-6, lock 3).
+
+    fn overflow_conds(e: &Expr, width: u32) -> Vec<String> {
+        let mut out = Vec::new();
+        collect_overflow_conditions(e, width, &mut out).expect("renders");
+        out
+    }
+
+    #[test]
+    fn overflow_conditions_cover_add_sub_mul_with_the_textbook_predicates() {
+        // a + b → unsigned add carry-out: result < an operand.
+        assert_eq!(
+            overflow_conds(&bin(BinOp::Add, var("a"), var("b")), 64),
+            vec!["(bvult (bvadd a b) a)".to_string()]
+        );
+        // a - b → unsigned underflow: a < b.
+        assert_eq!(
+            overflow_conds(&bin(BinOp::Sub, var("a"), var("b")), 32),
+            vec!["(bvult a b)".to_string()]
+        );
+        // a * b → high-half of the 2N-bit product non-zero.
+        assert_eq!(
+            overflow_conds(&bin(BinOp::Mul, var("a"), var("b")), 8),
+            vec!["(not (= ((_ extract 15 8) (bvmul ((_ zero_extend 8) a) \
+                  ((_ zero_extend 8) b))) (_ bv0 8)))"
+                .to_string()]
+        );
+    }
+
+    #[test]
+    fn overflow_conditions_recurse_into_nested_operations() {
+        // (a + b) * c emits BOTH the inner add overflow and the outer multiply overflow,
+        // with the outer multiply's left operand the wrapped `(bvadd a b)` machine value.
+        let e = bin(BinOp::Mul, bin(BinOp::Add, var("a"), var("b")), var("c"));
+        let conds = overflow_conds(&e, 64);
+        assert_eq!(conds.len(), 2, "one condition per wrap-prone op: {conds:?}");
+        assert!(
+            conds.iter().any(|c| c.contains("(bvult (bvadd a b) a)")),
+            "the inner add overflow is collected: {conds:?}"
+        );
+        assert!(
+            conds
+                .iter()
+                .any(|c| c.contains("(bvmul ((_ zero_extend 64) (bvadd a b))")),
+            "the outer multiply's operand is the wrapped inner sum: {conds:?}"
+        );
+    }
+
+    #[test]
+    fn non_arithmetic_clause_has_no_overflow_conditions() {
+        // A pure comparison / bitwise / shift body has nothing that wraps — the
+        // obligation holds vacuously (no conditions to discharge).
+        assert!(overflow_conds(&bin(BinOp::Eq, var("a"), var("b")), 64).is_empty());
+        assert!(overflow_conds(&bin(BinOp::BitAnd, var("a"), var("b")), 64).is_empty());
+        assert!(overflow_conds(&bin(BinOp::Shl, var("a"), lit(3)), 64).is_empty());
+        // A comparison over arithmetic operands still surfaces the inner overflow.
+        let e = bin(BinOp::Lt, bin(BinOp::Add, var("a"), var("b")), var("c"));
+        assert_eq!(
+            overflow_conds(&e, 64),
+            vec!["(bvult (bvadd a b) a)".to_string()]
+        );
+    }
+
+    #[test]
+    fn out_of_fragment_operand_is_an_honest_error() {
+        // A multiply whose operand is outside the term fragment (a method call) is an
+        // Err — the obligation is skipped, never silently passed.
+        let mc = Expr::MethodCall {
+            receiver: Box::new(var("a")),
+            name: "len".to_string(),
+            args: vec![],
+        };
+        let mut out = Vec::new();
+        assert!(collect_overflow_conditions(&bin(BinOp::Add, mc, var("b")), 64, &mut out).is_err());
+    }
+
+    #[test]
+    fn nowrap_query_asserts_overflow_directly_not_negated() {
+        let q = build_nowrap_query(
+            &["a".to_string(), "b".to_string()],
+            Some("(bvult a (_ bv100 64))"),
+            "(bvult (bvadd a b) a)",
+            64,
+            &BvBudgetProfile::default_profile(),
+        );
+        assert!(q.contains("(set-logic QF_BV)"));
+        assert!(q.contains("(declare-const a (_ BitVec 64))"));
+        assert!(
+            q.contains("(assert (bvult a (_ bv100 64)))"),
+            "the precondition is a hypothesis"
+        );
+        // The overflow disjunction is asserted DIRECTLY (not wrapped in `(not …)`), so a
+        // model is an overflowing input.
+        assert!(q.contains("(assert (bvult (bvadd a b) a))"));
+        assert!(
+            !q.contains("(not (bvult (bvadd a b) a))"),
+            "the overflow is NOT negated"
+        );
+        assert!(q.contains("(check-sat)"));
+    }
+
+    /// AC-6 (engine level): a `@bv64(nowrap)` body that cannot overflow holds — `a + b`
+    /// with both operands bounded below `2^32` never carries out of 64 bits.
+    #[test]
+    fn live_bounded_sum_passes_the_nowrap_obligation() {
+        if bv_skip() {
+            return;
+        }
+        let engine = BitVectorEngine::new();
+        // req a < 2^32 && b < 2^32 ; body a + b — provably no 64-bit overflow.
+        let req = bin(
+            BinOp::And,
+            bin(BinOp::Lt, var("a"), lit(1u128 << 32)),
+            bin(BinOp::Lt, var("b"), lit(1u128 << 32)),
+        );
+        let body = bin(BinOp::Add, var("a"), var("b"));
+        let out = engine.discharge_nowrap(
+            &["a".to_string(), "b".to_string()],
+            Some(&req),
+            &body,
+            BvWidth::W64,
+        );
+        assert_eq!(
+            out,
+            BvOutcome::Proved,
+            "a bounded 64-bit sum never overflows"
+        );
+    }
+
+    /// AC-6 (engine level): an unconstrained `@bv64(nowrap)` `a + b` CAN overflow — the
+    /// obligation fails with a concrete overflowing bit pattern (the witness genuinely
+    /// carries out of 64 bits).
+    #[test]
+    fn live_unbounded_sum_fails_with_a_concrete_overflowing_input() {
+        if bv_skip() {
+            return;
+        }
+        let engine = BitVectorEngine::new();
+        let body = bin(BinOp::Add, var("a"), var("b"));
+        let out = engine.discharge_nowrap(
+            &["a".to_string(), "b".to_string()],
+            None,
+            &body,
+            BvWidth::W64,
+        );
+        match out {
+            BvOutcome::Counterexample { bits } => {
+                assert_eq!(bits.len(), 2, "a bit pattern per variable");
+                // The witness genuinely overflows: a + b wraps below an operand at width 64.
+                let mask = u64::MAX as u128;
+                let wrapped = (bits[0].value + bits[1].value) & mask;
+                assert!(
+                    wrapped < bits[0].value || wrapped < bits[1].value,
+                    "the witness carries out of 64 bits: a={}, b={}",
+                    bits[0].value,
+                    bits[1].value
+                );
+            }
+            other => panic!("expected an overflowing Counterexample, got {other:?}"),
+        }
+    }
+
+    /// AC-6 (engine level): the multiply-overflow predicate is well-formed SMT and z3
+    /// decides it both ways. A small-width `a * b` with both operands bounded below
+    /// `2^(N/2)` cannot overflow `N` bits (Proved), while the same product unconstrained
+    /// CAN overflow (Counterexample). This exercises the `zero_extend`/`extract` render
+    /// against the real solver — a syntax slip would surface here, not just in the unit
+    /// string check.
+    #[test]
+    fn live_multiply_overflow_predicate_is_decided_both_ways() {
+        if bv_skip() {
+            return;
+        }
+        let engine = BitVectorEngine::new();
+        let body = bin(BinOp::Mul, var("a"), var("b"));
+        // Bounded below 2^4 at width 8 → a*b < 2^8 always → no overflow (Proved).
+        let req = bin(
+            BinOp::And,
+            bin(BinOp::Lt, var("a"), lit(16)),
+            bin(BinOp::Lt, var("b"), lit(16)),
+        );
+        let bounded = engine.discharge_nowrap(
+            &["a".to_string(), "b".to_string()],
+            Some(&req),
+            &body,
+            BvWidth::W8,
+        );
+        assert_eq!(
+            bounded,
+            BvOutcome::Proved,
+            "a*b with both operands < 2^4 never overflows 8 bits"
+        );
+        // Unconstrained → a*b can overflow 8 bits (e.g. 16*16 = 256 ≡ 0): Counterexample.
+        let unbounded = engine.discharge_nowrap(
+            &["a".to_string(), "b".to_string()],
+            None,
+            &body,
+            BvWidth::W8,
+        );
+        match unbounded {
+            BvOutcome::Counterexample { bits } => {
+                let prod = bits[0].value * bits[1].value;
+                assert!(
+                    prod >= 256,
+                    "the witness genuinely overflows 8 bits: a={}, b={}, a*b={prod}",
+                    bits[0].value,
+                    bits[1].value
+                );
+            }
+            other => panic!("expected an overflowing Counterexample, got {other:?}"),
+        }
+    }
+
+    /// AC-6 (engine level): a non-arithmetic `nowrap` body holds VACUOUSLY without a
+    /// solver round-trip (so it passes even with z3 absent — no skip guard needed).
+    #[test]
+    fn nowrap_obligation_is_vacuous_for_a_non_arithmetic_body() {
+        let engine = BitVectorEngine::new();
+        let body = bin(BinOp::Eq, var("a"), var("b"));
+        let out = engine.discharge_nowrap(
+            &["a".to_string(), "b".to_string()],
+            None,
+            &body,
+            BvWidth::W64,
+        );
+        assert_eq!(
+            out,
+            BvOutcome::Proved,
+            "no wrap-prone op → vacuously no overflow"
+        );
     }
 }

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -1740,7 +1740,23 @@ fn bv_fn_cert(
             };
             match bv.discharge_bv(&vars, Some(req), &clause_expr, tag.width) {
                 BvOutcome::Proved => {
-                    obligations.push(bv_proved_obl(&f.name, k, tag, &bv_attr));
+                    // Lock 3 (REQ-5 / AC-6): a `nowrap` clause additionally discharges its
+                    // no-overflow side obligation in-cage. A witnessed overflow REJECTS
+                    // (the nowrap promise is violated); a holds/undecided verdict rides the
+                    // clause's `bv_shadow.nowrap_obligation`.
+                    let nowrap = if tag.nowrap {
+                        match bv_nowrap_verdict(bv, &vars, req, &clause_expr, tag.width) {
+                            NowrapVerdict::Holds(v) | NowrapVerdict::Undecided(v) => Some(v),
+                            NowrapVerdict::Overflow { verdict, bits } => {
+                                return bv_nowrap_overflow_cert(
+                                    &f.name, &effects, slag, k, tag, &verdict, &bits, &bv_attr,
+                                );
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    obligations.push(bv_proved_obl(&f.name, k, tag, &bv_attr, nowrap));
                     // A `@bv` clause is decidable QF_BV with COMPLETE bit-pattern
                     // countermodels — the L4 (caged) refutation quality, RFC-1 §2/§4.
                     // The rung is the refutation quality; the SOLVER trust base
@@ -2024,7 +2040,24 @@ fn bv_lemma_cert(
             );
         };
         match bv.discharge_bv(&vars, Some(req), &ens.expr, tag.width) {
-            BvOutcome::Proved => obligations.push(bv_proved_obl(&l.name, k, tag, &bv_attr)),
+            BvOutcome::Proved => {
+                // Lock 3 (REQ-5 / AC-6): a `nowrap` lemma clause discharges its no-overflow
+                // side obligation too — a witnessed overflow rejects the lemma, else the
+                // verdict rides the clause's `bv_shadow.nowrap_obligation`.
+                let nowrap = if tag.nowrap {
+                    match bv_nowrap_verdict(bv, &vars, req, &ens.expr, tag.width) {
+                        NowrapVerdict::Holds(v) | NowrapVerdict::Undecided(v) => Some(v),
+                        NowrapVerdict::Overflow { verdict, bits } => {
+                            return bv_nowrap_overflow_cert(
+                                &l.name, &effects, false, k, tag, &verdict, &bits, &bv_attr,
+                            );
+                        }
+                    }
+                } else {
+                    None
+                };
+                obligations.push(bv_proved_obl(&l.name, k, tag, &bv_attr, nowrap));
+            }
             BvOutcome::Counterexample { bits } => {
                 return bv_counterexample_cert(&l.name, &effects, false, k, tag, &bits, &bv_attr);
             }
@@ -2053,6 +2086,7 @@ fn bv_proved_obl(
     k: usize,
     tag: &thermite_syntax::BvTag,
     attr: &crate::engine::EngineAttribution,
+    nowrap_obligation: Option<String>,
 ) -> ObligationResult {
     ObligationResult::discharged(format!(
         "{item}::ens#{k}: discharged by the bit-vector route over {} (fixed-width \
@@ -2066,8 +2100,136 @@ fn bv_proved_obl(
         attr.trust_profile.clone(),
         crate::verdict::CertVerdict::Proved,
     )
-    // Lock 1 (REQ-3 / AC-4): the shadow flag rides every tagged clause's obligation.
-    .with_bv_shadow(bv_shadow_for(tag))
+    // Lock 1 (REQ-3 / AC-4): the shadow flag rides every tagged clause's obligation;
+    // Lock 3 (REQ-5 / AC-6): a `nowrap` clause's no-overflow verdict rides it too.
+    .with_bv_shadow(bv_shadow_for(tag, nowrap_obligation))
+}
+
+/// The outcome of a `@bvN(nowrap)` clause's no-overflow SIDE OBLIGATION (`.design/
+/// stage3-bv-reconstruction.md` REQ-5 / AC-6 — lock 3), run after the main clause is
+/// `Proved`. The obligation is discharged in-cage by [`crate::bitvector::BitVectorEngine::
+/// discharge_nowrap`]; this triages the result into a verdict the certificate records.
+enum NowrapVerdict {
+    /// No operation overflows at width — the obligation holds. The verdict string is
+    /// recorded in `bv_shadow.nowrap_obligation`; the cert certifies normally.
+    Holds(String),
+    /// The obligation could not be decided (Z3 absent, the multiplier cliff, or an
+    /// out-of-fragment operand). Recorded HONESTLY in `bv_shadow.nowrap_obligation` — the
+    /// main clause still certifies (an undecided side obligation is labeled, never
+    /// silently passed and never a false `nowrap` claim).
+    Undecided(String),
+    /// A concrete overflowing input — the `nowrap` promise is violated, so the cert is
+    /// REJECTED (a witnessed nowrap violation must not certify). The verdict + bit
+    /// pattern ride the rejection cert's `bv_shadow.nowrap_obligation`.
+    Overflow {
+        verdict: String,
+        bits: Vec<crate::bitvector::BvBitPattern>,
+    },
+}
+
+/// Discharge a `@bvN(nowrap)` clause's no-overflow side obligation and triage it
+/// (`.design/stage3-bv-reconstruction.md` REQ-5 / AC-6). `clause` is the `result`-grounded
+/// clause body (the same expression the main QF_BV query decided); `req` is the
+/// precondition (the overflowing input must satisfy it). Pure beyond the in-cage Z3
+/// discharge.
+fn bv_nowrap_verdict(
+    bv: &crate::bitvector::BitVectorEngine,
+    vars: &[String],
+    req: &thermite_syntax::Expr,
+    clause: &thermite_syntax::Expr,
+    width: thermite_syntax::BvWidth,
+) -> NowrapVerdict {
+    use crate::bitvector::BvOutcome;
+    let n = width.bits();
+    match bv.discharge_nowrap(vars, Some(req), clause, width) {
+        BvOutcome::Proved => NowrapVerdict::Holds(format!(
+            "discharged: no operation in the clause overflows at bv{n} (the `nowrap` \
+             no-overflow side obligation holds in-cage; stage3-bv-reconstruction.md REQ-5)"
+        )),
+        BvOutcome::Counterexample { bits } => NowrapVerdict::Overflow {
+            verdict: format!(
+                "FAILED: a bv{n} operation overflows on input [{}] — the `nowrap` \
+                 no-overflow side obligation is violated by a concrete overflowing input \
+                 (stage3-bv-reconstruction.md REQ-5 / AC-6)",
+                render_bv_pattern(&bits)
+            ),
+            bits,
+        },
+        BvOutcome::Timeout { profile, detail } => NowrapVerdict::Undecided(format!(
+            "undecided (Timeout under `{profile}`): {detail} — the `nowrap` side obligation \
+             was not decided; recorded honestly, never a false no-overflow claim"
+        )),
+        BvOutcome::Unknown(reason) => NowrapVerdict::Undecided(format!(
+            "undecided (skipped): {reason} — the `nowrap` side obligation was not decided; \
+             recorded honestly, never a false no-overflow claim"
+        )),
+    }
+}
+
+/// Render a QF_BV bit-pattern witness as the certificate's one-line diagnostic fragment
+/// (`.design/stage3-bv-reconstruction.md` REQ-5 / AC-6). Joins the per-variable
+/// [`crate::bitvector::BvBitPattern::render`] lines.
+fn render_bv_pattern(bits: &[crate::bitvector::BvBitPattern]) -> String {
+    bits.iter()
+        .map(crate::bitvector::BvBitPattern::render)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The rejection cert a FAILED `@bvN(nowrap)` no-overflow side obligation produces
+/// (`.design/stage3-bv-reconstruction.md` REQ-5 / AC-6 — lock 3). The main clause was
+/// `Proved` at width, but the `nowrap` promise is violated by a concrete overflowing
+/// input, so the item does NOT certify: a witnessed nowrap violation must not pass. The
+/// witness obligation records the overflowing bit pattern in `bv_shadow.nowrap_obligation`
+/// (so `grep bv_shadow` still finds this tagged clause) with the per-clause
+/// [`crate::verdict::CertVerdict::Counterexample`].
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the nowrap-overflow cert threads the item/effects/slag identity, the clause \
+              index + tag, the verdict + witnessing bit pattern, and the attribution; each \
+              is a distinct datum the rejection records"
+)]
+fn bv_nowrap_overflow_cert(
+    item: &str,
+    effects: &[String],
+    slag: bool,
+    k: usize,
+    tag: &thermite_syntax::BvTag,
+    verdict: &str,
+    bits: &[crate::bitvector::BvBitPattern],
+    attr: &crate::engine::EngineAttribution,
+) -> Certificate {
+    let detail = format!(
+        "`{item}`'s {} clause `ens#{k}` is machine-valid at width but its `nowrap` \
+         no-overflow side obligation FAILED: the bit pattern [{}] makes an operation \
+         overflow at fixed width — machine width is the domain but wrap is not the intent \
+         (stage3-bv-reconstruction.md REQ-5 / AC-6)",
+        bv_semantics_label(tag),
+        render_bv_pattern(bits)
+    );
+    let witness_obl =
+        ObligationResult::failed(format!("{item}#ens#{k}#nowrap"), None, Some(detail.clone()))
+            // Lock 1 + Lock 3: the shadow flag stays greppable AND carries the nowrap
+            // verdict, so the failing side obligation is visible in the certificate.
+            .with_bv_shadow(bv_shadow_for(tag, Some(verdict.to_string())));
+    let cert_verdict = crate::verdict::CertVerdict::Counterexample {
+        obligations: vec![witness_obl.clone()],
+    };
+    let mut cert = Certificate::rejected(
+        item.to_string(),
+        effects.to_vec(),
+        slag,
+        RejectReason {
+            cause: "BvNowrapOverflow".to_string(),
+            detail,
+        },
+    );
+    cert.obligations = vec![witness_obl.with_clause_attribution(
+        attr.engine.clone(),
+        attr.trust_profile.clone(),
+        cert_verdict,
+    )];
+    cert.with_engine_attribution(attr.clone())
 }
 
 /// The per-clause [`ObligationResult`] an untagged (unbounded) nlsat `Proved` records on
@@ -2106,18 +2268,21 @@ fn bv_semantics_label(tag: &thermite_syntax::BvTag) -> String {
 /// Build Lock 1 — the bv shadow flag (`.design/stage3-bv-reconstruction.md` REQ-3 /
 /// AC-4, the RFC §9 shape) — for a tagged clause's obligation from its tag. `flagged`
 /// is always true (it IS a tagged clause), `semantics` is the fixed-width label, and
-/// `note` names the fork + lock. `nowrap_obligation` is the RESERVED slot REQ-5 fills
-/// for the `@bvN(nowrap)` spelling (the `ContractQuality` forward-declaration
-/// precedent): `None` here even for a `nowrap` tag, because this increment ships the
-/// flag, not the side obligation. Pure (R-CODE-5).
-fn bv_shadow_for(tag: &thermite_syntax::BvTag) -> crate::manifest::BvShadow {
+/// `note` names the fork + lock. `nowrap_obligation` carries Lock 3's verdict (REQ-5 /
+/// AC-6): `Some(verdict)` for a `@bvN(nowrap)` clause whose side obligation ran (the
+/// no-overflow discharge result), `None` for a bare `@bvN` (no side obligation
+/// requested). Pure (R-CODE-5).
+fn bv_shadow_for(
+    tag: &thermite_syntax::BvTag,
+    nowrap_obligation: Option<String>,
+) -> crate::manifest::BvShadow {
     let semantics = bv_semantics_label(tag);
     crate::manifest::BvShadow {
         flagged: true,
         semantics: semantics.clone(),
-        // REQ-5 (`@bvN(nowrap)` side obligation) fills this; until then it is the
-        // schema-reserved slot, `None` for both the bare and the `nowrap` spelling.
-        nowrap_obligation: None,
+        // Lock 3 (REQ-5 / AC-6): the `@bvN(nowrap)` no-overflow side obligation's verdict,
+        // filled by `bv_nowrap_verdict` for a `nowrap` clause and `None` for a bare tag.
+        nowrap_obligation,
         note: format!(
             "machine-semantics fork: this clause is interpreted over fixed-width {semantics} \
              (RFC §9 lock 1 — the shadow flag; stage3-bv-reconstruction.md REQ-3)"
@@ -2153,7 +2318,7 @@ fn bv_counterexample_cert(
         ObligationResult::failed(format!("{item}#ens#{k}"), None, Some(detail.clone()))
             // Lock 1 (REQ-3 / AC-4): a refuted tagged clause still carries the shadow flag —
             // a counterexample is a machine-semantics fact, so the fork must stay visible.
-            .with_bv_shadow(bv_shadow_for(tag));
+            .with_bv_shadow(bv_shadow_for(tag, None));
     let cert_verdict = crate::verdict::CertVerdict::Counterexample {
         obligations: vec![witness_obl.clone()],
     };
@@ -2210,7 +2375,7 @@ fn bv_timeout_cert(
         )
         // Lock 1 (REQ-3 / AC-4): the shadow flag rides the timeout obligation too — the
         // multiplier cliff is a machine-semantics fact, so the fork stays greppable.
-        .with_bv_shadow(bv_shadow_for(tag));
+        .with_bv_shadow(bv_shadow_for(tag, None));
     let mut cert = Certificate::rejected(
         item.to_string(),
         effects.to_vec(),
@@ -2255,7 +2420,7 @@ fn bv_skip_cert(
     cert.obligations =
         vec![
             ObligationResult::failed(format!("{item}#ens#{k}"), None, Some(detail))
-                .with_bv_shadow(bv_shadow_for(tag)),
+                .with_bv_shadow(bv_shadow_for(tag, None)),
         ];
     cert
 }
@@ -6414,6 +6579,159 @@ note: Cost * Instantiations: 150 (Instantiated 10 times - 71% of the total, cost
             bv_mutation_score(&bv, &f, &[]).is_none(),
             "a parameter-closed @bv clause (no `result`) yields no scoreable mutant set — \
              so mix64's golden is unperturbed (needs no z3: the early `None` return)"
+        );
+    }
+
+    // ───────────────────────────────────────────────────────────────────────────
+    // REQ-5 / AC-6 (stage-3 lock 3 — the `nowrap` side obligation). A `@bvN(nowrap)`
+    // clause additionally discharges a no-overflow side obligation IN-CAGE; its verdict
+    // rides `bv_shadow.nowrap_obligation`. A body that can overflow FAILS the obligation
+    // with a concrete overflowing input (the cert is rejected); a body that cannot
+    // overflow records the discharged verdict and certifies. These drive the full cert
+    // through `bv_fn_cert`.
+    // ───────────────────────────────────────────────────────────────────────────
+
+    /// Build one `@bv`-tagged `fn`'s full bit-vector certificate from source (the AC-6
+    /// driver — the same `bv_fn_cert` the `--engine bv` route runs per item).
+    #[cfg(feature = "bv")]
+    fn bv_fn_cert_from(src: &str, name: &str) -> Certificate {
+        let parsed = thermite_syntax::parse(src);
+        assert!(parsed.is_clean(), "fixture must parse: {:?}", parsed.errors);
+        let f = parsed
+            .program
+            .items
+            .iter()
+            .find_map(|i| match i {
+                Item::Fn(f) if f.name == name => Some(f.clone()),
+                _ => None,
+            })
+            .expect("fixture has the named fn");
+        let bv = crate::bitvector::BitVectorEngine::new();
+        let nlsat = crate::engine::NlsatEngine::new(parsed.program.clone());
+        let base = Certificate::new(
+            name.to_string(),
+            Level::L4,
+            vec!["pure".to_string()],
+            0,
+            vec![],
+        );
+        bv_fn_cert(&bv, &nlsat, &f, &base, &[])
+    }
+
+    /// AC-6: a `@bv64(nowrap)` clause whose body can overflow FAILS its side obligation
+    /// with a concrete overflowing input, and the verdict is recorded in
+    /// `bv_shadow.nowrap_obligation`. The clause `result == a + b` is machine-valid at
+    /// width (result is DEFINED as `a + b` mod 2^64, so the equality is tautological),
+    /// but `a + b` itself overflows 64 bits for some input — so the nowrap promise is
+    /// violated and the cert is rejected `BvNowrapOverflow`.
+    #[cfg(feature = "bv")]
+    #[test]
+    fn ac6_nowrap_body_that_overflows_fails_with_a_concrete_input() {
+        use crate::bitvector::BitVectorEngine;
+        if !BitVectorEngine::z3_present() {
+            eprintln!("SKIP: z3 absent — the AC-6 nowrap-overflow discharge needs z3.");
+            return;
+        }
+        let cert = bv_fn_cert_from(
+            "fn add_nowrap(a: u64, b: u64) -> u64 req true ens@bv64(nowrap) result == a + b \
+             fx pure { a + b }",
+            "add_nowrap",
+        );
+        // A witnessed nowrap overflow must NOT certify (the promise is violated).
+        let reject = cert
+            .reject
+            .as_ref()
+            .expect("a body that can overflow fails the nowrap obligation → rejected");
+        assert_eq!(
+            reject.cause, "BvNowrapOverflow",
+            "the rejection names the failed nowrap side obligation"
+        );
+        // The verdict + concrete overflowing bit pattern ride `bv_shadow.nowrap_obligation`,
+        // so the failure is greppable in the certificate.
+        let shadow = cert
+            .obligations
+            .iter()
+            .find_map(|o| o.bv_shadow.as_ref())
+            .expect("the witness obligation carries the bv shadow flag");
+        let verdict = shadow
+            .nowrap_obligation
+            .as_ref()
+            .expect("the nowrap obligation verdict is recorded");
+        assert!(
+            verdict.contains("FAILED"),
+            "the verdict records the failure: {verdict}"
+        );
+        assert!(
+            verdict.contains("0b"),
+            "the verdict carries a concrete overflowing bit pattern: {verdict}"
+        );
+    }
+
+    /// AC-6 (the holds side): a `@bv64(nowrap)` clause whose body carries no wrap-prone
+    /// arithmetic discharges the no-overflow obligation VACUOUSLY (no operation can
+    /// overflow), certifies at L4, and records the discharged verdict in
+    /// `bv_shadow.nowrap_obligation`. `result == a` over body `{ a }` needs no z3 (the
+    /// obligation is vacuous — there is nothing that could overflow).
+    #[cfg(feature = "bv")]
+    #[test]
+    fn ac6_nowrap_body_without_arithmetic_holds_and_records_discharged() {
+        let cert = bv_fn_cert_from(
+            "fn idem(a: u64) -> u64 req true ens@bv64(nowrap) result == a fx pure { a }",
+            "idem",
+        );
+        assert!(
+            cert.reject.is_none(),
+            "a non-arithmetic nowrap body certifies (the obligation holds vacuously): {:?}",
+            cert.reject
+        );
+        assert_eq!(
+            cert.level,
+            Level::L4,
+            "the @bv clause certifies at the caged rung"
+        );
+        let shadow = cert
+            .obligations
+            .iter()
+            .find_map(|o| o.bv_shadow.as_ref())
+            .expect("the @bv clause obligation carries the bv shadow flag");
+        let verdict = shadow
+            .nowrap_obligation
+            .as_ref()
+            .expect("the nowrap obligation verdict is recorded even when it holds");
+        assert!(
+            verdict.contains("discharged"),
+            "the holds verdict records the discharge: {verdict}"
+        );
+        assert!(
+            shadow.semantics.contains("nowrap"),
+            "the semantics label names the nowrap fork: {}",
+            shadow.semantics
+        );
+    }
+
+    /// A bare `@bv64` (NO `nowrap`) clause runs NO side obligation, so its
+    /// `bv_shadow.nowrap_obligation` stays `None` — the slot is filled only for the
+    /// `nowrap` spelling (REQ-5). Guards against the lock firing on every tagged clause.
+    #[cfg(feature = "bv")]
+    #[test]
+    fn bare_bv_clause_records_no_nowrap_obligation() {
+        let cert = bv_fn_cert_from(
+            "fn idem(a: u64) -> u64 req true ens@bv64 result == a fx pure { a }",
+            "idem",
+        );
+        assert!(
+            cert.reject.is_none(),
+            "a tautological bare @bv clause certifies"
+        );
+        let shadow = cert
+            .obligations
+            .iter()
+            .find_map(|o| o.bv_shadow.as_ref())
+            .expect("a bare @bv clause still carries the shadow flag (lock 1)");
+        assert!(
+            shadow.nowrap_obligation.is_none(),
+            "a bare @bv clause runs no side obligation: {:?}",
+            shadow.nowrap_obligation
         );
     }
 }

--- a/forge/src/manifest.rs
+++ b/forge/src/manifest.rs
@@ -303,10 +303,13 @@ pub struct BvShadow {
     /// shape) — the named fork, so a reader sees WHICH machine semantics this clause
     /// committed to.
     pub semantics: String,
-    /// The `@bvN(nowrap)` no-overflow side obligation's verdict (REQ-5 / AC-6). `None`
-    /// for a bare `@bvN` (no side obligation requested), and a RESERVED slot until REQ-5
-    /// fills it for the `nowrap` spelling — the schema-reserves-the-slot,
-    /// producer-fills-the-value forward-declaration precedent ([`ContractQuality`]).
+    /// The `@bvN(nowrap)` no-overflow side obligation's verdict (REQ-5 / AC-6, lock 3).
+    /// `Some(verdict)` for a `@bvN(nowrap)` clause whose side obligation ran — the in-cage
+    /// no-overflow discharge result ("discharged: no operation overflows…" when it holds,
+    /// "FAILED: a bvN operation overflows on input […]" with the witnessing bit pattern
+    /// when a concrete input overflows, or an "undecided …" label when Z3 could not
+    /// decide it). `None` for a bare `@bvN` (no side obligation requested). Filled by
+    /// `check::bv_nowrap_verdict`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nowrap_obligation: Option<String>,
     /// A human note naming the fork + the lock (the auditor's one-line "why this block
@@ -1619,7 +1622,8 @@ mod tests {
 
     // Stage-3 REQ-3 / AC-4 (Lock 1, the shadow flag): the `bv_shadow` field is additive —
     // a v1 / untagged clause omits it (byte-identical goldens), a tagged clause serializes
-    // the RFC §9 block, and `nowrap_obligation` is the reserved (None → omitted) slot.
+    // the RFC §9 block; `nowrap_obligation` is omitted for a bare tag and filled (REQ-5)
+    // for the `nowrap` spelling.
     #[test]
     fn bv_shadow_is_additive_and_serializes_the_rfc9_shape() {
         // A v1-shape clause (no shadow) must NOT serialize a `bv_shadow` key — so the v1
@@ -1663,12 +1667,40 @@ mod tests {
         assert!(shadow.get("note").is_some(), "the §9 note is present");
         assert!(
             shadow.get("nowrap_obligation").is_none(),
-            "the reserved `nowrap_obligation` slot (None) is omitted, not a placeholder \
-             (REQ-5 fills it): {json}"
+            "a bare/wraparound clause runs no side obligation, so `nowrap_obligation` is \
+             omitted (None → skipped, never a placeholder): {json}"
         );
         // Round-trips: deserialize → re-serialize is byte-stable.
         let back: Certificate = serde_json::from_str(&json).expect("round-trip");
         assert_eq!(serialize(&back), json, "the shadow block round-trips");
+
+        // Lock 3 (REQ-5 / AC-6): a `@bvN(nowrap)` clause whose obligation ran serializes
+        // the verdict — the filled slot is present and greppable, round-tripping stably.
+        let nowrap = Certificate::new(
+            "add_nowrap",
+            Level::L4,
+            vec!["pure".to_string()],
+            0,
+            vec![
+                ObligationResult::discharged("add_nowrap::ens#0").with_bv_shadow(BvShadow {
+                    flagged: true,
+                    semantics: "bv64 (nowrap)".to_string(),
+                    nowrap_obligation: Some(
+                        "discharged: no operation in the clause overflows at bv64".to_string(),
+                    ),
+                    note: "machine-semantics fork".to_string(),
+                }),
+            ],
+        );
+        let njson = serialize(&nowrap);
+        let nv: serde_json::Value = serde_json::from_str(&njson).expect("parse");
+        assert_eq!(
+            nv["obligations"][0]["bv_shadow"]["nowrap_obligation"],
+            serde_json::Value::from("discharged: no operation in the clause overflows at bv64"),
+            "the filled nowrap obligation verdict serializes: {njson}"
+        );
+        let nback: Certificate = serde_json::from_str(&njson).expect("round-trip");
+        assert_eq!(serialize(&nback), njson, "the filled slot round-trips");
     }
 
     // Stage-3 REQ-3 / AC-4: the shadow flag is ORACLE-INCLUDED (Q-ORACLE: deterministic +

--- a/forge/src/review.rs
+++ b/forge/src/review.rs
@@ -255,7 +255,7 @@ pub struct ReviewArtifact {
 /// One `@bv`-tagged clause's shadow flag in the review artifact
 /// (`.design/stage3-bv-reconstruction.md` REQ-3 / AC-4 — Lock 1). A pure projection of an
 /// obligation's [`crate::manifest::BvShadow`]: the owning item, the per-clause obligation
-/// name, and the shadow block (flag + semantics + reserved `nowrap_obligation` + note).
+/// name, and the shadow block (flag + semantics + `nowrap_obligation` + note).
 /// Never fabricated — read verbatim from the cert (R-CODE-5).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BvShadowClause {

--- a/forge/tests/bv_lowering.rs
+++ b/forge/tests/bv_lowering.rs
@@ -531,7 +531,11 @@ fn bv_nowrap_side_obligation_rejects_overflow_and_records_the_verdict() {
         return;
     }
     let (code, certs) = run_bv("bv_nowrap.th");
-    assert_ne!(code, Some(0), "the overflowing nowrap fn must reject the project");
+    assert_ne!(
+        code,
+        Some(0),
+        "the overflowing nowrap fn must reject the project"
+    );
 
     // (1) `add_overflows` — the side obligation FAILS with a concrete overflow witness.
     let of = cert(&certs, "add_overflows");
@@ -547,7 +551,10 @@ fn bv_nowrap_side_obligation_rejects_overflow_and_records_the_verdict() {
     );
     let witness = of["obligations"]
         .as_array()
-        .and_then(|o| o.iter().find(|o| o["bv_shadow"]["nowrap_obligation"].is_string()))
+        .and_then(|o| {
+            o.iter()
+                .find(|o| o["bv_shadow"]["nowrap_obligation"].is_string())
+        })
         .expect("a witness obligation carries the nowrap verdict");
     let nowrap = witness["bv_shadow"]["nowrap_obligation"]
         .as_str()
@@ -574,7 +581,10 @@ fn bv_nowrap_side_obligation_rejects_overflow_and_records_the_verdict() {
     );
     let held = ok["obligations"]
         .as_array()
-        .and_then(|o| o.iter().find_map(|o| o["bv_shadow"]["nowrap_obligation"].as_str()))
+        .and_then(|o| {
+            o.iter()
+                .find_map(|o| o["bv_shadow"]["nowrap_obligation"].as_str())
+        })
         .expect("the holding nowrap verdict is recorded");
     assert!(
         held.contains("discharged"),

--- a/forge/tests/bv_lowering.rs
+++ b/forge/tests/bv_lowering.rs
@@ -517,3 +517,67 @@ fn forge_review_lists_the_bv_shadows() {
         "every reviewed shadow is flagged"
     );
 }
+
+/// REQ-5 / AC-6 (lock 3 — `@bvN(nowrap)`): the no-overflow side obligation, end to end
+/// through the binary. A `@bv64(nowrap)` clause whose arithmetic can overflow at width
+/// fails its side obligation — the fn is rejected `BvNowrapOverflow` with the concrete
+/// overflowing bit pattern recorded in `bv_shadow.nowrap_obligation`. A clause whose `req`
+/// bounds the arithmetic below the wrap point holds in-cage and certifies L4, the holding
+/// verdict recorded in the same slot.
+#[test]
+fn bv_nowrap_side_obligation_rejects_overflow_and_records_the_verdict() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — the bit-vector route is not run.");
+        return;
+    }
+    let (code, certs) = run_bv("bv_nowrap.th");
+    assert_ne!(code, Some(0), "the overflowing nowrap fn must reject the project");
+
+    // (1) `add_overflows` — the side obligation FAILS with a concrete overflow witness.
+    let of = cert(&certs, "add_overflows");
+    assert_eq!(
+        of["level"],
+        Value::from("L0"),
+        "an overflowing nowrap clause does not certify: {of}"
+    );
+    assert_eq!(
+        of["reject"]["cause"],
+        Value::from("BvNowrapOverflow"),
+        "rejected by the nowrap obligation, not some other cause: {of}"
+    );
+    let witness = of["obligations"]
+        .as_array()
+        .and_then(|o| o.iter().find(|o| o["bv_shadow"]["nowrap_obligation"].is_string()))
+        .expect("a witness obligation carries the nowrap verdict");
+    let nowrap = witness["bv_shadow"]["nowrap_obligation"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        nowrap.contains("FAILED"),
+        "the failed nowrap verdict is recorded: {nowrap}"
+    );
+    assert!(
+        nowrap.contains("0b"),
+        "with the concrete overflowing bit pattern: {nowrap}"
+    );
+
+    // (2) `add_bounded` — `req` bounds the sum, so the obligation HOLDS in-cage at L4.
+    let ok = cert(&certs, "add_bounded");
+    assert_eq!(
+        ok["level"],
+        Value::from("L4"),
+        "a non-overflowing nowrap clause certifies at the caged rung L4: {ok}"
+    );
+    assert!(
+        ok.get("reject").map(|r| r.is_null()).unwrap_or(true),
+        "a held nowrap obligation is no reject: {ok}"
+    );
+    let held = ok["obligations"]
+        .as_array()
+        .and_then(|o| o.iter().find_map(|o| o["bv_shadow"]["nowrap_obligation"].as_str()))
+        .expect("the holding nowrap verdict is recorded");
+    assert!(
+        held.contains("discharged"),
+        "the nowrap obligation holds in-cage: {held}"
+    );
+}


### PR DESCRIPTION
Stage-3 REQ-5 — lock 3, the `@bvN(nowrap)` no-overflow side obligation. Closes #347. Child of the Stage-3 tree (umbrella xl #342 / gh #80; spec REQ-5 / AC-6).

## What ships
- **`discharge_nowrap`** (`forge/src/bitvector.rs`): for a `@bvN(nowrap)` clause that proves at width, discharges an **in-cage QF_BV** no-overflow obligation — `collect_overflow_conditions` emits the textbook unsigned predicates (add carry-out `bvult (bvadd l r) l`, sub borrow `bvult l r`, mul high-half-nonzero via `2N` zero-extend), recursing through nested arithmetic. `sat` = a concrete overflowing input (`Counterexample`); `unsat` = no overflow (`Proved`); vacuous-hold when the clause has no wrap-prone op.
- **Wiring** (`check.rs`/`manifest.rs`): a *held* obligation records its verdict in `bv_shadow.nowrap_obligation` and the clause certifies; a *witnessed overflow* **rejects** via `BvNowrapOverflow` whose witness obligation carries the failed verdict + the concrete overflow bit pattern (a `nowrap` promise, witnessed-violated, must not certify).

## Verification (full env: verus + z3 + Lean spine)
- AC-6 ✅ end-to-end: `@bv64(nowrap) result == a + b` over `{ a + b }` with `req true` → **`BvNowrapOverflow`** with the overflow bits; the same clause under `req a < 100 && b < 100` → **L4**, obligation HOLDS in-cage (a real z3 discharge, not vacuous).
- All prior invariants preserved (verified): mix64 → L4; `double` → WeakContract (REQ-4 gate); the REQ-3 per-item overlay (`plain_add` L3 beside a `@bv` fn).
- Added the binary-level fixture `conformance/forge/bv_nowrap.th` + integration test (the kickoff had in-crate coverage only; this matches the REQ-3/4 conformance-fixture pattern).
- Full `forge` suite green; clippy `-D warnings` + rustfmt 1.95.0 (workspace) clean; v1 goldens byte-identical; `make doc-drift` exit 0.

The kickoff output needed no behavioral fix this round — it absorbed the accumulated invariants (feature `bv`, L4 rung, per-item overlay, mutation gate, full spine, pinned workspace fmt). I added the orchestrator doc-drift re-pin and the end-to-end test.