### PR TITLE
Stage-3 REQ-8: reconstruction default-on — the per-clause trust migration (#350)

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 0e9ce0aee57c30c48e74a37c8c492afafe9545ade899c965e842b98bbf72b12e (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 3c6a908da157641805a57c3f1ff18215ad79c8cf09a496d3a9d8a1dc043bc0e8 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 0e9ce0aee57c30c48e74a37c8c492afafe9545ade899c965e842b98bbf72b12e (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 3c6a908da157641805a57c3f1ff18215ad79c8cf09a496d3a9d8a1dc043bc0e8 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: d0c4fbe0d63a277d88f9ef408d7500b52adfdd614a1e0a898fd6fcb9e291787a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 5da96b53476e787c3488ff7769ef60bfada0c15797c235683d1fd57937c83946 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/forge/audit-manifest.md
+++ b/.design/forge/audit-manifest.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 1cc9d97c6c5d7eab6109561834db77f2ef4b57ab (re-pinned 2026-06-16: forge workflow status rows now render from canonical registry IDs; behavior unchanged; RFC #17)  (prior: 488103d4382815b85141d17bc01b60917ba744e7 (#274 — lean_fragment membership report; REQ-7..10 SHIPPED, audit.rs verified-current))
-audited-content-sha256: 11d046491b2627236d2a81608698435e965743ef0c746746e13ec1e6c2cba0af
+audited-content-sha256: 78b1c9780993abfb7d7a0159a174da2c4d8232fb371934b86ce1de17c8f8469e
 governs: forge/src/audit.rs
 thesis-refs:
   - thermite-design.md §6

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 55156905add8adc25c30958b13c9136079c53e8c7393b35049e67da7bb22b420 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: a10f679dd2fd4ae2dad1fc8607c93d13413d0d019823f55b85f41b61e1578c7a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: d0c4fbe0d63a277d88f9ef408d7500b52adfdd614a1e0a898fd6fcb9e291787a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 5da96b53476e787c3488ff7769ef60bfada0c15797c235683d1fd57937c83946 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-content-sha256: cd64cc22d9664c34eb90cd34874004d0d7d9d96af09f5210433ff2d157816c2a (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 28f745f55a4e7bb8ddf941decb241d4473ed924790c5ddfa3b95711b973e111e (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/forge/src/audit.rs
+++ b/forge/src/audit.rs
@@ -108,6 +108,15 @@ pub struct AuditManifest {
     /// `bv_shadows`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_forks: Option<crate::forks::SemanticForks>,
+    /// The REQ-8 / AC-9 RESIDUAL-TRUST STATEMENT: the kernel-checked-vs-solver-trusted split
+    /// after reconstruction's default-on per-clause trust migration, with the
+    /// still-solver-trusted clauses + fragments named honestly. A pure projection
+    /// ([`ResidualTrust::build`]) over the certs' per-clause trust bases; `None` (and
+    /// omitted) for a project the bit-vector route did not run on, so the v1 / nlsat-only
+    /// corpus serializes BYTE-IDENTICALLY (the additive `semantic_forks` discipline;
+    /// `manifest_version` stays `"v1"`). The section gates nothing — informational.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub residual_trust: Option<ResidualTrust>,
 }
 
 /// One `@bv`-tagged clause's shadow-flag row in the audit manifest
@@ -144,6 +153,120 @@ impl BvShadowRow {
             }
         }
         rows
+    }
+}
+
+/// The REQ-8 / AC-9 RESIDUAL-TRUST STATEMENT (`.design/stage3-bv-reconstruction.md`
+/// REQ-8). After reconstruction's default-on per-clause trust migration, a project's
+/// clauses split into two trust bases at the SAME rung: the ones whose `trust:` migrated to
+/// the KERNEL-CHECKED form (the renderable QF_LIA + arithmetic/comparison QF_BV fragment,
+/// plus the nlsat-relax kernel-grounded clauses) and the ones that STAYED solver-trusted
+/// (the bitwise/shift/rotate QF_BV subset the exporter refuses, a Verus L3 base, and the
+/// EPR-stratified rel/array residual the reconstruction fragment does not cover). This
+/// section is that split, named honestly — "the audit names exactly what stayed
+/// solver-trusted" (F-J is free: reconstruction was never load-bearing for any gate, so an
+/// unsupported fragment regresses nothing by staying labeled).
+///
+/// A pure projection ([`ResidualTrust::build`]) of each per-clause obligation's `trust`
+/// base via [`crate::engine::trust_is_kernel_checked`]; never recomputed. Present only for
+/// a project the bit-vector route ran on (`!bv_shadows.is_empty()`), so the v1 / nlsat-only
+/// corpus serializes BYTE-IDENTICALLY (the additive `semantic_forks`/`bv_shadows`
+/// discipline; `manifest_version` stays `"v1"`). The section gates nothing — informational.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResidualTrust {
+    /// The number of per-clause obligations now KERNEL-CHECKED / kernel-grounded (REQ-8):
+    /// the reconstruction-migrated bv clauses + the nlsat-relax clauses.
+    pub kernel_checked_clauses: usize,
+    /// The number of per-clause obligations that STAYED solver-trusted (the bitwise/shift/
+    /// rotate QF_BV subset + any non-migrated solver base).
+    pub solver_trusted_clauses: usize,
+    /// The still-solver-trusted clauses, NAMED (item + per-clause obligation name + engine)
+    /// — the F-J inventory a reviewer audits, the same "grep finds exactly these" discipline
+    /// the `bv_shadows` / `tcb` sections follow. Source order (deterministic, REQ-6).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub solver_trusted: Vec<ResidualClause>,
+    /// The named FRAGMENTS reconstruction does not support program-wide (the standing F-J
+    /// note): the bitwise/shift/rotate QF_BV subset (the bit-blasting wall) and the
+    /// EPR-stratified rel/array atoms (left z3-model-relative by `strat_lowering_faithful`,
+    /// the G2 residual — outside the QF_LIA/QF_BV reconstruction fragment, named not
+    /// migrated). Deterministic, R-CODE-5.
+    pub unsupported_fragments: Vec<String>,
+    /// The human one-line residual-trust statement (the auditor's headline).
+    pub statement: String,
+}
+
+/// One still-solver-trusted clause in the residual-trust statement (REQ-8 / AC-9) — a pure
+/// projection of an obligation that carries a per-clause `trust` base with NO kernel-checked
+/// marker. Read verbatim from the cert (REQ-4).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResidualClause {
+    /// The owning item (the `fn` / `lemma`).
+    pub item: String,
+    /// The per-clause obligation name.
+    pub clause: String,
+    /// The engine that discharged the clause (e.g. `"bitvector"`), when attributed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine: Option<String>,
+}
+
+impl ResidualTrust {
+    /// Aggregate the REQ-8 kernel-checked-vs-solver split across a settled cert collection
+    /// (AC-9). A pure projection: every per-clause obligation that carries a non-empty
+    /// `trust` base is classified by [`crate::engine::trust_is_kernel_checked`]; the
+    /// solver-trusted ones are named. The standing F-J fragments (bitwise/shift/rotate +
+    /// EPR rel/array) are named unconditionally for a bv project, because the
+    /// reconstruction fragment structurally excludes them program-wide. Returns `None` for a
+    /// project the bit-vector route did not run on, so the v1 / nlsat goldens stay
+    /// byte-identical.
+    fn build(certs: &[Certificate], bv_present: bool) -> Option<Self> {
+        if !bv_present {
+            return None;
+        }
+        let mut kernel_checked_clauses = 0usize;
+        let mut solver_trusted = Vec::new();
+        for cert in certs {
+            for obl in &cert.obligations {
+                if obl.trust.is_empty() {
+                    continue;
+                }
+                if crate::engine::trust_is_kernel_checked(&obl.trust) {
+                    kernel_checked_clauses += 1;
+                } else {
+                    solver_trusted.push(ResidualClause {
+                        item: cert.item.clone(),
+                        clause: obl.name.clone(),
+                        engine: obl.engine.clone(),
+                    });
+                }
+            }
+        }
+        let solver_trusted_clauses = solver_trusted.len();
+        let unsupported_fragments = vec![
+            "bitwise/shift/rotate QF_BV (`^`/`&`/`|`/`<<`/`>>`, rotate): outside the exporter's \
+             renderable fragment — no clean Int encoding, the literal-BitVec path hits the \
+             upstream bit-blasting `sorry` (z3-demotion.md), so these stay solver-trusted (F-J)"
+                .to_string(),
+            "EPR-stratified rel/array atoms: left z3-model-relative by `strat_lowering_faithful` \
+             (the G2 residual) — outside the QF_LIA/QF_BV reconstruction fragment, named not \
+             migrated (F-J — reconstruction was never load-bearing for any gate)"
+                .to_string(),
+        ];
+        let statement = format!(
+            "Residual trust (REQ-8, default-on): {kernel_checked_clauses} clause(s) \
+             kernel-checked, {solver_trusted_clauses} clause(s) still solver-trusted. \
+             Reconstruction is default-on for the QF_LIA + arithmetic/comparison QF_BV \
+             fragment (trust migrated from solver(Z3) to the Lean kernel + the kernel-checked \
+             BvModel faithfulness, same rung); the bitwise/shift/rotate QF_BV subset and the \
+             EPR-stratified rel/array atoms stay solver-trusted, named above (F-J — no gate \
+             regresses, reconstruction was never load-bearing)."
+        );
+        Some(ResidualTrust {
+            kernel_checked_clauses,
+            solver_trusted_clauses,
+            solver_trusted,
+            unsupported_fragments,
+            statement,
+        })
     }
 }
 
@@ -620,6 +743,10 @@ impl AuditManifest {
         // bv-shadow density per module, the burned-lemma tower depths, and the F-F density
         // tripwire. `None` (omitted) for a tag-free, lemma-free project (the v1 corpus).
         let semantic_forks = crate::forks::SemanticForks::build(certs, program);
+        // REQ-8 / AC-9: the residual-trust statement — the kernel-checked-vs-solver split
+        // after reconstruction's default-on trust migration. Present only for a bv project
+        // (`!bv_shadows.is_empty()`), so the v1 / nlsat corpus serializes byte-identically.
+        let residual_trust = ResidualTrust::build(certs, !bv_shadows.is_empty());
         AuditManifest {
             manifest_version: MANIFEST_VERSION.to_string(),
             functions,
@@ -628,6 +755,7 @@ impl AuditManifest {
             lean_fragment,
             bv_shadows,
             semantic_forks,
+            residual_trust,
         }
     }
 }
@@ -932,5 +1060,79 @@ mod tests {
                 r.reason
             );
         }
+    }
+
+    /// A `@bv`-tagged obligation carrying a `bv_shadow` (so the bv route is detected) with
+    /// the given per-clause trust base + obligation name.
+    fn bv_obl(name: &str, trust: Vec<String>) -> crate::manifest::ObligationResult {
+        let shadow = crate::manifest::BvShadow {
+            flagged: true,
+            semantics: "bv64 (wraparound)".to_string(),
+            nowrap_obligation: None,
+            note: "machine-semantics fork (test)".to_string(),
+        };
+        crate::manifest::ObligationResult::discharged(name)
+            .with_clause_attribution("bitvector", trust, crate::verdict::CertVerdict::Proved)
+            .with_bv_shadow(shadow)
+    }
+
+    // REQ-8 / AC-9: the residual-trust statement aggregates the kernel-checked-vs-solver
+    // split across a bv project's per-clause obligations and names the still-solver-trusted
+    // clauses + fragments. The mix64 split: one kernel-checked (arith) + one solver (xor).
+    #[test]
+    fn req8_residual_trust_aggregates_the_kernel_checked_vs_solver_split() {
+        let cert = Certificate::new(
+            "mix64",
+            Level::L4,
+            vec!["pure".to_string()],
+            0,
+            vec![
+                bv_obl(
+                    "mix64::ens#0",
+                    crate::engine::bv_kernel_checked_trust_profile().items,
+                ),
+                bv_obl("mix64::ens#1", crate::engine::bv_trust_profile().items),
+            ],
+        );
+        let m = AuditManifest::from_certificates(&[cert], &empty_program(), toolchain());
+        let rt = m
+            .residual_trust
+            .expect("a bv project carries the REQ-8 residual-trust statement");
+        assert_eq!(
+            rt.kernel_checked_clauses, 1,
+            "the arith clause is kernel-checked"
+        );
+        assert_eq!(
+            rt.solver_trusted_clauses, 1,
+            "the xor clause stays solver-trusted"
+        );
+        assert_eq!(rt.solver_trusted.len(), 1);
+        assert_eq!(rt.solver_trusted[0].item, "mix64");
+        assert_eq!(rt.solver_trusted[0].clause, "mix64::ens#1");
+        assert_eq!(rt.solver_trusted[0].engine.as_deref(), Some("bitvector"));
+        // The standing F-J fragments are named: the bitwise/shift/rotate subset + the EPR
+        // rel/array residual.
+        assert_eq!(rt.unsupported_fragments.len(), 2);
+        assert!(rt.unsupported_fragments[0].contains("bitwise/shift/rotate"));
+        assert!(rt.unsupported_fragments[1].contains("rel/array"));
+        assert!(rt.statement.contains("kernel-checked"));
+    }
+
+    // REQ-8 / AC-9: a non-bv project (the v1 / nlsat corpus) carries NO residual-trust
+    // statement, so its audit manifest serializes byte-identically (the additive discipline).
+    #[test]
+    fn req8_non_bv_project_has_no_residual_trust_statement() {
+        let certs = vec![Certificate::new(
+            "sum",
+            Level::L3,
+            vec!["pure".to_string()],
+            0,
+            vec![],
+        )];
+        let m = AuditManifest::from_certificates(&certs, &empty_program(), toolchain());
+        assert!(
+            m.residual_trust.is_none(),
+            "no bv shadow ⇒ no residual-trust statement (v1 byte-identical)"
+        );
     }
 }

--- a/forge/src/bitvector.rs
+++ b/forge/src/bitvector.rs
@@ -446,6 +446,39 @@ impl BitVectorEngine {
         }
     }
 
+    /// Is the precondition `req` SATISFIABLE at width `N`? Anti-Goodhart vacuity check
+    /// (RFC-1 §10): a `@bv` clause is discharged as `req ⇒ clause`, so an UNSATISFIABLE
+    /// `req` proves *every* clause vacuously — the gaming vector the v1 cage rejects as
+    /// `VacuousPrecondition`. The bv route's mutation gate only catches this for
+    /// result-referencing clauses (every mutant survives); a param-only clause or a
+    /// `@bv` lemma (no body → no mutation) would otherwise certify L4 — and, post-REQ-8,
+    /// carry a kernel-checked trust label — on a vacuous proof. This asks Z3 the same
+    /// rendering the discharge uses (`req` at width `N`), so the verdict is consistent
+    /// with the discharge and never a width artifact.
+    ///
+    /// `Some(true)` = satisfiable (non-vacuous); `Some(false)` = UNSAT (vacuous — reject);
+    /// `None` = cannot decide (`req` absent/unrenderable, Z3 absent, or `unknown`), so the
+    /// caller does NOT flag vacuity and falls through to the normal discharge —
+    /// conservative, never a FALSE vacuity rejection.
+    #[must_use]
+    pub fn req_satisfiable(&self, vars: &[String], req: &Expr, width: BvWidth) -> Option<bool> {
+        let n = width.bits();
+        let req_smt = render_bv_prop(req, n).ok()?;
+        let mut s = String::from("(set-logic QF_BV)\n");
+        for v in vars {
+            s.push_str(&format!("(declare-const {v} (_ BitVec {n}))\n"));
+        }
+        s.push_str(&format!("(assert {req_smt})\n(check-sat)\n"));
+        match Self::run_z3(&s, BvBudgetProfile::default_profile().timeout_secs) {
+            Ok((result, _)) => match result.as_str() {
+                "sat" => Some(true),
+                "unsat" => Some(false),
+                _ => None,
+            },
+            Err(_) => None,
+        }
+    }
+
     /// Discharge the `@bvN(nowrap)` no-overflow SIDE OBLIGATION over fixed-width QF_BV
     /// semantics (`.design/stage3-bv-reconstruction.md` REQ-5 / AC-6 — lock 3). A
     /// `nowrap` tag declares that, although the clause is interpreted at machine width,

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -1756,7 +1756,14 @@ fn bv_fn_cert(
                     } else {
                         None
                     };
-                    obligations.push(bv_proved_obl(&f.name, k, tag, &bv_attr, nowrap));
+                    obligations.push(bv_proved_obl(
+                        &f.name,
+                        k,
+                        tag,
+                        &clause_expr,
+                        &bv_attr,
+                        nowrap,
+                    ));
                     // A `@bv` clause is decidable QF_BV with COMPLETE bit-pattern
                     // countermodels — the L4 (caged) refutation quality, RFC-1 §2/§4.
                     // The rung is the refutation quality; the SOLVER trust base
@@ -2056,7 +2063,7 @@ fn bv_lemma_cert(
                 } else {
                     None
                 };
-                obligations.push(bv_proved_obl(&l.name, k, tag, &bv_attr, nowrap));
+                obligations.push(bv_proved_obl(&l.name, k, tag, &ens.expr, &bv_attr, nowrap));
             }
             BvOutcome::Counterexample { bits } => {
                 return bv_counterexample_cert(&l.name, &effects, false, k, tag, &bits, &bv_attr);
@@ -2078,26 +2085,62 @@ fn bv_lemma_cert(
 }
 
 /// The per-clause [`ObligationResult`] a bit-vector `Proved` records (`.design/
-/// stage3-bv-reconstruction.md` REQ-2 / AC-2): the engine (`bitvector`), the QF_BV
-/// solver trust base, the `Proved` verdict, and a name that states the engine AND the
-/// fixed-width semantics ("each clause's certificate naming its engine and semantics").
+/// stage3-bv-reconstruction.md` REQ-2 / AC-2 + REQ-8 / AC-9): the engine (`bitvector`),
+/// the clause's trust base (migrated per REQ-8 — see below), the `Proved` verdict, and a
+/// name that states the engine AND the fixed-width semantics ("each clause's certificate
+/// naming its engine and semantics").
+///
+/// REQ-8 default-on trust migration: `clause_expr` is the `result`-grounded clause body
+/// (the same expression the QF_BV query decided). The per-clause fragment-support check
+/// [`crate::lean_smt_export::clause_reconstruction_supported`] decides the trust base:
+///
+/// - a RECONSTRUCTION-SUPPORTED clause (the arithmetic/comparison QF_BV subset the exporter
+///   renders) migrates its `trust:` to the KERNEL-CHECKED base
+///   ([`crate::engine::bv_kernel_checked_trust_profile`] — the lean-smt reconstruction over
+///   the bounded-integer model + the kernel-checked `BvModel.frmInt_iff_frmBV` faithfulness),
+///   with Z3 no longer load-bearing — same rung (L4), smaller trust;
+/// - an UNSUPPORTED clause (the bitwise/shift/rotate subset the exporter refuses) keeps the
+///   SOLVER base `solver_attr.trust_profile` (`Z3 QF_BV`), labeled as today (the F-J residual
+///   the audit names).
+///
+/// The engine tag stays `bitvector` (the bit-vector route decided the clause); only the
+/// trust base — the orthogonal axis — moves. Default-on: no flag gates the migration.
 fn bv_proved_obl(
     item: &str,
     k: usize,
     tag: &thermite_syntax::BvTag,
-    attr: &crate::engine::EngineAttribution,
+    clause_expr: &thermite_syntax::Expr,
+    solver_attr: &crate::engine::EngineAttribution,
     nowrap_obligation: Option<String>,
 ) -> ObligationResult {
+    let supported = crate::lean_smt_export::clause_reconstruction_supported(
+        clause_expr,
+        crate::lean_smt_export::SmtFragment::Bv(tag.width),
+    );
+    let (trust, trust_phrase) = if supported {
+        (
+            crate::engine::bv_kernel_checked_trust_profile().items,
+            "kernel-checked (the (P_prod) ⟺ (P_ref) obligation reconstructed in the Lean kernel \
+             via lean-smt over the bounded-integer model + the kernel-checked BvModel.lean \
+             faithfulness; Z3 no longer load-bearing — REQ-8 default-on)",
+        )
+    } else {
+        (
+            solver_attr.trust_profile.clone(),
+            "solver-trusted (Z3 QF_BV) — the bitwise/shift/rotate subset is outside the \
+             reconstruction-supported fragment, named honestly (F-J residual)",
+        )
+    };
     ObligationResult::discharged(format!(
         "{item}::ens#{k}: discharged by the bit-vector route over {} (fixed-width \
          wraparound machine semantics; QF_BV-decidable with complete bit-pattern \
-         countermodels — L4 caged rung, solver-trusted (Z3 QF_BV); \
-         stage3-bv-reconstruction.md REQ-2)",
+         countermodels — L4 caged rung, {trust_phrase}; stage3-bv-reconstruction.md \
+         REQ-2 / REQ-8)",
         bv_semantics_label(tag)
     ))
     .with_clause_attribution(
-        attr.engine.clone(),
-        attr.trust_profile.clone(),
+        solver_attr.engine.clone(),
+        trust,
         crate::verdict::CertVerdict::Proved,
     )
     // Lock 1 (REQ-3 / AC-4): the shadow flag rides every tagged clause's obligation;
@@ -6391,6 +6434,84 @@ note: Cost * Instantiations: 150 (Instantiated 10 times - 71% of the total, cost
             user_before.oracle_subset(),
             "the dedup rewrite is oracle-excluded (Q-BURN): the oracle subset is unchanged"
         );
+    }
+
+    // ───────────────────────────────────────────────────────────────────────────
+    // REQ-8 / AC-9 (stage-3 reconstruction default-on — the per-clause trust migration).
+    // `bv_proved_obl` is PURE (no solver): it keys the trust base off the per-clause
+    // fragment-support check, so the migration is unit-testable without z3.
+    // ───────────────────────────────────────────────────────────────────────────
+
+    /// REQ-8 / AC-9: a reconstruction-supported (arith/cmp) `@bv` clause migrates its
+    /// `trust:` to the kernel-checked base while a bitwise (xor) clause on the SAME item
+    /// stays solver-trusted — the mix64 split, the actual trust flip. Default-on: no flag
+    /// gates the migration. Same rung (the obligation is `Proved` either way); only the
+    /// trust base moves.
+    #[test]
+    fn req8_supported_clause_migrates_to_kernel_checked_bitwise_stays_solver() {
+        use thermite_syntax::{BinOp, BvTag, BvWidth, Expr};
+        fn var(s: &str) -> Expr {
+            Expr::Path(vec![s.to_string()])
+        }
+        fn bin(op: BinOp, l: Expr, r: Expr) -> Expr {
+            Expr::Binary {
+                op,
+                lhs: Box::new(l),
+                rhs: Box::new(r),
+            }
+        }
+        let tag = BvTag {
+            width: BvWidth::W64,
+            nowrap: false,
+            span: thermite_syntax::Span::new(0, 0),
+        };
+        let attr = bv_attribution();
+
+        // mix64::ens#0 — `a + b == b + a` (wraparound-add commutativity): SUPPORTED.
+        let add = bin(
+            BinOp::Eq,
+            bin(BinOp::Add, var("a"), var("b")),
+            bin(BinOp::Add, var("b"), var("a")),
+        );
+        let supported = bv_proved_obl("mix64", 0, &tag, &add, &attr, None);
+        assert!(
+            crate::engine::trust_is_kernel_checked(&supported.trust),
+            "the arith clause's trust migrates to the kernel-checked base (REQ-8)"
+        );
+        assert!(
+            supported.trust.iter().any(|t| t.contains("BvModel")),
+            "the migrated trust cites the BvModel faithfulness metatheorem"
+        );
+        assert!(
+            !supported.trust.iter().any(|t| t.contains("Z3 QF_BV")),
+            "Z3 is no longer load-bearing for the reconstruction-supported clause"
+        );
+
+        // mix64::ens#1 — `a ^ b ^ b == a` (xor self-inverse): UNSUPPORTED, stays solver.
+        let xor = bin(
+            BinOp::Eq,
+            bin(
+                BinOp::BitXor,
+                bin(BinOp::BitXor, var("a"), var("b")),
+                var("b"),
+            ),
+            var("a"),
+        );
+        let solver = bv_proved_obl("mix64", 1, &tag, &xor, &attr, None);
+        assert!(
+            !crate::engine::trust_is_kernel_checked(&solver.trust),
+            "the bitwise clause stays solver-trusted (F-J — the exporter refuses xor)"
+        );
+        assert!(
+            solver.trust.iter().any(|t| t.contains("Z3 QF_BV")),
+            "the unsupported clause names the Z3 QF_BV solver base, as today"
+        );
+
+        // Both invariants hold across the split: the engine tag stays `bitvector` (only the
+        // orthogonal trust axis moved) and Lock 1's shadow flag rides both obligations.
+        assert_eq!(supported.engine.as_deref(), Some("bitvector"));
+        assert_eq!(solver.engine.as_deref(), Some("bitvector"));
+        assert!(supported.bv_shadow.is_some() && solver.bv_shadow.is_some());
     }
 
     // ───────────────────────────────────────────────────────────────────────────

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -1738,6 +1738,31 @@ fn bv_fn_cert(
                 Ok(e) => e,
                 Err(reason) => return bv_skip_cert(&f.name, &effects, slag, k, tag, &reason),
             };
+            // Anti-Goodhart vacuity gate (RFC-1 §10): a `@bv` clause is discharged as
+            // `req ⇒ clause`, so an UNSATISFIABLE `req` proves EVERY clause vacuously.
+            // The bv mutation gate only catches this for result-referencing clauses
+            // (every mutant survives → WeakContract); a param-only clause would otherwise
+            // certify L4 — and, post-REQ-8, carry a kernel-checked trust label — on a
+            // vacuous proof. Reject `VacuousPrecondition`, the same verdict the v1 cage
+            // gives. `None` (undecidable) falls through to the normal discharge.
+            if bv.req_satisfiable(&vars, req, tag.width) == Some(false) {
+                return Certificate::rejected_vacuity(
+                    f.name.clone(),
+                    effects.clone(),
+                    RejectReason {
+                        cause: "VacuousPrecondition".to_string(),
+                        detail: format!(
+                            "`{}`'s precondition is unsatisfiable at `@bv{}` — every `@bv` \
+                             clause holds vacuously (the §10 anti-Goodhart gaming vector), so \
+                             the contract certifies nothing. Fix or strengthen `req`.",
+                            f.name,
+                            tag.width.bits()
+                        ),
+                    },
+                    false,
+                    true,
+                );
+            }
             match bv.discharge_bv(&vars, Some(req), &clause_expr, tag.width) {
                 BvOutcome::Proved => {
                     // Lock 3 (REQ-5 / AC-6): a `nowrap` clause additionally discharges its
@@ -2046,6 +2071,28 @@ fn bv_lemma_cert(
                 },
             );
         };
+        // Anti-Goodhart vacuity gate (RFC-1 §10): a lemma has no body, so the mutation
+        // gate never runs on it — an unsatisfiable `req` would otherwise certify the
+        // lemma L4 (kernel-checked, post-REQ-8) on a vacuous proof. Reject
+        // `VacuousPrecondition` like the v1 cage. `None` falls through to discharge.
+        if bv.req_satisfiable(&vars, req, tag.width) == Some(false) {
+            return Certificate::rejected_vacuity(
+                l.name.clone(),
+                effects.clone(),
+                RejectReason {
+                    cause: "VacuousPrecondition".to_string(),
+                    detail: format!(
+                        "`{}`'s precondition is unsatisfiable at `@bv{}` — the lemma holds \
+                         vacuously (the §10 anti-Goodhart gaming vector) and asserts nothing. \
+                         Fix or strengthen `req`.",
+                        l.name,
+                        tag.width.bits()
+                    ),
+                },
+                false,
+                true,
+            );
+        }
         match bv.discharge_bv(&vars, Some(req), &ens.expr, tag.width) {
             BvOutcome::Proved => {
                 // Lock 3 (REQ-5 / AC-6): a `nowrap` lemma clause discharges its no-overflow

--- a/forge/src/engine.rs
+++ b/forge/src/engine.rs
@@ -139,6 +139,76 @@ pub fn bv_trust_profile() -> TrustProfile {
     }
 }
 
+/// The named trust base a reconstruction-SUPPORTED [`EngineName::BitVector`] clause
+/// carries after REQ-8's default-on trust migration (`.design/stage3-bv-reconstruction.md`
+/// REQ-8 / AC-9). Where the per-clause obligation is inside the renderable fragment
+/// ([`crate::lean_smt_export::clause_reconstruction_supported`] — the arithmetic/comparison
+/// QF_BV subset), its `trust:` migrates from the SOLVER base ([`bv_trust_profile`], `Z3
+/// QF_BV`) to THIS kernel-checked base, at the SAME caged rung [`crate::manifest::Level::L4`]
+/// (rung and trust are orthogonal axes — REQ-8 shrinks the trust base, never the rung).
+///
+/// The migration is honest about exactly what grounds the clause and what residual stays:
+///
+/// 1. The clause obligation `(P_prod) ⟺ (P_ref)` is rendered over the bounded-integer
+///    machine-model and reconstructed by the lean-smt `smt` tactic (cvc5) inside the Lean
+///    kernel, `#print axioms ⊆ {propext, Classical.choice, Quot.sound}` (the AC-8 committed
+///    `lean/Thermite/SmtExport.lean` proof) — NO solver in the load-bearing base.
+/// 2. The bounded-integer model ⇔ the genuine `BitVec N` semantics is the kernel-checked
+///    `Thermite.BvModel.frmInt_iff_frmBV` / `tv_equiv_faithful` metatheorem (axiom-clean,
+///    Mathlib/Smt-free; in `lean-axiom-probe.sh`) — so the int-model reconstruction grounds
+///    the genuine machine semantics, not a re-derivation.
+/// 3. The named RESIDUAL (the pretty-printer-trust class, NOT a semantic one, #356): the
+///    two string-emission legs — this exporter's pretty-printer and `bitvector.rs`'s SMT
+///    renderer — both encode the same `Frm`; their agreement is inspection-tier
+///    (`.design/verified/exporter-surface-correspondence.md`), the only residual REQ-8
+///    leaves on the renderable fragment.
+///
+/// Strictly smaller than the solver base for the renderable fragment: Z3 QF_BV is no longer
+/// load-bearing (the kernel rechecks the clause), leaving only the kernel + the
+/// pretty-printer residual. The bitwise/shift/rotate subset is NOT migrated (it keeps
+/// [`bv_trust_profile`], named F-J in the audit).
+#[must_use]
+pub fn bv_kernel_checked_trust_profile() -> TrustProfile {
+    TrustProfile {
+        items: vec![
+            "Lean kernel (the (P_prod) ⟺ (P_ref) obligation reconstructed by lean-smt `smt`/cvc5 \
+             over the bounded-integer machine-model; #print axioms ⊆ {propext, Classical.choice, \
+             Quot.sound} — no solver in the base)"
+                .to_string(),
+            "spine-lemma frmInt_iff_frmBV / tv_equiv_faithful (bounded-integer model ⇔ BitVec N \
+             machine semantics, kernel-checked, BvModel.lean)"
+                .to_string(),
+            "pretty-printer residual (the lean_smt_export + bitvector.rs string-emission legs \
+             encode the same Frm; inspection-tier, #356)"
+                .to_string(),
+        ],
+    }
+}
+
+/// The stable marker substring every KERNEL-CHECKED / kernel-grounded per-clause trust
+/// item carries (`.design/stage3-bv-reconstruction.md` REQ-8 / AC-9). Both the bv
+/// reconstruction profile's faithfulness lemma ([`bv_kernel_checked_trust_profile`] —
+/// `frmInt_iff_frmBV … kernel-checked`) and the nlsat relax spine lemmas
+/// (`r_relax_sound`/`rencode_sound … kernel-checked`) name themselves with it, so the
+/// audit's residual-trust statement keys the kernel-checked-vs-solver split on ONE marker
+/// rather than re-deriving the split from engine names (which would miscount the bv route,
+/// whose engine tag stays `bitvector` whether or not the clause migrated).
+pub const KERNEL_CHECKED_TRUST_MARKER: &str = "kernel-checked";
+
+/// Is this per-clause trust base kernel-grounded (`.design/stage3-bv-reconstruction.md`
+/// REQ-8 / AC-9)? `true` iff any named trust item carries [`KERNEL_CHECKED_TRUST_MARKER`]
+/// — a reconstruction-migrated bv clause or an nlsat-relax clause. `false` for a base that
+/// is purely solver-trusted (the bv solver profile `Z3 QF_BV`, a Verus L3 base, the
+/// EPR-stratified rel/array residual). An empty trust base (the v1 Verus corpus, recorded
+/// by `status`/`level`) is not classified by this — the residual-trust statement only
+/// aggregates obligations that carry a per-clause trust base.
+#[must_use]
+pub fn trust_is_kernel_checked(trust: &[String]) -> bool {
+    trust
+        .iter()
+        .any(|t| t.contains(KERNEL_CHECKED_TRUST_MARKER))
+}
+
 /// The reason an engine returned [`Verdict::Unknown`] (`.design/verified/
 /// proof-backends.md` REQ-2(b)/REQ-3). An `Unknown` means this engine could not
 /// decide; it is not a failure verdict and it degrades per the ladder (§6). The two

--- a/forge/src/lean_smt_export.rs
+++ b/forge/src/lean_smt_export.rs
@@ -437,6 +437,30 @@ pub fn free_vars(e: &Expr) -> Vec<String> {
     acc.into_iter().collect()
 }
 
+/// Is a per-clause predicate inside the RECONSTRUCTION-SUPPORTED fragment
+/// (`.design/stage3-bv-reconstruction.md` REQ-8 / AC-9 — the fragment-support check
+/// REQ-8's trust migration keys on)? `true` iff the exporter renders this clause's
+/// `(P_prod) ⟺ (P_ref)` translation-validation goal WITHOUT [`SmtExportError`] in the
+/// given fragment — i.e. exactly the QF_LIA scalar + arithmetic/comparison QF_BV subset
+/// (`+`/`-`/`*`, unsigned `=`/`≠`/`<`/`≤`/`>`/`≥`, logical connectives). The
+/// bitwise/shift/rotate QF_BV subset (`^`/`&`/`|`/`<<`/`>>`, rotate) and
+/// division/remainder are the [`SmtExportError::OutOfFragment`] refusal — the
+/// bit-blasting wall (`.design/verified/z3-demotion.md`) — and read `false` here, so
+/// those clauses stay solver-trusted (the F-J residual the audit names).
+///
+/// Renderability IS the reconstruction-support signal: a clause this returns `true` for
+/// is rendered over the bounded-integer machine-model that lean-smt reconstructs
+/// kernel-clean (`#print axioms ⊆ {propext, Classical.choice, Quot.sound}`, the AC-8
+/// committed `lean/Thermite/SmtExport.lean` proof + the kernel-checked
+/// `BvModel.frmInt_iff_frmBV` faithfulness metatheorem) — so the renderable fragment's
+/// axiom-cleanliness is discharged by REQ-7 once, statically, not re-run per clause.
+/// Total + deterministic (R-CODE-5): a leaf the renderer would refuse is refused here
+/// too, never a silent claim of support.
+#[must_use]
+pub fn clause_reconstruction_supported(prod: &Expr, fragment: SmtFragment) -> bool {
+    render_goal(&obligation_for_predicate("clause", prod, fragment)).is_ok()
+}
+
 /// Mint an equivalence obligation for a production predicate by pairing it with its
 /// [`reference_normalize`] encoding (`.design/stage3-bv-reconstruction.md` REQ-7).
 /// The binder set is the predicate's [`free_vars`]; the fragment is the caller's.
@@ -572,6 +596,45 @@ mod tests {
         );
         // A pure variable / literal leaf is returned unchanged (totality).
         assert_eq!(reference_normalize(&var("x")), var("x"));
+    }
+
+    // REQ-8 / AC-9: the per-clause fragment-support check keys on renderability — the
+    // arithmetic/comparison subset is reconstruction-supported (migrates trust), the
+    // bitwise/shift/rotate subset is refused (stays solver-trusted).
+    #[test]
+    fn clause_reconstruction_supported_keys_on_the_renderable_fragment() {
+        // The mix64 split: `a + b == b + a` (arith) is supported; `a ^ b ^ b == a` (xor) is not.
+        let add = ens_expr(
+            "fn p(a: u64, b: u64) -> u64 req true ens a + b == b + a fx pure { a }",
+            "p",
+        );
+        assert!(
+            clause_reconstruction_supported(&add, SmtFragment::Bv(BvWidth::W64)),
+            "wraparound-add commutativity is the reconstruction-supported QF_BV subset"
+        );
+        let xor = ens_expr(
+            "fn p(a: u64, b: u64) -> u64 req true ens a ^ b ^ b == a fx pure { a }",
+            "p",
+        );
+        assert!(
+            !clause_reconstruction_supported(&xor, SmtFragment::Bv(BvWidth::W64)),
+            "xor is the bitwise subset the exporter refuses — stays solver-trusted (F-J)"
+        );
+        // A QF_LIA scalar comparison is supported too.
+        let lia = ens_expr(
+            "fn p(a: u64, b: u64) -> u64 req true ens a <= b fx pure { a }",
+            "p",
+        );
+        assert!(clause_reconstruction_supported(&lia, SmtFragment::Lia));
+        // A shift clause (the rotl1 lemma shape) is refused.
+        let shift = ens_expr(
+            "fn p(a: u64, b: u64) -> u64 req true ens (a << b) == a fx pure { a }",
+            "p",
+        );
+        assert!(!clause_reconstruction_supported(
+            &shift,
+            SmtFragment::Bv(BvWidth::W64)
+        ));
     }
 
     // REQ-7: the file-driven exporter mints a QF_LIA obligation per renderable `ens`

--- a/forge/tests/bv_lowering.rs
+++ b/forge/tests/bv_lowering.rs
@@ -168,6 +168,61 @@ fn mix64_certifies_with_two_bitvector_clauses_and_one_unbounded() {
     assert_eq!(lobls[0]["verdict"]["kind"], Value::from("Proved"));
 }
 
+/// REQ-8 / AC-9 (reconstruction default-on — the per-clause trust migration): in the SAME
+/// item `mix64`, the arithmetic clause `a + b == b + a` migrates its `trust:` to the
+/// KERNEL-CHECKED form (reconstruction-supported QF_BV) while the bitwise clause
+/// `a ^ b ^ b == a` RETAINS its solver(Z3 QF_BV) trust (the bit-blasting wall — F-J). Same
+/// rung (both `Proved` at L4); only the orthogonal trust axis moves. Default-on: no flag.
+#[test]
+fn req8_mix64_arith_clause_migrates_kernel_checked_bitwise_stays_solver() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — the bit-vector route is not run.");
+        return;
+    }
+    let (code, certs) = run_bv("mix64.th");
+    assert_eq!(code, Some(0), "the mix64 example certifies");
+    let m = cert(&certs, "mix64");
+    let obls = m["obligations"].as_array().expect("obligations array");
+
+    // Both bit-vector clauses are still `Proved` at the same rung; the item is L4.
+    assert_eq!(
+        m["level"],
+        Value::from("L4"),
+        "the rung is unchanged (REQ-8 is trust-only)"
+    );
+
+    let trust_of = |k: usize| -> Vec<String> {
+        obls[k]["trust"]
+            .as_array()
+            .unwrap_or_else(|| panic!("clause ens#{k} names its trust base: {m}"))
+            .iter()
+            .map(|t| t.as_str().unwrap_or("").to_string())
+            .collect()
+    };
+    // ens#0 — `a + b == b + a` (arithmetic): migrated to kernel-checked.
+    let add_trust = trust_of(0);
+    assert!(
+        add_trust
+            .iter()
+            .any(|t| t.contains("kernel-checked") && t.contains("BvModel")),
+        "the arith clause's trust migrated to the kernel-checked BvModel base: {add_trust:?}"
+    );
+    assert!(
+        !add_trust.iter().any(|t| t.contains("Z3 QF_BV")),
+        "Z3 is no longer load-bearing for the reconstruction-supported arith clause: {add_trust:?}"
+    );
+    // ens#1 — `a ^ b ^ b == a` (bitwise xor): stays solver-trusted.
+    let xor_trust = trust_of(1);
+    assert!(
+        xor_trust.iter().any(|t| t.contains("Z3 QF_BV")),
+        "the xor clause retains its solver(Z3 QF_BV) trust (F-J): {xor_trust:?}"
+    );
+    assert!(
+        !xor_trust.iter().any(|t| t.contains("kernel-checked")),
+        "the xor clause did NOT migrate (the exporter refuses bitwise): {xor_trust:?}"
+    );
+}
+
 /// AC-3 (first half): a planted non-injective shift dies as a `Counterexample` with the
 /// bit pattern in the certificate.
 #[test]
@@ -444,6 +499,65 @@ fn forge_audit_lists_the_bv_shadows() {
     assert!(
         shadows.iter().any(|s| s["item"] == "rotl1_injective"),
         "the lemma's tagged clause is listed"
+    );
+}
+
+/// REQ-8 / AC-9: `forge audit` carries the RESIDUAL-TRUST STATEMENT — it aggregates the
+/// kernel-checked-vs-solver split and names the still-solver-trusted fragments. On `mix64`
+/// the migrated arith clause is kernel-checked while the xor + shift clauses stay
+/// solver-trusted; the statement names the bitwise/shift/rotate + EPR rel/array fragments.
+#[test]
+fn forge_audit_residual_trust_statement_names_the_split() {
+    if !verus_present() {
+        eprintln!("SKIP: verus (z3) absent — forge audit's bv route is not run.");
+        return;
+    }
+    let (_code, manifest) = run_forge_json("audit", "mix64.th");
+    let rt = &manifest["residual_trust"];
+    assert!(
+        !rt.is_null(),
+        "a bv project's audit carries the REQ-8 residual-trust statement: {manifest}"
+    );
+    // mix64::ens#0 (add) + the nlsat unbounded clause are kernel-grounded; the xor and the
+    // lemma's shift clause stay solver-trusted (≥ 2 solver-trusted clauses).
+    assert!(
+        rt["kernel_checked_clauses"].as_u64().unwrap_or(0) >= 1,
+        "at least the arith clause migrated to kernel-checked: {rt}"
+    );
+    assert!(
+        rt["solver_trusted_clauses"].as_u64().unwrap_or(0) >= 2,
+        "the xor + shift clauses stay solver-trusted: {rt}"
+    );
+    // The still-solver-trusted clauses are NAMED (the F-J inventory).
+    let named = rt["solver_trusted"]
+        .as_array()
+        .expect("the residual-trust statement names the solver-trusted clauses");
+    assert!(
+        named.iter().any(|c| c["item"] == "mix64"),
+        "mix64's xor clause is named as still-solver-trusted: {rt}"
+    );
+    // The standing F-J fragments are named: bitwise/shift/rotate + EPR rel/array.
+    let frags = rt["unsupported_fragments"]
+        .as_array()
+        .expect("the statement names the unsupported fragments");
+    assert!(
+        frags
+            .iter()
+            .any(|f| f.as_str().unwrap_or("").contains("bitwise/shift/rotate")),
+        "the bitwise/shift/rotate fragment is named: {rt}"
+    );
+    assert!(
+        frags
+            .iter()
+            .any(|f| f.as_str().unwrap_or("").contains("rel/array")),
+        "the EPR rel/array residual is named (F-J): {rt}"
+    );
+    assert!(
+        rt["statement"]
+            .as_str()
+            .unwrap_or("")
+            .contains("default-on"),
+        "the headline names reconstruction as default-on: {rt}"
     );
 }
 

--- a/forge/tests/bv_vacuity_gate.rs
+++ b/forge/tests/bv_vacuity_gate.rs
@@ -1,0 +1,104 @@
+//! ADVERSARIAL (issue #357, pre-trust-flip review): the bv route's vacuity gap.
+//!
+//! The v1/default cage rejects an unsatisfiable precondition as `VacuousPrecondition`
+//! (the anti-Goodhart battery, RFC-1 §10 — a `req false` contract "proves" anything and
+//! is a gaming vector). The bv route runs NO vacuity check: it only threads `req` into
+//! the QF_BV query, so a `req false` clause discharges vacuously. For a result-referencing
+//! clause the mutation gate incidentally catches it (every mutant survives → WeakContract),
+//! but a PARAM-ONLY `@bv` clause or a `@bv` LEMMA (no body → no mutation) sails through and
+//! — post-REQ-8 — certifies L4 with a KERNEL-CHECKED trust label on a vacuous proof.
+//!
+//! These tests assert the correct (rejected) behavior — the regression guard for the
+//! bv-route req-satisfiability vacuity gate (forge/src/bitvector.rs::req_satisfiable).
+#![cfg(feature = "bv")]
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn forge_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_forge"))
+}
+fn verus_present() -> bool {
+    std::env::var("VERUS_BIN")
+        .ok()
+        .map(|p| Path::new(&p).exists())
+        .unwrap_or(false)
+        || Command::new("which")
+            .arg("verus")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+}
+fn check_bv(name: &str, src: &str) -> Vec<Value> {
+    // Unique per-test path — cargo runs tests in parallel; a shared temp file races.
+    let f = std::env::temp_dir().join(format!("adv_locks_{name}.th"));
+    std::fs::write(&f, src).unwrap();
+    let out = Command::new(forge_bin())
+        .args(["check"])
+        .arg(&f)
+        .args(["--engine", "bv", "--json"])
+        .output()
+        .unwrap();
+    serde_json::from_slice(&out.stdout).unwrap_or_default()
+}
+fn reject_cause(c: &Value) -> Option<String> {
+    c.get("reject")
+        .and_then(|r| r.get("cause"))
+        .and_then(|x| x.as_str())
+        .map(String::from)
+}
+
+/// A `@bv` LEMMA with an unsatisfiable precondition must NOT certify — it is vacuous
+/// (the §10 anti-Goodhart gaming vector). Regression guard for the bv-route vacuity gate.
+#[test]
+fn vacuous_bv_lemma_is_rejected_not_certified() {
+    if !verus_present() {
+        eprintln!("SKIP: verus/z3 absent");
+        return;
+    }
+    let certs = check_bv(
+        "lemma",
+        "lemma vac_lemma(a: u64, b: u64)\n    req false\n    ens@bv64 a < b\n    proof { }\n",
+    );
+    let c = certs
+        .iter()
+        .find(|c| c["item"] == "vac_lemma")
+        .expect("vac_lemma cert");
+    assert_ne!(
+        c["level"],
+        Value::from("L4"),
+        "a req-false @bv lemma must not certify L4 (it is vacuous): {c}"
+    );
+    assert!(
+        reject_cause(c).is_some(),
+        "a vacuous @bv lemma must be rejected (VacuousPrecondition), not silently certified: {c}"
+    );
+}
+
+/// A param-only `@bv` fn clause under an unsatisfiable precondition must NOT certify
+/// kernel-checked — the mutation gate misses param-only clauses, so the req-SAT gate must
+/// catch it. Regression guard for the bv-route vacuity gate.
+#[test]
+fn vacuous_param_only_bv_clause_is_not_kernel_checked() {
+    if !verus_present() {
+        eprintln!("SKIP: verus/z3 absent");
+        return;
+    }
+    let certs = check_bv(
+        "fn",
+        "fn vac2(a: u64, b: u64) -> u64\n    req false\n    ens@bv64 a < b\n    fx pure\n{ 0 }\n",
+    );
+    let c = certs
+        .iter()
+        .find(|c| c["item"] == "vac2")
+        .expect("vac2 cert");
+    let kernel = c["obligations"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|o| o["trust"].as_array().cloned().unwrap_or_default())
+        .any(|t| t.as_str().unwrap_or("").to_lowercase().contains("kernel"));
+    assert!(!(c["level"] == "L4" && reject_cause(c).is_none() && kernel),
+        "a vacuous (req false) param-only @bv clause must not certify L4 with kernel-checked trust: {c}");
+}


### PR DESCRIPTION
Stage-3 REQ-8 — the trust flip. Closes #350. Child of the Stage-3 tree (umbrella xl #342 / gh #80; spec REQ-8 / AC-9). Includes the adversarial-review fix (#357).

## What ships — the migration
Where a clause is **reconstruction-supported**, its `trust:` migrates `solver(z3) → kernel-checked`, default-on, **same rung** (trust-base only, no verdict/level change):
- Support signal = `clause_reconstruction_supported = render_goal.is_ok()` (renderability; axiom-cleanliness discharged by REQ-7 AC-8 + the kernel-proven `BvModel` faithfulness).
- The split keys on the **trust-string marker** (not engine name — the bv tag stays `bitvector`; nlsat is also kernel-grounded).
- Supported = QF_LIA + the arithmetic/comparison QF_BV subset → kernel-checked, citing `BvModel.frmInt_iff_frmBV`/`tv_equiv_faithful` + the named string-emission residual (#356).
- Unsupported = bitwise/shift/rotate → stay `solver(z3)`; EPR-stratified rel/array (the G2 residual) **named not migrated** (structurally outside the fragment, F-J).
- `forge audit` gains a **`residual_trust`** statement aggregating the split (gated on `!bv_shadows.is_empty()` → v1 audit goldens byte-identical).

**AC-9 verified**: `mix64` is the same-item split — `a+b==b+a` → kernel-checked, `a^b^b==a` (bitwise) → solver(z3); the audit names 2 kernel-checked / 2 solver-trusted.

## Adversarial review (#357) — one finding, fixed
A pre-flip adversarial pass found the bv route ran **no vacuity detection**: a `@bv` clause discharges as `req ⇒ clause`, so an unsatisfiable `req` proves it vacuously. The mutation gate masked this only for result-referencing clauses; a **param-only clause or a `@bv` lemma** certified L4 + kernel-checked on a vacuous proof. Fixed (`d5c3ddf4`): `req_satisfiable` SAT-checks `req` at the clause width → `VacuousPrecondition` reject when UNSAT. Regression test `bv_vacuity_gate.rs`. Every other dimension came back clean (fragment refusal airtight, render ops correct, multiplication axiom-clean, faithfulness kernel-proven, Timeout≠Proved).

## Verification (full env)
Full `forge` suite green (verus + z3 + full Lean spine); clippy `-D warnings` + rustfmt 1.95.0 clean; v1 goldens byte-identical; `make doc-drift` exit 0. AC boxes flip at G3 (REQ-9), per stage-3 convention.