### PR TITLE
Stage-3 REQ-6: review surface — semantic forks + towers (the F-F tripwire) (#348)

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 0be0416df846c149e4d5b6feaf22596d7ab912906bd992184cb63eec8d0e9723 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 0e9ce0aee57c30c48e74a37c8c492afafe9545ade899c965e842b98bbf72b12e (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 0be0416df846c149e4d5b6feaf22596d7ab912906bd992184cb63eec8d0e9723 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 0e9ce0aee57c30c48e74a37c8c492afafe9545ade899c965e842b98bbf72b12e (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/forge/audit-manifest.md
+++ b/.design/forge/audit-manifest.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 1cc9d97c6c5d7eab6109561834db77f2ef4b57ab (re-pinned 2026-06-16: forge workflow status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (#274 — lean_fragment membership report; REQ-7..10 SHIPPED, audit.rs verified-current))
-audited-content-sha256: adf1e73cdae4923311fc2bdac210e295850a490f0edacdc1055a810195dc2458
+audited-content-sha256: 11d046491b2627236d2a81608698435e965743ef0c746746e13ec1e6c2cba0af
 governs: forge/src/audit.rs
 thesis-refs:
   - thermite-design.md §6

--- a/.design/forge/cli.md
+++ b/.design/forge/cli.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: shipped
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (content-sha256 re-pinned 2026-06-21 for stage-2 REQ-8 / AC-8 (#330), faithfulness + two-phase TV + the trust flip: the change to this doc's governed file (cli.rs) is the additive `forge strat-faithful-tv [--generated N] [--seed <u64>] [--json]` subcommand (`Command::StratFaithfulTv` → `run_strat_faithful_tv`, the two-phase TV sweep reporting the phase split + the gated trust profile); every other subcommand + flag parse is unchanged. The legacy commit pin stays at the 5ae0816c stable-main ancestor; only the active content-sha256 digest moves. prior: 2026-06-20 stage-2 REQ-4 / AC-4 (#326) `forge strat-tv` + `ForgeError::StratDifferential`; 2026-06-18 umbrella REQ-2c / AC-4 rotating-seed `--seed` flag on `forge tv`; §6 metrics dashboard `--metrics` value)
-audited-content-sha256: fefedbf24bbda305680c8fb5947123fd1190ce32279fca0fc21b9f6bb8c86b42
+audited-content-sha256: fdf790121bf8dc4fa50c43b0b476a3a390d114cac27709240a111b11f126dcab
 governs: forge/src/cli.rs
 thesis-refs:
   - thermite-design.md §5

--- a/.design/forge/spec-review.md
+++ b/.design/forge/spec-review.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 8b4d2580b472d04fca2b14de5b6be52533a2d258 (re-pinned 2026-06-17 for stage-1 increment 3, REQ-9 lemma library: the only change to this doc's governed file (review.rs) is the additive REQ-9 burned_lemmas partition + BurnedLemma projection (a certified lemma surfaces like any certified item); the v1 intent-reviewable / battery-failing partitions are unchanged (REQ-S1-9). prior: 92396428567edc6940a9e2845217f5ff4c2ea3c6)
-audited-content-sha256: 835a51237e78d06896155aff194ef58091b658ed34a04ea32f7b9e13f4de1c3c
+audited-content-sha256: dadde2fd2a0e6b248e4d843a120be92e1e69537780b0c531bb2aab2864c1f213
 governs: forge/src/review.rs
 thesis-refs:
   - thermite-design.md §7

--- a/.design/scaffold/workspace.md
+++ b/.design/scaffold/workspace.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (content-sha256 re-pinned 2026-06-20 for stage-2 REQ-4 / AC-4 (#326), the classifier ops half: the changes to this doc's governed lib roots are additive — `pub mod classifier;` + the classifier re-exports in thermite-spec/src/lib.rs (the new Rust admission classifier), and `mod strat_tv;` in forge/src/main.rs (the differential battery module); the workspace/crate structure is otherwise unchanged. The legacy commit pin stays at the 5ae0816c stable-main ancestor; only the active content-sha256 digest moves. prior: 2026-06-17 umbrella REQ-7 / AC-12 §6 metrics dashboard `mod metrics;`; stage-1 REQ-10/AC-14 G1 gate seven-verdict test module)
-audited-content-sha256: 8028435bfe4a6bedcdd68c639756f7097944430a118435134982131b19527154
+audited-content-sha256: bb5fae7f5c33ec049c7e9cd730c1038c02e29e9fce73a6a1a93f42c5e8c7164f
 governs:
   - Cargo.toml (virtual workspace manifest)
   - rust-toolchain.toml

--- a/conformance/forge/bv_density_normal.th
+++ b/conformance/forge/bv_density_normal.th
@@ -1,0 +1,40 @@
+// bv_density_normal.th — a project whose bv-shadow density is BELOW the F-F retreat
+// threshold (`.design/stage3-bv-reconstruction.md` REQ-6 / AC-7, the "normal" case).
+//
+// `forge audit` / `forge review` auto-route this through the bit-vector engine (it carries
+// a `@bv` tag), so the "semantic forks and definition towers" section reports the
+// per-module bv-shadow density and the project-wide F-F tripwire. Here ONE @bv-tagged ens
+// clause sits among FOUR contract-bearing ens clauses: a project density of 1/4 = 250‰,
+// well within the 500‰ retreat threshold — the tripwire does NOT fire (the healthy
+// baseline: a small, deliberate machine-semantics fork in an otherwise-unbounded codebase).
+//
+// Per-module known counts (a pure parse-level projection):
+//   * wrap_add  — 1/1 ens machine-semantics (1000‰)
+//   * plain_add — 0/1 (0‰)
+//   * plain_inc — 0/1 (0‰)
+//   * plain_id  — 0/1 (0‰)
+//   project     — 1/4 ens machine-semantics (250‰) → WITHIN the 500‰ threshold.
+
+fn wrap_add(a: u64, b: u64) -> u64
+    req true
+    ens@bv64 a + b == b + a
+    fx pure
+{ a + b }
+
+fn plain_add(a: u64, b: u64) -> u64
+    req a < 100 && b < 100
+    ens result >= a
+    fx pure
+{ a + b }
+
+fn plain_inc(x: u32) -> u32
+    req x < 100
+    ens result == x + 1
+    fx pure
+{ x + 1 }
+
+fn plain_id(x: u32) -> u32
+    req true
+    ens result == x
+    fx pure
+{ x }

--- a/conformance/forge/bv_density_spike.th
+++ b/conformance/forge/bv_density_spike.th
@@ -1,0 +1,33 @@
+// bv_density_spike.th — a SYNTHETIC density spike that trips the named F-F warning
+// (`.design/stage3-bv-reconstruction.md` REQ-6 / AC-7, the "spike" case).
+//
+// The post-ship F-F tripwire: when machine-semantics forks become the MAJORITY of the
+// contract-bearing postcondition surface, the program has drifted far enough toward the
+// fork that the @bv retreat ladder (full → nowrap-only → lemma-only → drop) should be
+// weighed. Here TWO @bv-tagged ens clauses sit among THREE contract-bearing ens clauses:
+// a project density of 2/3 = 666‰, at or above the 500‰ retreat threshold — the F-F
+// tripwire FIRES (a loud, informational warning; it gates nothing, changes no verdict).
+//
+// Per-module known counts (a pure parse-level projection):
+//   * wrap_comm  — 1/1 ens machine-semantics (1000‰)
+//   * wrap_xor   — 1/1 ens machine-semantics (1000‰)
+//   * plain_add  — 0/1 (0‰)
+//   project      — 2/3 ens machine-semantics (666‰) → REACHES the 500‰ threshold (TRIP).
+
+fn wrap_comm(a: u64, b: u64) -> u64
+    req true
+    ens@bv64 a + b == b + a
+    fx pure
+{ a + b }
+
+fn wrap_xor(a: u64, b: u64) -> u64
+    req true
+    ens@bv64 a ^ b ^ b == a
+    fx pure
+{ a ^ b }
+
+fn plain_add(a: u64, b: u64) -> u64
+    req a < 100 && b < 100
+    ens result >= a
+    fx pure
+{ a + b }

--- a/forge/src/audit.rs
+++ b/forge/src/audit.rs
@@ -97,6 +97,17 @@ pub struct AuditManifest {
     /// discipline). The section gates nothing — informational, like `lean_fragment`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub bv_shadows: Vec<BvShadowRow>,
+    /// The "semantic forks and definition towers" section
+    /// (`.design/stage3-bv-reconstruction.md` REQ-6 / AC-7): the AGGREGATE legibility
+    /// surface over the per-clause `bv_shadows` above + the burned-lemma towers — bv-shadow
+    /// density per module, every burned lemma's definition-tower depth, and the post-ship
+    /// **F-F density tripwire**. A pure projection ([`crate::forks::SemanticForks::build`]);
+    /// `None` (and omitted) for a tag-free, lemma-free project, so the v1 corpus serializes
+    /// BYTE-IDENTICALLY (the additive `bv_shadows`/`lean_fragment` discipline;
+    /// `manifest_version` stays `"v1"`). The section gates nothing — informational, like
+    /// `bv_shadows`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_forks: Option<crate::forks::SemanticForks>,
 }
 
 /// One `@bv`-tagged clause's shadow-flag row in the audit manifest
@@ -605,6 +616,10 @@ impl AuditManifest {
         // Lock 1 (stage-3 REQ-3 / AC-4): the project's `@bv` shadow flags, one row per
         // tagged clause — a pure projection of the certs' obligations.
         let bv_shadows = BvShadowRow::from_certificates(certs);
+        // REQ-6 / AC-7: the aggregate "semantic forks and definition towers" section — the
+        // bv-shadow density per module, the burned-lemma tower depths, and the F-F density
+        // tripwire. `None` (omitted) for a tag-free, lemma-free project (the v1 corpus).
+        let semantic_forks = crate::forks::SemanticForks::build(certs, program);
         AuditManifest {
             manifest_version: MANIFEST_VERSION.to_string(),
             functions,
@@ -612,6 +627,7 @@ impl AuditManifest {
             tcb,
             lean_fragment,
             bv_shadows,
+            semantic_forks,
         }
     }
 }

--- a/forge/src/cli.rs
+++ b/forge/src/cli.rs
@@ -2761,6 +2761,12 @@ fn render_review(artifact: &ReviewArtifact) -> String {
             ));
         }
     }
+    // REQ-6 / AC-7: the aggregate "semantic forks and definition towers" section — the
+    // bv-shadow density per module + burned-lemma tower depths + the F-F density tripwire.
+    if let Some(forks) = &artifact.semantic_forks {
+        out.push('\n');
+        out.push_str(&forks.render());
+    }
     out
 }
 
@@ -3006,6 +3012,11 @@ fn render_audit(manifest: &AuditManifest) -> String {
                 s.item, s.clause, s.shadow.flagged, s.shadow.semantics
             ));
         }
+    }
+    // REQ-6 / AC-7: the aggregate "semantic forks and definition towers" section — the
+    // bv-shadow density per module + burned-lemma tower depths + the F-F density tripwire.
+    if let Some(forks) = &manifest.semantic_forks {
+        out.push_str(&forks.render());
     }
     out
 }

--- a/forge/src/forks.rs
+++ b/forge/src/forks.rs
@@ -1,0 +1,465 @@
+//! `forge/src/forks.rs` — the "semantic forks and definition towers" review/audit
+//! section (`.design/stage3-bv-reconstruction.md` REQ-6 / AC-7, issue #348). The
+//! human-audit surface for the two legibility risks the forge tier and the `@bv` machine-
+//! semantics tag add to the program:
+//!
+//! 1. **semantic forks** — `@bv`-tagged clauses are interpreted over a fixed-width
+//!    machine-semantics fork, not the default unbounded integers. Lock 1 (REQ-3) already
+//!    makes each tagged clause loud + greppable (its `bv_shadow` block, surfaced per
+//!    clause in `forge audit`/`forge review`). This section is the AGGREGATE over those
+//!    clauses: **bv-shadow density per module** — how much of each contract-bearing
+//!    item's postcondition surface has committed to a machine-semantics fork.
+//! 2. **definition towers** — a forge-tier `lemma`'s `req ∪ ens` can unfold a tower of
+//!    `spec fn` definitions an auditor must read through (the REQ-6c anti-Goodhart risk
+//!    `meaning.rs` bounds for `fn`s). This section reports the **tower depth for every
+//!    burned lemma**, so the project's proven-lemma library is legible at a glance.
+//!
+//! ## Why this section is the POST-SHIP F-F tripwire (D-BVSCOPE)
+//!
+//! Q-BVSCOPE asked whether to ship the `@bv` tag full, `nowrap`-only, or lemma-only. The
+//! "measure bv-shadow density first" input was circular — no bv clause exists to measure
+//! until the tag ships. So the resolution (`.design/stage3-bv-reconstruction.md` Decision
+//! Record) ships the full tag guarded by its three locks and makes THIS density report the
+//! *post-ship* retreat trigger: rising shadow-flag density in contract-bearing code is the
+//! named **F-F tripwire** down the ladder (full → `nowrap`-only → lemma-only → drop). The
+//! tripwire fires when the project's bv-shadow density crosses
+//! [`FF_DENSITY_THRESHOLD_PERMILLE`] — a loud, informational warning that the program is
+//! becoming dominated by machine-semantics forks and the retreat ladder should be weighed.
+//!
+//! ## A pure projection that GATES NOTHING
+//!
+//! Like `forge audit` itself (#274 "audit gates nothing") and the `--meaning` companion,
+//! this section is a deterministic projection of the settled cert collection + the parsed
+//! program (R-CODE-5): it re-runs no prover, changes no verdict, and alters no exit code.
+//! The F-F warning is a human signal, not a gate. Density is a parse-level fact (which
+//! clauses carry the `@bv` tag), the tower depth reuses `meaning::tower_metrics` (the same
+//! spec-fn meaning closure `forge audit --meaning` reports), and which lemmas are "burned"
+//! is read from the certificates (mirroring `review::burned_lemma_projection`).
+
+use serde::{Deserialize, Serialize};
+use thermite_syntax::{Expr, Item, Program};
+
+use crate::manifest::{cert_certifies, Certificate};
+
+/// The F-F retreat-trigger threshold (REQ-6 / AC-7): the project-wide bv-shadow density,
+/// in PER-MILLE of the contract-bearing postcondition surface, at or above which the named
+/// F-F tripwire fires. `500‰` (half) is the Schelling point — when a MAJORITY of the
+/// project's `ens` clauses have committed to a fixed-width machine-semantics fork, the
+/// program has drifted far enough toward the fork that the retreat ladder (full →
+/// `nowrap`-only → lemma-only → drop) should be weighed. Per-mille (not percent) so a
+/// modest density still resolves to a stable integer (`Eq`-safe — no `f64`), keeping the
+/// section a byte-deterministic projection.
+pub const FF_DENSITY_THRESHOLD_PERMILLE: u32 = 500;
+
+/// The "semantic forks and definition towers" section (REQ-6 / AC-7) — the additive,
+/// read-only audit/review surface for the forge + `@bv` legibility risks. A pure
+/// projection ([`SemanticForks::build`]); present only when the project has a semantic
+/// fork or a burned lemma to report (so the v1 / non-bv corpus omits it and its goldens
+/// stay byte-identical — the `bv_shadows`/`burned_lemmas` additive discipline).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticForks {
+    /// The bv-shadow density per module (one row per contract-bearing item with ≥1 `ens`
+    /// clause, in source order) — the semantic-fork legibility surface.
+    pub bv_density: Vec<ModuleDensity>,
+    /// The definition-tower depth of every burned lemma (in cert order) — the
+    /// definition-tower legibility surface.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub burned_lemma_towers: Vec<LemmaTower>,
+    /// The project-wide F-F density tripwire (the post-ship retreat trigger).
+    pub tripwire: FfTripwire,
+}
+
+/// One module's bv-shadow density (REQ-6 / AC-7) — a contract-bearing item (`fn` /
+/// `lemma`) and how much of its `ens` postcondition surface is a machine-semantics fork.
+/// Denominated by the `ens` clauses because the `@bv` tag attaches only to `ens` (and a
+/// lemma's `ens`) — the taggable surface (`check::fn_has_bv_tag` keys on `contract.ens`).
+/// A pure parse-level fact (which clauses carry the `@bv` tag); never recomputed from a
+/// verdict (R-CODE-5).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModuleDensity {
+    /// The module — the `fn` / `lemma` item name.
+    pub module: String,
+    /// The number of `@bv`-tagged `ens` clauses (the machine-semantics forks).
+    pub shadow_clauses: usize,
+    /// The total `ens` clauses (the taggable postcondition surface; the denominator).
+    pub contract_clauses: usize,
+    /// The density in per-mille: `shadow_clauses * 1000 / contract_clauses` (an item with
+    /// at least one `ens` always has a non-zero denominator, so this never divides by
+    /// zero — items with no `ens` clause are not listed). Integer (`Eq`-safe).
+    pub density_permille: u32,
+}
+
+/// One burned lemma's definition-tower depth (REQ-6 / AC-7) — a certified forge-tier
+/// `lemma` (the `review::BurnedLemma` set) and the depth + size of the `spec fn` tower its
+/// `req ∪ ens` unfolds (`meaning::tower_metrics`, the same meaning closure
+/// `forge audit --meaning` reports for `fn`s). A scalar lemma (no `spec fn` reference) has
+/// depth `0`. Pure (R-CODE-5).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LemmaTower {
+    /// The burned lemma's name.
+    pub lemma: String,
+    /// The tower depth — the longest distinct-definition `spec fn` unfolding chain rooted
+    /// at the lemma's `req ∪ ens` (`0` for a scalar contract).
+    pub depth: usize,
+    /// The number of distinct `spec fn` definitions the tower reaches.
+    pub definitions: usize,
+}
+
+/// The project-wide F-F density tripwire (REQ-6 / AC-7) — the post-ship retreat trigger.
+/// Aggregates the bv-shadow density across ALL contract-bearing `ens` clauses and compares
+/// it to [`FF_DENSITY_THRESHOLD_PERMILLE`]. Informational: a tripped tripwire gates
+/// nothing (it changes no verdict and no exit code), it raises a named human warning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FfTripwire {
+    /// The project total of `@bv`-tagged `ens` clauses (machine-semantics forks).
+    pub shadow_clauses: usize,
+    /// The project total of `ens` clauses (the contract-bearing postcondition surface).
+    pub contract_clauses: usize,
+    /// The project-wide density in per-mille (`0` when there is no `ens` surface).
+    pub density_permille: u32,
+    /// The threshold the density is compared against ([`FF_DENSITY_THRESHOLD_PERMILLE`]).
+    pub threshold_permille: u32,
+    /// `true` iff the density is at or above the threshold — the F-F tripwire fired.
+    pub tripped: bool,
+    /// The named F-F warning, present iff `tripped` (`#[serde(skip_serializing_if)]`). The
+    /// auditor's one-line "the program is fork-dominated; weigh the retreat ladder".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
+}
+
+impl SemanticForks {
+    /// Build the section from the settled cert collection + the parsed program (REQ-6 /
+    /// AC-7), or `None` when there is nothing to report — no `@bv`-tagged clause AND no
+    /// burned lemma (the v1 / non-bv corpus, whose goldens stay byte-identical). A pure
+    /// projection: density is a parse-level fact, the burned-lemma set is read from the
+    /// certificates (the `review::burned_lemma_projection` predicate), and the tower depth
+    /// reuses `meaning::tower_metrics`. No prover, no wall-clock (R-CODE-5).
+    #[must_use]
+    pub fn build(certs: &[Certificate], program: &Program) -> Option<Self> {
+        let bv_density = module_densities(program);
+        let burned_lemma_towers = burned_lemma_towers(certs, program);
+        let tripwire = FfTripwire::from_densities(&bv_density);
+
+        // Present only when there is a semantic fork (≥1 tagged clause) or a burned lemma
+        // to report — otherwise omitted, so the v1 corpus serializes byte-identically.
+        if tripwire.shadow_clauses == 0 && burned_lemma_towers.is_empty() {
+            return None;
+        }
+        Some(SemanticForks {
+            bv_density,
+            burned_lemma_towers,
+            tripwire,
+        })
+    }
+
+    /// Render the section as human-readable text (the `forge audit` / `forge review` body,
+    /// REQ-6). Read-only: this prints; it gates nothing.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        out.push_str("semantic forks and definition towers (the F-F tripwire):\n");
+
+        out.push_str("  bv-shadow density per module:\n");
+        if self.bv_density.is_empty() {
+            out.push_str("    (no contract-bearing modules)\n");
+        }
+        for row in &self.bv_density {
+            out.push_str(&format!(
+                "    {}: {}/{} ens clauses machine-semantics ({}‰)\n",
+                row.module, row.shadow_clauses, row.contract_clauses, row.density_permille
+            ));
+        }
+
+        out.push_str("  burned-lemma definition-tower depths:\n");
+        if self.burned_lemma_towers.is_empty() {
+            out.push_str("    (no burned lemmas)\n");
+        }
+        for row in &self.burned_lemma_towers {
+            out.push_str(&format!(
+                "    {}: depth {}, {} definitions\n",
+                row.lemma, row.depth, row.definitions
+            ));
+        }
+
+        match &self.tripwire.warning {
+            Some(warning) => out.push_str(&format!("  {warning}\n")),
+            None => out.push_str(&format!(
+                "  F-F tripwire: {}‰ bv-shadow density in contract-bearing code is WITHIN the \
+                 {}‰ retreat threshold.\n",
+                self.tripwire.density_permille, self.tripwire.threshold_permille
+            )),
+        }
+        out
+    }
+}
+
+impl FfTripwire {
+    /// Aggregate the per-module densities into the project-wide F-F tripwire (REQ-6 /
+    /// AC-7). Sums the tagged + total `ens` clauses across every module, computes the
+    /// per-mille density, and fires the named warning iff it reaches the threshold.
+    fn from_densities(densities: &[ModuleDensity]) -> Self {
+        let shadow_clauses: usize = densities.iter().map(|d| d.shadow_clauses).sum();
+        let contract_clauses: usize = densities.iter().map(|d| d.contract_clauses).sum();
+        let density_permille = permille(shadow_clauses, contract_clauses);
+        let tripped = density_permille >= FF_DENSITY_THRESHOLD_PERMILLE;
+        let warning = tripped.then(|| {
+            format!(
+                "F-F tripwire TRIPPED: {density_permille}‰ bv-shadow density in contract-bearing \
+                 code ({shadow_clauses}/{contract_clauses} ens clauses) reaches the \
+                 {FF_DENSITY_THRESHOLD_PERMILLE}‰ retreat threshold — the program is becoming \
+                 dominated by fixed-width machine-semantics forks; weigh the @bv retreat ladder \
+                 (full → nowrap-only → lemma-only → drop). Informational (gates nothing)."
+            )
+        });
+        FfTripwire {
+            shadow_clauses,
+            contract_clauses,
+            density_permille,
+            threshold_permille: FF_DENSITY_THRESHOLD_PERMILLE,
+            tripped,
+            warning,
+        }
+    }
+}
+
+/// The bv-shadow density of every contract-bearing module (REQ-6) — a `fn` / `lemma` with
+/// ≥1 `ens` clause, in source order. A pure parse-level projection: the numerator counts
+/// the `@bv`-tagged `ens` clauses (`Clause.bv.is_some()`), the denominator the total `ens`
+/// clauses. An item with no `ens` clause (a `req`-only `fn`) has no taggable surface and is
+/// not listed.
+fn module_densities(program: &Program) -> Vec<ModuleDensity> {
+    program
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Fn(f) => density_row(&f.name, &f.contract.ens),
+            Item::Forge(thermite_syntax::ForgeItem::Lemma(l)) => density_row(&l.name, &l.ens),
+            _ => None,
+        })
+        .collect()
+}
+
+/// One module's density row from its `ens` clauses (REQ-6), or `None` when the item has no
+/// `ens` clause (no taggable postcondition surface).
+fn density_row(name: &str, ens: &[thermite_syntax::Clause]) -> Option<ModuleDensity> {
+    if ens.is_empty() {
+        return None;
+    }
+    let shadow_clauses = ens.iter().filter(|c| c.bv.is_some()).count();
+    let contract_clauses = ens.len();
+    Some(ModuleDensity {
+        module: name.to_string(),
+        shadow_clauses,
+        contract_clauses,
+        density_permille: permille(shadow_clauses, contract_clauses),
+    })
+}
+
+/// The definition-tower depth of every burned lemma (REQ-6) — a certified forge-tier
+/// `lemma` carrying a burn receipt (the `review::burned_lemma_projection` predicate),
+/// projected to its `req ∪ ens` `spec fn` tower depth via `meaning::tower_metrics`. In
+/// cert order (deterministic, R-CODE-5).
+fn burned_lemma_towers(certs: &[Certificate], program: &Program) -> Vec<LemmaTower> {
+    let mut rows = Vec::new();
+    for cert in certs {
+        // Mirror `review::burned_lemma_projection`: the cert's item is a top-level
+        // `lemma`, it CERTIFIED (`cert_certifies`), and it carries a burn receipt.
+        let Some(lemma) = program.items.iter().find_map(|i| match i {
+            Item::Forge(thermite_syntax::ForgeItem::Lemma(l)) if l.name == cert.item => Some(l),
+            _ => None,
+        }) else {
+            continue;
+        };
+        if !cert_certifies(cert) || cert.burn.is_none() {
+            continue;
+        }
+        // The tower roots: the lemma's `req ∪ ens` (the meaning surface), exactly as
+        // `meaning::build_tower` roots a `fn`'s tower.
+        let mut roots: Vec<&Expr> = Vec::with_capacity(1 + lemma.ens.len());
+        roots.push(&lemma.req.expr);
+        roots.extend(lemma.ens.iter().map(|c| &c.expr));
+        let (depth, definitions) = crate::meaning::tower_metrics(program, &roots);
+        rows.push(LemmaTower {
+            lemma: cert.item.clone(),
+            depth,
+            definitions,
+        });
+    }
+    rows
+}
+
+/// `numerator * 1000 / denominator`, in per-mille; `0` when the denominator is `0` (no
+/// contract surface). Integer arithmetic — `Eq`-safe and byte-deterministic (R-CODE-5).
+fn permille(numerator: usize, denominator: usize) -> u32 {
+    if denominator == 0 {
+        return 0;
+    }
+    u32::try_from(numerator * 1000 / denominator).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::burn::BurnReceipt;
+    use crate::manifest::{Level, ObligationResult};
+
+    fn parse(src: &str) -> Program {
+        let parsed = thermite_syntax::parse(src);
+        assert!(
+            parsed.is_clean(),
+            "fixture must parse clean: {:?}",
+            parsed.errors
+        );
+        parsed.program
+    }
+
+    // AC-7: bv-shadow density per module — known counts. `mix64` carries two `@bv64` ens
+    // clauses + one unbounded ens clause (2/3); the injectivity lemma one `@bv64` clause
+    // (1/1). The numbers match the fixture's known counts exactly (a pure parse-level
+    // projection; no verus needed). The `bv` feature gates the tag's parse (REQ-1).
+    #[cfg(feature = "bv")]
+    #[test]
+    fn bv_density_per_module_matches_known_counts() {
+        let program = parse(include_str!("../../conformance/forge/mix64.th"));
+        let densities = module_densities(&program);
+        let row = |name: &str| densities.iter().find(|d| d.module == name).cloned();
+
+        let mix = row("mix64").expect("mix64 is a contract-bearing module");
+        assert_eq!(mix.shadow_clauses, 2, "two @bv64 ens clauses");
+        assert_eq!(mix.contract_clauses, 3, "three ens clauses total");
+        assert_eq!(mix.density_permille, 666, "2/3 → 666‰");
+
+        let lemma = row("rotl1_injective").expect("the lemma is a contract-bearing module");
+        assert_eq!(lemma.shadow_clauses, 1);
+        assert_eq!(lemma.contract_clauses, 1);
+        assert_eq!(lemma.density_permille, 1000, "1/1 → 1000‰");
+    }
+
+    // AC-7: a synthetic density spike trips the named F-F warning, and a normal density
+    // does not. Built from raw `ModuleDensity` rows (no parse needed — the tripwire is a
+    // pure aggregate). The named warning names the F-F retreat ladder.
+    #[test]
+    fn density_spike_trips_the_named_ff_warning() {
+        // Normal: one tagged clause among five contract clauses (200‰ < 500‰) — no trip.
+        let normal = vec![
+            ModuleDensity {
+                module: "wrap_one".to_string(),
+                shadow_clauses: 1,
+                contract_clauses: 1,
+                density_permille: 1000,
+            },
+            ModuleDensity {
+                module: "plain".to_string(),
+                shadow_clauses: 0,
+                contract_clauses: 4,
+                density_permille: 0,
+            },
+        ];
+        let tw = FfTripwire::from_densities(&normal);
+        assert_eq!(tw.shadow_clauses, 1);
+        assert_eq!(tw.contract_clauses, 5);
+        assert_eq!(tw.density_permille, 200);
+        assert!(!tw.tripped, "200‰ is within the 500‰ threshold");
+        assert!(tw.warning.is_none(), "no warning when within threshold");
+
+        // Spike: the machine-semantics forks become the majority (4/5 = 800‰ ≥ 500‰).
+        let spike = vec![
+            ModuleDensity {
+                module: "fork_heavy".to_string(),
+                shadow_clauses: 4,
+                contract_clauses: 4,
+                density_permille: 1000,
+            },
+            ModuleDensity {
+                module: "plain".to_string(),
+                shadow_clauses: 0,
+                contract_clauses: 1,
+                density_permille: 0,
+            },
+        ];
+        let tw = FfTripwire::from_densities(&spike);
+        assert_eq!(tw.density_permille, 800);
+        assert!(tw.tripped, "800‰ reaches the 500‰ threshold");
+        let warning = tw
+            .warning
+            .expect("a tripped tripwire carries the named warning");
+        assert!(warning.contains("F-F tripwire TRIPPED"), "{warning}");
+        assert!(
+            warning.contains("full → nowrap-only → lemma-only → drop"),
+            "the warning names the retreat ladder: {warning}"
+        );
+    }
+
+    // AC-7: the tripwire fires exactly at the threshold (500‰ is "reaches", not "exceeds").
+    #[test]
+    fn tripwire_fires_at_the_threshold_boundary() {
+        let at = vec![ModuleDensity {
+            module: "half".to_string(),
+            shadow_clauses: 1,
+            contract_clauses: 2,
+            density_permille: 500,
+        }];
+        let tw = FfTripwire::from_densities(&at);
+        assert_eq!(tw.density_permille, 500);
+        assert!(tw.tripped, "exactly 500‰ trips (>= threshold)");
+    }
+
+    // AC-7: burned-lemma tower depth. A burned lemma whose `ens` references a `spec fn`
+    // chain reports that chain's depth; the section reads which lemmas burned from the
+    // certs (a certified lemma with a burn receipt) — an uncertified lemma is not a tower.
+    #[test]
+    fn burned_lemma_tower_depth_follows_the_spec_fn_chain() {
+        let program = parse(
+            "spec fn a(x: u32) -> bool dec x { b(x) }\n\
+             spec fn b(x: u32) -> bool dec x { x > 0 }\n\
+             lemma deep(x: u32) req true ens a(x) proof { }",
+        );
+        let burned = Certificate::new(
+            "deep",
+            Level::L3,
+            vec!["pure".to_string()],
+            0,
+            vec![ObligationResult::discharged("deep")],
+        )
+        .graduate_triage_clean()
+        .with_burn(BurnReceipt::for_proof_text("trivial"));
+        let towers = burned_lemma_towers(&[burned], &program);
+        assert_eq!(towers.len(), 1, "the certified burned lemma is a tower");
+        assert_eq!(towers[0].lemma, "deep");
+        assert_eq!(towers[0].depth, 2, "a → b is a 2-deep spec-fn chain");
+        assert_eq!(towers[0].definitions, 2);
+    }
+
+    // AC-7: an uncertified lemma (no burn) is NOT surfaced as a tower — only a burned
+    // (certified, receipted) lemma is, mirroring `review::burned_lemma_projection`.
+    #[test]
+    fn uncertified_lemma_is_not_a_tower() {
+        let program = parse("lemma bad(x: u32) req true ens x >= 0 proof { }");
+        let rejected = Certificate::rejected(
+            "bad".to_string(),
+            vec!["pure".to_string()],
+            false,
+            crate::manifest::RejectReason {
+                cause: "LeanUnknown".to_string(),
+                detail: "did not discharge".to_string(),
+            },
+        );
+        let towers = burned_lemma_towers(&[rejected], &program);
+        assert!(
+            towers.is_empty(),
+            "an uncertified lemma is not a burned tower"
+        );
+    }
+
+    // The section is omitted (None) for a tag-free, lemma-free program (the v1 corpus):
+    // the additive discipline that keeps v1 goldens byte-identical.
+    #[test]
+    fn section_omitted_for_v1_corpus() {
+        let program = parse("fn f(x: u32) -> u32 req x < 100 ens result == x fx pure { x }");
+        let cert = Certificate::new("f", Level::L3, vec!["pure".to_string()], 0, vec![]);
+        assert!(
+            SemanticForks::build(&[cert], &program).is_none(),
+            "a tag-free, lemma-free program carries no semantic-forks section"
+        );
+    }
+}

--- a/forge/src/main.rs
+++ b/forge/src/main.rs
@@ -43,6 +43,7 @@ mod degrade;
 mod effect_wrappers;
 mod engine;
 mod exec_tv;
+mod forks;
 mod goal_repl;
 mod kani;
 mod lean_export;

--- a/forge/src/meaning.rs
+++ b/forge/src/meaning.rs
@@ -38,7 +38,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use thermite_syntax::{FnItem, Item, Program, SpecFnItem};
+use thermite_syntax::{Expr, FnItem, Item, Program, SpecFnItem};
 
 /// The Q2 default definition-tower DEPTH budget (REQ-6c): the maximum length of the
 /// longest distinct-definition unfolding chain rooted at the contract. A tower whose
@@ -287,14 +287,7 @@ impl DefinitionTower {
 /// not part of the tower (it is not an unfoldable in-file definition).
 #[must_use]
 pub fn build_tower(program: &Program, src: &str, f: &FnItem) -> DefinitionTower {
-    let spec_decls: BTreeMap<&str, &SpecFnItem> = program
-        .items
-        .iter()
-        .filter_map(|i| match i {
-            Item::SpecFn(s) => Some((s.name.as_str(), s)),
-            _ => None,
-        })
-        .collect();
+    let spec_decls = spec_decls_of(program);
 
     // The roots: the spec fns the CONTRACT (`req ∪ ens`) directly references — the
     // meaning surface. (The body's own calls are implementation, not the claim.)
@@ -304,41 +297,8 @@ pub fn build_tower(program: &Program, src: &str, f: &FnItem) -> DefinitionTower 
         crate::check::collect_expr_spec_fn_calls(&ens.expr, &spec_decls, &mut roots);
     }
 
-    // The per-definition callee edges (intersected with the in-file spec-fn set): a
-    // definition's meaning unfolds the spec fns its `body ∪ dec` references.
-    let edges: BTreeMap<String, BTreeSet<String>> = spec_decls
-        .iter()
-        .map(|(name, decl)| {
-            let mut callees: BTreeSet<String> = BTreeSet::new();
-            crate::check::collect_block_spec_fn_calls(&decl.body, &spec_decls, &mut callees);
-            crate::check::collect_expr_spec_fn_calls(&decl.dec.expr, &spec_decls, &mut callees);
-            ((*name).to_string(), callees)
-        })
-        .collect();
-
-    // The reachable set (transitive closure of the roots over the edges) and each
-    // definition's level (shortest reference distance from a root, root = 1) by BFS.
-    let mut level: BTreeMap<String, usize> = BTreeMap::new();
-    let mut frontier: Vec<String> = roots.iter().cloned().collect();
-    for r in &frontier {
-        level.insert(r.clone(), 1);
-    }
-    while let Some(name) = frontier.pop() {
-        let cur = level.get(&name).copied().unwrap_or(1);
-        if let Some(callees) = edges.get(&name) {
-            for c in callees {
-                let next = cur + 1;
-                let improved = match level.get(c) {
-                    Some(&existing) => next < existing,
-                    None => true,
-                };
-                if improved {
-                    level.insert(c.clone(), next);
-                    frontier.push(c.clone());
-                }
-            }
-        }
-    }
+    let edges = spec_fn_edges(&spec_decls);
+    let level = reachable_levels(&roots, &edges);
 
     // The defs in source order (deterministic), each with its verbatim span slice.
     let defs: Vec<TowerDef> = program
@@ -361,6 +321,94 @@ pub fn build_tower(program: &Program, src: &str, f: &FnItem) -> DefinitionTower 
         defs,
         depth,
     }
+}
+
+/// The definition-tower DEPTH + distinct-definition count rooted at an arbitrary set of
+/// contract clause exprs (stage-3 REQ-6) — the depth-only projection the "semantic forks
+/// and definition towers" section ([`crate::forks`]) uses for a burned `lemma`. A
+/// [`thermite_syntax::LemmaItem`] carries `req ∪ ens` but no `FnItem`/body, so
+/// [`build_tower`] (which keys on a `FnItem` + slices `src` for verbatim text) does not
+/// apply, and the section needs only the depth + count, not the unfolded text — so this
+/// takes no `src`. It reuses the same `spec fn` call collectors + edge graph helpers as
+/// [`build_tower`], so the two AGREE on what "the tower" is (the spec-fn meaning closure
+/// of the contract). Pure (R-CODE-5): a function of the AST alone. Returns
+/// `(depth, definition_count)`.
+#[must_use]
+pub fn tower_metrics(program: &Program, root_exprs: &[&Expr]) -> (usize, usize) {
+    let spec_decls = spec_decls_of(program);
+    let mut roots: BTreeSet<String> = BTreeSet::new();
+    for e in root_exprs {
+        crate::check::collect_expr_spec_fn_calls(e, &spec_decls, &mut roots);
+    }
+    let edges = spec_fn_edges(&spec_decls);
+    let level = reachable_levels(&roots, &edges);
+    let depth = tower_depth(&roots, &edges);
+    // The reachable set is exactly the keys of `level` (the collectors only insert names
+    // in `spec_decls`, so every reached name is an in-file definition) — `level.len()` is
+    // the distinct-definition count, the same count `build_tower`'s `defs` carries.
+    (depth, level.len())
+}
+
+/// The in-file `spec fn` declarations, keyed by name (shared by [`build_tower`] +
+/// [`tower_metrics`]). A combinator / cross-file callee has no in-file declaration and so
+/// is not in this map (and never enters the tower).
+fn spec_decls_of(program: &Program) -> BTreeMap<&str, &SpecFnItem> {
+    program
+        .items
+        .iter()
+        .filter_map(|i| match i {
+            Item::SpecFn(s) => Some((s.name.as_str(), s)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The per-definition callee edges (intersected with the in-file spec-fn set): a
+/// definition's meaning unfolds the spec fns its `body ∪ dec` references. Shared by
+/// [`build_tower`] + [`tower_metrics`].
+fn spec_fn_edges(spec_decls: &BTreeMap<&str, &SpecFnItem>) -> BTreeMap<String, BTreeSet<String>> {
+    spec_decls
+        .iter()
+        .map(|(name, decl)| {
+            let mut callees: BTreeSet<String> = BTreeSet::new();
+            crate::check::collect_block_spec_fn_calls(&decl.body, spec_decls, &mut callees);
+            crate::check::collect_expr_spec_fn_calls(&decl.dec.expr, spec_decls, &mut callees);
+            ((*name).to_string(), callees)
+        })
+        .collect()
+}
+
+/// The reachable set (transitive closure of the roots over the edges) with each
+/// definition's level (shortest reference distance from a root, root = 1) by BFS. Shared
+/// by [`build_tower`] (which maps levels to `TowerDef`s) + [`tower_metrics`] (which counts
+/// the keys). Deterministic (R-CODE-5): the `BTreeMap`/`BTreeSet` iteration order is
+/// stable.
+fn reachable_levels(
+    roots: &BTreeSet<String>,
+    edges: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeMap<String, usize> {
+    let mut level: BTreeMap<String, usize> = BTreeMap::new();
+    let mut frontier: Vec<String> = roots.iter().cloned().collect();
+    for r in &frontier {
+        level.insert(r.clone(), 1);
+    }
+    while let Some(name) = frontier.pop() {
+        let cur = level.get(&name).copied().unwrap_or(1);
+        if let Some(callees) = edges.get(&name) {
+            for c in callees {
+                let next = cur + 1;
+                let improved = match level.get(c) {
+                    Some(&existing) => next < existing,
+                    None => true,
+                };
+                if improved {
+                    level.insert(c.clone(), next);
+                    frontier.push(c.clone());
+                }
+            }
+        }
+    }
+    level
 }
 
 /// The longest distinct-definition unfolding chain rooted at any contract root

--- a/forge/src/review.rs
+++ b/forge/src/review.rs
@@ -250,6 +250,16 @@ pub struct ReviewArtifact {
     /// `forge review --json` ≡ the project's tagged clauses (AC-4).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub bv_shadows: Vec<BvShadowClause>,
+    /// The "semantic forks and definition towers" section
+    /// (`.design/stage3-bv-reconstruction.md` REQ-6 / AC-7): the AGGREGATE legibility
+    /// surface a reviewer reads alongside the per-clause `bv_shadows` + `burned_lemmas`
+    /// above — bv-shadow density per module, every burned lemma's definition-tower depth,
+    /// and the post-ship **F-F density tripwire**. A pure projection
+    /// ([`crate::forks::SemanticForks::build`]); `None` (and omitted) on the default Verus
+    /// path / the v1 corpus (no `@bv` tag, no burned lemma), so a v1 review artifact
+    /// serializes BYTE-IDENTICALLY (the additive `bv_shadows`/`burned_lemmas` discipline).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_forks: Option<crate::forks::SemanticForks>,
 }
 
 /// One `@bv`-tagged clause's shadow flag in the review artifact
@@ -463,11 +473,17 @@ fn project_artifact(
         }
     }
 
+    // REQ-6 / AC-7: the aggregate "semantic forks and definition towers" section — the
+    // bv-shadow density per module, the burned-lemma tower depths, and the F-F density
+    // tripwire. `None` (omitted) on the default Verus / v1 path (no tag, no burned lemma).
+    let semantic_forks = crate::forks::SemanticForks::build(certs, program);
+
     ReviewArtifact {
         intent_reviewable,
         battery_failing,
         burned_lemmas,
         bv_shadows,
+        semantic_forks,
     }
 }
 

--- a/forge/tests/bv_lowering.rs
+++ b/forge/tests/bv_lowering.rs
@@ -591,3 +591,124 @@ fn bv_nowrap_side_obligation_rejects_overflow_and_records_the_verdict() {
         "the nowrap obligation holds in-cage: {held}"
     );
 }
+
+/// REQ-6 / AC-7 (the "semantic forks and definition towers" section, normal density): the
+/// additive section reports bv-shadow density PER MODULE matching the fixture's known
+/// counts, and the project-wide F-F tripwire stays WITHIN the retreat threshold (one tagged
+/// clause among four contract-bearing clauses, 250‰ < 500‰ → no trip). The whole project
+/// certifies (the ordinary fns at L3, the @bv fn at L4), so the audit exits 0.
+#[test]
+fn forge_audit_semantic_forks_density_matches_known_counts() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — forge audit's bv route is not run.");
+        return;
+    }
+    let (code, manifest) = run_forge_json("audit", "bv_density_normal.th");
+    assert_eq!(
+        code,
+        Some(0),
+        "the normal-density project certifies: {manifest}"
+    );
+    let forks = &manifest["semantic_forks"];
+    assert!(
+        !forks.is_null(),
+        "the audit manifest carries the semantic_forks section: {manifest}"
+    );
+
+    // Per-module density matches the fixture's KNOWN counts (a pure parse-level projection).
+    let density = forks["bv_density"]
+        .as_array()
+        .expect("a bv_density per-module list");
+    let row = |module: &str| -> &Value {
+        density
+            .iter()
+            .find(|d| d["module"] == module)
+            .unwrap_or_else(|| panic!("module `{module}` in the density report: {forks}"))
+    };
+    assert_eq!(row("wrap_add")["shadow_clauses"], Value::from(1));
+    assert_eq!(row("wrap_add")["contract_clauses"], Value::from(1));
+    assert_eq!(row("wrap_add")["density_permille"], Value::from(1000));
+    assert_eq!(row("plain_add")["shadow_clauses"], Value::from(0));
+    assert_eq!(row("plain_add")["density_permille"], Value::from(0));
+
+    // The project-wide F-F tripwire: 1/4 = 250‰ < 500‰ → NOT tripped, no warning.
+    let tw = &forks["tripwire"];
+    assert_eq!(tw["shadow_clauses"], Value::from(1));
+    assert_eq!(tw["contract_clauses"], Value::from(4));
+    assert_eq!(tw["density_permille"], Value::from(250));
+    assert_eq!(tw["threshold_permille"], Value::from(500));
+    assert_eq!(
+        tw["tripped"],
+        Value::Bool(false),
+        "250‰ is within threshold"
+    );
+    assert!(
+        tw.get("warning").is_none() || tw["warning"].is_null(),
+        "no F-F warning when within the retreat threshold: {tw}"
+    );
+}
+
+/// REQ-6 / AC-7 (the F-F tripwire, density spike): a synthetic density spike — two
+/// `@bv`-tagged clauses among three contract-bearing clauses (666‰ ≥ 500‰) — TRIPS the
+/// named F-F warning, which names the retreat ladder. The tripwire gates nothing: the
+/// project still certifies (exit 0), the warning is purely informational.
+#[test]
+fn forge_audit_density_spike_trips_the_named_ff_tripwire() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — forge audit's bv route is not run.");
+        return;
+    }
+    let (code, manifest) = run_forge_json("audit", "bv_density_spike.th");
+    assert_eq!(
+        code,
+        Some(0),
+        "the F-F tripwire gates nothing — the project still certifies: {manifest}"
+    );
+    let tw = &manifest["semantic_forks"]["tripwire"];
+    assert_eq!(tw["shadow_clauses"], Value::from(2));
+    assert_eq!(tw["contract_clauses"], Value::from(3));
+    assert_eq!(tw["density_permille"], Value::from(666), "2/3 → 666‰");
+    assert_eq!(
+        tw["tripped"],
+        Value::Bool(true),
+        "666‰ reaches the 500‰ threshold"
+    );
+    let warning = tw["warning"]
+        .as_str()
+        .expect("a tripped tripwire carries the named warning");
+    assert!(
+        warning.contains("F-F tripwire TRIPPED"),
+        "the named F-F warning fires: {warning}"
+    );
+    assert!(
+        warning.contains("full → nowrap-only → lemma-only → drop"),
+        "the warning names the retreat ladder: {warning}"
+    );
+}
+
+/// REQ-6 / AC-7: `forge review` carries the same additive semantic-forks section as
+/// `forge audit` — the reviewer sees the per-module density + the F-F tripwire alongside
+/// the per-clause shadow flags.
+#[test]
+fn forge_review_carries_the_semantic_forks_section() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — forge review's bv route is not run.");
+        return;
+    }
+    let (_code, artifact) = run_forge_json("review", "bv_density_spike.th");
+    let forks = &artifact["semantic_forks"];
+    assert!(
+        !forks.is_null(),
+        "the review artifact carries the semantic_forks section: {artifact}"
+    );
+    assert_eq!(
+        forks["bv_density"].as_array().map(Vec::len),
+        Some(3),
+        "three contract-bearing modules in the density report: {forks}"
+    );
+    assert_eq!(
+        forks["tripwire"]["tripped"],
+        Value::Bool(true),
+        "the spike trips in review too: {forks}"
+    );
+}


### PR DESCRIPTION
Stage-3 REQ-6 — the "semantic forks and definition towers" review/audit section + the F-F density tripwire. Closes #348. Child of the Stage-3 tree (umbrella xl #342 / gh #80; spec REQ-6 / AC-7).

## What ships
- **`forge/src/forks.rs`** (`SemanticForks`): per-module **bv-shadow density** (shadowed `@bv` clauses / contract `ens` clauses, in permille), **burned-lemma tower depths** (via a new depth-only `meaning::tower_metrics`, refactored to share graph helpers with the existing tower analysis), and the **`FfTripwire`**.
- **Additive section**: `Option<SemanticForks>` on `AuditManifest` + `ReviewArtifact` (`serde skip_if_none` → v1 goldens byte-identical); `cli` renders it under `forge audit`/`forge review`.
- **The F-F tripwire** (the named retreat trigger): when project-wide bv-shadow density reaches the **500‰** threshold (a majority of the `ens` surface), a named informational warning fires — *"the program is becoming predominantly machine-semantics forks."* The post-ship trigger down the F-F ladder (full → nowrap-only → lemma-only → drop).

## Verification (full env: verus + z3 + Lean spine)
- AC-7 ✅: `bv_density_spike.th` (2/3 ens = 666‰) **trips** the named warning; `bv_density_normal.th` (1/4 = 250‰) does not; per-module density matches the fixtures' known counts.
- The `meaning.rs` refactor preserved all 7 existing tower/meaning tests (no anti-Goodhart regression); prior invariants intact (per-item overlay, mutation gate, nowrap).
- Full `forge` suite green; clippy `-D warnings` + rustfmt 1.95.0 (workspace) clean both configs; v1 goldens byte-identical; `make doc-drift` exit 0.

Reporting-only increment — no behavioral fix needed on the kickoff output. I verified AC-7 + the refactor's safety and added the orchestrator doc-drift re-pin. **This completes the bv-half locks (REQ-3/4/5/6).**