### PR TITLE
fix(harness): re-wire the de-wired gates + route the control plane (#93)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,16 @@
       {
         "hooks": [
           {
+            "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/tooling/spec-discipline.py\"; if [ -f \"$HOOK\" ]; then python3 \"$HOOK\"; else exit 0; fi",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Read"
+      },
+      {
+        "hooks": [
+          {
             "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/.claude/hooks/heartbeat.py\"; if [ -f \"$HOOK\" ]; then python3 \"$HOOK\"; else exit 0; fi",
             "timeout": 3,
             "type": "command"
@@ -46,6 +56,21 @@
           }
         ],
         "matcher": "Write|Edit|Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/tooling/spec-discipline.py\"; if [ -f \"$HOOK\" ]; then python3 \"$HOOK\"; else exit 0; fi",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/tooling/anti-pattern-gate.py\"; if [ -f \"$HOOK\" ]; then python3 \"$HOOK\"; else exit 0; fi",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit"
       }
     ],
     "SessionStart": [

--- a/.design/tooling/control-plane.md
+++ b/.design/tooling/control-plane.md
@@ -1,0 +1,229 @@
+# Control Plane — the gate that guards the gates
+
+<!--
+tier: 3-component
+status: draft
+governs: tooling/control-plane-check.py + the control-plane files it and
+         doc-drift.py now pin (.claude/settings.json, .claude/agents/*.md) +
+         the `make control-plane` Makefile target and its CI step. Explicitly
+         NOT `scripts/audit.sh`, which this component leaves byte-identical
+         (the doc-drift decision-5 precedent).
+audited-content-sha256: 383403a2dd8c325e76f22e4f2986b820f093d8eaf8bceb7f1fdf27c9c2972382
+thesis-refs:
+  - thermite-design.md §1 (trust relocated: "a skeptical third party can audit in minutes")
+  - thermite-design.md §8 (#[slag]: the unverified residue is LOUD, never silent)
+issue: crosslink #93
+prior-arc:
+  - .design/tooling/doc-drift-tripwire.md (the sibling gate: pinned freshness for
+    routed design docs. This component is its missing complement — doc-drift pins
+    the CONTENT of what the routes govern; nothing pinned whether the routes are
+    WIRED. Same 0/1/3 exit contract, same fixture-oracle test convention.)
+-->
+
+## Summary
+
+`tooling/spec-discipline.py` and `tooling/anti-pattern-gate.py` are the two
+agent-facing enforcement gates. They are real, tested, and tracked — and they
+only ever fire because `.claude/settings.json` wires them into Claude Code's
+`PreToolUse`/`PostToolUse` events. That wiring is the entire control plane, and
+until this component nothing checked it.
+
+On 2026-06-21 commit `5581b65f` ("Stage-3 REQ-1: the @bv clause tag,
+parse-gated") removed three hook entries from `.claude/settings.json`: the
+`PostToolUse`/`Read` recorder and the `PreToolUse`/`Write|Edit` pair invoking
+both gates. The commit message is entirely about the `@bv` clause tag and never
+mentions the settings change; the crosslink-generic entries survived while the
+project-specific ones vanished. The signature is a `crosslink init` regenerating
+`settings.json` from its generic template — the file is tracked but
+machine-authored, so a routine (or `--force`) re-init clobbers it.
+
+Both gates were therefore **dormant for the entire Stage-3 arc**, while:
+
+- `README.md:172` — "`.claude/settings.json` (also tracked) wires these into
+  Claude Code's `PreToolUse`/`PostToolUse` events, so they enforce automatically
+  — no setup."
+- `goal.md:183` — "### Spec-discipline (enforced by `tooling/spec-discipline.py`)"
+- all four `.claude/agents/acto-*.md` — "The spec-discipline hook enforces these
+  reads before it lets you edit."
+
+This is precisely the **"asserted enforcement that isn't"** failure mode the
+methodology exists to prevent, and it survived weeks of ACToR loops because
+nothing in the repo could see it.
+
+## The blind spot this closes
+
+`tooling/doc-drift.py` pins design↔source freshness for every file reachable
+from `tooling/spec-routes.toml`. It is thorough, CI-enforced, and it even routes
+its own gate (`tooling/doc-drift.py` → `.design/tooling/doc-drift-tripwire.md`,
+REQ-11's dogfood). But:
+
+```
+$ grep -nE "\.claude|settings\.json|agents/" tooling/spec-routes.toml
+(no output)
+```
+
+No route covered the control plane. The design layer governed every source file
+in the workspace **except the file that decides whether the governance runs** —
+so a `settings.json` regression was structurally invisible, and an
+`.claude/agents/*.md` regression with it. (That second gap is not hypothetical:
+`acto-critic.md` and `acto-doc-author.md` carry `model: fable` in frontmatter
+while their bodies say "Opus — always. … Never substitute." Nothing catches the
+contradiction because agent defs are not routed. Reconciling that is out of
+scope here — see Open questions OQ-1 — but routing them is not.)
+
+The custom anti-pattern rules also have no CI backstop: there is no
+`clippy.toml`, and `ci.yml:95` runs stock `cargo clippy --workspace
+--all-targets -- -D warnings` with no `disallowed_*` / `unwrap_used` lints. So
+the anti-pattern gate being dead was not compensated elsewhere (OQ-2).
+
+## Design decisions (resolved here, grounded below)
+
+1. **Assert the wiring, don't regenerate it.** A merge step that re-injects the
+   entries after `crosslink init` would be silent repair — and silent repair of
+   a control plane is how you stop noticing that something keeps breaking it.
+   The gate FAILS LOUDLY and prints the exact JSON to paste back. The human sees
+   every occurrence.
+
+2. **Matcher coverage, not matcher equality.** A required wiring is satisfied
+   when the entry's matcher fires for every required tool. `Write|Edit|Bash`
+   covers a `Write|Edit` requirement; `Write` alone does not. Equality would
+   false-fail on a harmless reorder; substring matching would pass a matcher
+   that silently dropped `Edit`. Alternative-set containment is the predicate
+   that means what the requirement means.
+
+3. **A malformed `settings.json` is a FINDING (exit 1), not INCONCLUSIVE.**
+   Claude Code loads no hooks at all from a settings file it cannot parse, so
+   unparseable is maximally gate-dead. Exit 3 is reserved for failures of the
+   gate's own environment (git absent / not a repo) — the `doc-drift.py` REQ-9
+   and `scripts/audit.sh` precedent: a gate that fails open is a silent pass
+   (R-HONEST-3).
+
+4. **Wired-but-absent is its own defect class.** Every hook command is
+   `if [ -f "$HOOK" ]; then … else exit 0; fi`-guarded, so a wiring naming a
+   script that does not exist degrades to a silent no-op — indistinguishable
+   from success at runtime. `MISSING-SCRIPT` names it separately from
+   `MISSING-WIRING` because the fix is different (restore the file, not the
+   JSON).
+
+5. **Not part of `make audit`.** Hook wiring is a development-discipline
+   invariant, not a link in the proof-trust chain. This mirrors doc-drift's
+   decision 5 exactly, and `scripts/audit.sh` is left byte-identical.
+
+6. **The control-plane routes are DECLARATIVE for spec-discipline, ENFORCED for
+   doc-drift.** `is_gated_path` in `tooling/spec-discipline.py` requires a
+   `.rs` extension, a `thermite-`/`forge` crate dir, and a `src/` component, so
+   it structurally cannot gate `.claude/settings.json` or a `.md` agent def —
+   the same honest limitation `doc-drift-tripwire.md` REQ-11 records for
+   `tooling/*.py` (its OQ-5). The routes added here therefore do not make
+   spec-discipline block control-plane edits; they make the control plane
+   **content-pinned under `doc-drift.py`**, which IS CI-enforced. Changing
+   `settings.json` or an agent def without re-pinning this doc fires the
+   tripwire.
+
+## Requirements
+
+- **REQ-1 (settings.json is the subject).** The gate loads the tracked
+  `.claude/settings.json` from the repo root. Absent or unparseable is a
+  finding (`UNPARSEABLE`, exit 1), never a traceback and never exit 3.
+
+- **REQ-2 (required-wiring predicate).** For each entry in `REQUIRED_HOOKS`
+  — a `(event, tools, script, claim)` tuple — the gate asserts some hook entry
+  under `event` has a matcher COVERING every tool in `tools` (per decision 2)
+  and names `script` in one of its commands. A failure emits `MISSING-WIRING`,
+  the doc line that would go false, and the JSON entry to restore.
+  The three required wirings are exactly the three `5581b65f` removed:
+  `PostToolUse`/`Read` → `spec-discipline.py`;
+  `PreToolUse`/`Write|Edit` → `spec-discipline.py`;
+  `PreToolUse`/`Write|Edit` → `anti-pattern-gate.py`.
+
+- **REQ-3 (wired implies present).** Each required `script` must exist at its
+  repo-relative path. A wiring whose script is absent emits `MISSING-SCRIPT`
+  (decision 4).
+
+- **REQ-4 (deterministic report).** Findings print in `REQUIRED_HOOKS` order,
+  one block per requirement, with the literal tokens `WIRED` /
+  `MISSING-WIRING` / `MISSING-SCRIPT` / `UNPARSEABLE` (R-CODE-5). Two runs over
+  an unchanged tree produce byte-identical stdout.
+
+- **REQ-5 (exit contract).** `0` = every required hook wired and present;
+  `1` = at least one finding; `3` = the gate could not determine the answer
+  (git absent / not a repo). Mirrors `doc-drift.py` REQ-9.
+
+- **REQ-6 (control plane routed).** `tooling/spec-routes.toml` carries routes
+  for `.claude/settings.json`, `.claude/agents/*.md`, and
+  `tooling/control-plane-check.py`, all governed by this doc, so `doc-drift.py`
+  content-pins them (decision 6).
+
+- **REQ-7 (CI enforcement).** The gate runs in the `checks` job of
+  `.github/workflows/ci.yml` and via `make control-plane`, so the assertion is
+  a red build and not a thing someone remembers to run.
+
+## Acceptance criteria
+
+- **AC-1**: with the three entries removed from `.claude/settings.json` (the
+  verbatim post-`5581b65f` file), `python3 tooling/control-plane-check.py`
+  exits 1 and names all three missing wirings and both script paths.
+- **AC-2**: with the entries restored, the gate exits 0 and prints one `WIRED`
+  line per requirement.
+- **AC-3**: a wiring whose script is absent from disk exits 1 with
+  `MISSING-SCRIPT`, distinct from `MISSING-WIRING`.
+- **AC-4**: an unparseable `settings.json` exits 1 with `UNPARSEABLE` and no
+  `Traceback` on stderr.
+- **AC-5**: invoked with no `--root` outside a git repository, the gate exits 3
+  and never 0.
+- **AC-6**: a matcher of `Write|Edit|Bash` satisfies a `Write|Edit`
+  requirement; a matcher of `Write` alone does not.
+- **AC-7**: `scripts/audit.sh` is byte-identical to its pre-component state.
+
+## Verification
+
+`tooling/tests/test_control_plane.py` — nine hand-authored oracle fixtures
+(O-1..O-9), the same convention as `test_doc_drift.py`: build a throwaway
+control plane in a tmpdir, run the gate by subprocess with `--root`, assert
+against expected values the spec fixes, never against the tool's own output
+(R-CHAR-3).
+
+O-2 is load-bearing: its fixture is the **verbatim** de-wired `settings.json`
+that `5581b65f` left on `main`, so if the gate ever stops catching the exact
+regression it was built for, the suite goes red.
+
+Run: `make control-plane-test`, or `python3 -m unittest discover -s tooling/tests`.
+
+## REQ status
+
+| REQ | Status | Evidence |
+| --- | --- | --- |
+| REQ-1 (settings.json is the subject) | SHIPPED | `SETTINGS_RELPATH = ".claude/settings.json"` + `def evaluate` in `tooling/control-plane-check.py`; the absent/unparseable branches return `(EXIT_FAIL, [UNPARSEABLE …])`. Non-test consumer: the `control-plane gate (hook wiring)` step in `.github/workflows/ci.yml` and `make control-plane`. Verification: O-4/O-5 in `tooling/tests/test_control_plane.py`. |
+| REQ-2 (required-wiring predicate) | SHIPPED | `REQUIRED_HOOKS` + `def _matcher_covers` + `def _entry_commands` + `def _restore_snippet` in `tooling/control-plane-check.py`. Non-test consumer: as REQ-1. Verification: O-1 (all wired → exit 0), O-2 (the verbatim `5581b65f` fixture → exit 1, three findings), O-6/O-7 (matcher coverage) in `tooling/tests/test_control_plane.py`. |
+| REQ-3 (wired implies present) | SHIPPED | the `if not (root / script).is_file():` branch emitting `MISSING_SCRIPT` in `def evaluate`. Non-test consumer: as REQ-1. Verification: O-3. |
+| REQ-4 (deterministic report) | SHIPPED | `def evaluate` iterates `REQUIRED_HOOKS` in declaration order; no set/dict iteration reaches the output. Non-test consumer: as REQ-1. Verification: O-8 (two runs byte-identical). |
+| REQ-5 (exit contract) | SHIPPED | `EXIT_OK`/`EXIT_FAIL`/`EXIT_INCONCLUSIVE` + `class EnvironmentError3` + the `except EnvironmentError3` arm in `def main`. Non-test consumer: CI reads the exit status. Verification: O-9 (non-git cwd → exit 3, never 0). |
+| REQ-6 (control plane routed) | SHIPPED | the `# tooling — the control plane gating itself` block in `tooling/spec-routes.toml`: three `[[route]]` entries (`.claude/settings.json`, `.claude/agents/*.md`, `tooling/control-plane-check.py`) all `design = ".design/tooling/control-plane.md"`. Non-test consumer: `def load_doc_files in tooling/doc-drift.py` inverts the table and content-pins this doc's governed set. Verification: `python3 tooling/doc-drift.py` reports this doc CURRENT at the pinned aggregate. |
+| REQ-7 (CI enforcement) | SHIPPED | `.github/workflows/ci.yml` `checks` job step `control-plane gate (hook wiring)` → `python3 tooling/control-plane-check.py`; `Makefile` targets `control-plane` / `control-plane-test`. Verification: the step is sequenced with the sibling `doc-drift tripwire` step in the same job. |
+
+## Open questions
+
+- **OQ-1 (agent-def self-contradiction).** `.claude/agents/acto-critic.md` and
+  `acto-doc-author.md` declare `model: fable` in frontmatter while their bodies
+  read "Opus — always. … Never substitute." Routing them (REQ-6) makes any
+  future edit re-pin this doc, but the gate does not yet assert
+  frontmatter↔body consistency, and resolving which side is correct is a
+  harness-behavior decision for the maintainer, not a mechanical fix. A
+  follow-up could add a `REQUIRED_AGENTS` block asserting declared `model:` and
+  `tools:` against a pinned expectation.
+
+- **OQ-2 (anti-pattern rules have no CI backstop).** There is no `clippy.toml`;
+  `ci.yml:95` is stock `cargo clippy --workspace --all-targets -- -D warnings`
+  with no `disallowed_*` / `unwrap_used` lints. This component restores and pins
+  the hook, but the hook is still the only enforcement of those rules — a
+  clone that never runs Claude Code gets none of them. A `clippy.toml`
+  encoding the same rules would make the property hold in CI independent of the
+  harness.
+
+- **OQ-3 (read-only roles are conventional, not capability-enforced).**
+  `acto-critic` / `acto-doc-author` withhold `Edit` but retain `Write` and
+  unrestricted `Bash`, so "the critic cannot modify production code" is patched
+  with prose (`acto-critic.md:37`) on the `Write`/`Bash` vectors. The critic
+  genuinely needs `Write` to author failing tests, so the fix is not "drop
+  `Write`" — it is a read-only mount or a path-scoped write allowlist. Out of
+  scope here; recorded so the gap is not lost.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,15 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all --check
 
-      - name: doc-drift gate tests (tooling/tests)
+      - name: tooling gate tests (tooling/tests)
         run: python3 -m unittest discover -s tooling/tests
       - name: doc-drift tripwire (design-doc freshness)
         run: python3 tooling/doc-drift.py
+      # The gate that guards the gates (crosslink #93): asserts the two
+      # agent-facing hooks are still WIRED in the tracked settings.json, which
+      # `crosslink init` regenerates and 5581b65f silently clobbered.
+      - name: control-plane gate (hook wiring)
+        run: python3 tooling/control-plane-check.py
       - name: req-status lint (source-comment status consistency)
         run: python3 tooling/req-status.py
       - name: req-registry gate (canonical status inventory)

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 # ACToR harness read-state (per-worktree)
 .crosslink/.spec-reads.json
 tooling/__pycache__/
+__pycache__/
 
 # Rust build artifacts
 target/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Thermite — convenience targets. The build/test system is Cargo; these are
 # thin entry points. `make audit` is the headline: a FULL TRUST-CHAIN
 # re-derivation a skeptic runs on their own machine (see scripts/audit.sh).
-.PHONY: audit audit-fast check test fmt clippy gauntlet doc-drift doc-drift-ci doc-drift-worktree doc-drift-test req-status req-status-test req-registry req-registry-test
+.PHONY: audit audit-fast check test fmt clippy gauntlet doc-drift doc-drift-ci doc-drift-worktree doc-drift-test req-status req-status-test req-registry req-registry-test control-plane control-plane-test
 
 DOC_DRIFT_CI_BASE ?= origin/main
 DOC_DRIFT_CI_HEAD ?= HEAD
@@ -107,4 +107,16 @@ req-registry:
 	@tooling/reqs check
 
 req-registry-test:
+	@python3 -m unittest discover -s tooling/tests -v
+
+# The gate that guards the gates (crosslink #93). doc-drift pins the CONTENT of
+# what the routes govern; this asserts the two agent-facing hooks are actually
+# WIRED in the tracked .claude/settings.json — the file `crosslink init`
+# regenerates, and which 5581b65f silently de-wired for the whole Stage-3 arc.
+# Not part of `make audit`: hook wiring is a development-discipline invariant,
+# not a link in the proof-trust chain (the doc-drift decision-5 precedent).
+control-plane:
+	@python3 tooling/control-plane-check.py
+
+control-plane-test:
 	@python3 -m unittest discover -s tooling/tests -v

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ agent needs to work the repo **ships in the repo**:
   no stubs/TODOs), and the **route table** (`spec-routes.toml`: which file maps to
   which design doc). `.claude/settings.json` (also tracked) wires these into Claude
   Code's `PreToolUse`/`PostToolUse` events, so they enforce automatically — no setup.
+  That last sentence is itself CI-checked: `crosslink init` regenerates
+  `settings.json` from a generic template and once silently dropped both gates for
+  a whole stage (#93), so the **control-plane gate** (`control-plane-check.py`,
+  `make control-plane`) asserts every hook the docs claim is live is actually wired,
+  and the route table pins the control plane under `doc-drift.py`.
 - **`.claude/hooks/`** (gitignored — environment infra, *not* project source) — the
   crosslink issue-tracking + session machinery (`work-check.py` = an active issue is
   required before any edit, plus session/heartbeat/prompt hooks). These are regenerated

--- a/tooling/control-plane-check.py
+++ b/tooling/control-plane-check.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+control-plane gate — the gate that guards the gates.
+
+`tooling/spec-discipline.py` and `tooling/anti-pattern-gate.py` are agent-facing
+PreToolUse/PostToolUse hooks. They only ever fire because `.claude/settings.json`
+WIRES them. That wiring is a single tracked JSON file that `crosslink init`
+regenerates from a generic template — so a routine `crosslink init` (or a
+`--force` re-init) silently drops the project-specific entries and leaves the
+crosslink-generic ones. That is exactly what commit 5581b65f did on 2026-06-21:
+both gates were dormant for the whole Stage-3 arc while README.md:172, goal.md
+§Spec-discipline, and all four `.claude/agents/acto-*.md` files kept asserting
+"they enforce automatically — no setup" (crosslink #93).
+
+Nothing could catch it: `doc-drift.py` only checks files reachable from
+`tooling/spec-routes.toml`, and no route covered the control plane. The design
+layer governed everything except the file that decides whether the governance
+runs.
+
+This gate closes that loop. It asserts — as a CI-enforced, deterministic check —
+that every hook this project's documentation CLAIMS is live is actually wired in
+the tracked `settings.json`, and that the script each entry names exists on disk.
+An "asserted enforcement that isn't" becomes a red build instead of a quiet
+regression (the R-HONEST-3 move: a gate that fails open is a silent pass).
+
+The rule, precisely (governed by .design/tooling/control-plane.md):
+
+  1. Load the tracked `.claude/settings.json` (REQ-1). It must exist and parse:
+     Claude Code loads NO hooks from a malformed settings file, so unparseable
+     is gate-dead, i.e. a FINDING (exit 1), never INCONCLUSIVE.
+  2. For each required wiring (event, tools, script) in REQUIRED_HOOKS below,
+     find a hook entry under that event whose `matcher` COVERS every required
+     tool and one of whose commands names `script` (REQ-2). Matcher coverage is
+     alternative-set containment (`Write|Edit|Bash` covers a `Write|Edit`
+     requirement), so a superset matcher passes and a reordering does not
+     false-fail — but a matcher that drops a required tool is a MISSING-WIRING.
+  3. Assert each required script exists at its repo-relative path (REQ-3). A
+     wired-but-absent hook is the same dead gate as an unwired one: every
+     command is `if [ -f "$HOOK" ]`-guarded, so an absent script degrades to a
+     silent no-op exit 0.
+  4. Report (REQ-4) deterministically in REQUIRED_HOOKS order, and exit per the
+     REQ-5 contract:
+         0 = every required hook wired and present;
+         1 = at least one MISSING-WIRING / MISSING-SCRIPT / UNPARSEABLE;
+         3 = the gate could not determine the answer (no git / not a repo) —
+             the audit's INCONCLUSIVE precedent (scripts/audit.sh, doc-drift.py
+             REQ-9). An environment failure is never collapsed to "all wired".
+
+A finding prints the exact JSON entry to restore, so the fix is a paste, not an
+archaeology dig through `git show 5581b65f`.
+
+NOT a Claude-Code hook: invoked by CI and by `make control-plane`. Deliberately
+NOT part of `make audit` — hook wiring is a development-discipline invariant,
+not a link in the proof-trust chain (the doc-drift decision-5 precedent).
+
+Usage:  python3 tooling/control-plane-check.py [--root <repo-toplevel>]
+
+  --root  the repo to check (default: the git toplevel of the cwd). The
+          production invocation is flagless; --root keeps the fixture tests
+          hermetic.
+
+See:
+  .design/tooling/control-plane.md  (the governing doc — REQ-1..REQ-5)
+  goal.md                            (authority chain; R-CODE-4/5, R-HONEST-3)
+  tooling/doc-drift.py               (the sibling gate; exit-3 precedent)
+  tooling/spec-routes.toml           (routes the control plane under doc-drift)
+
+PROJECT CUSTOMIZATION:
+  Edit SETTINGS_RELPATH, REQUIRED_HOOKS below.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+# =====================================================================
+# PROJECT CUSTOMIZATION — edit these constants for your project
+# =====================================================================
+
+# Repo-relative path to the tracked Claude Code settings file (the subject).
+SETTINGS_RELPATH = ".claude/settings.json"
+
+# The wirings this project's docs claim are live. Each entry is:
+#   event   — the settings.json hook event key
+#   tools   — the tool names the matcher MUST cover
+#   script  — the repo-relative hook script the entry must invoke
+#   claim   — the doc line asserting this hook enforces (named in the report,
+#             so a finding points at the prose that would go false)
+REQUIRED_HOOKS = (
+    {
+        "event": "PostToolUse",
+        "tools": ("Read",),
+        "script": "tooling/spec-discipline.py",
+        "claim": "spec-discipline.py:16 'PostToolUse on Read -> records the Read'",
+    },
+    {
+        "event": "PreToolUse",
+        "tools": ("Write", "Edit"),
+        "script": "tooling/spec-discipline.py",
+        "claim": "goal.md R-XLATE-1/2/3 'enforced by tooling/spec-discipline.py'",
+    },
+    {
+        "event": "PreToolUse",
+        "tools": ("Write", "Edit"),
+        "script": "tooling/anti-pattern-gate.py",
+        "claim": "goal.md R-APG 'enforced by tooling/anti-pattern-gate.py'",
+    },
+)
+
+# =====================================================================
+# Implementation — generally no edits needed below this line
+# =====================================================================
+
+# Defect classes (REQ-4). The literal tokens the report emits and the oracle
+# asserts.
+MISSING_WIRING = "MISSING-WIRING"
+MISSING_SCRIPT = "MISSING-SCRIPT"
+UNPARSEABLE = "UNPARSEABLE"
+WIRED = "WIRED"
+
+# Exit codes (REQ-5), matching tooling/doc-drift.py.
+EXIT_OK = 0
+EXIT_FAIL = 1
+EXIT_INCONCLUSIVE = 3
+
+# A matcher is a regex alternation of tool names (`Write|Edit|Bash`). Split on
+# `|` and strip regex-grouping punctuation so `(Write|Edit)` reads the same as
+# `Write|Edit`. An absent matcher means "every tool" in Claude Code, which
+# trivially covers any requirement.
+_MATCHER_STRIP_RE = re.compile(r"[()\s^$]")
+
+
+class EnvironmentError3(Exception):
+    """The gate could not determine the answer — maps to exit 3 (REQ-5).
+
+    Raised (never a traceback to the user) for: git absent / not a repo. A CI
+    gate that fails open is a silent pass, so these are INCONCLUSIVE, never
+    "every hook is wired".
+    """
+
+
+def _git_toplevel(start):
+    """Resolve the git worktree toplevel containing `start`, or raise exit-3."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        raise EnvironmentError3(f"git could not be invoked: {exc}") from exc
+    if proc.returncode != 0:
+        raise EnvironmentError3(f"not inside a git repository: {start}")
+    top = proc.stdout.strip()
+    if not top:
+        raise EnvironmentError3(f"could not resolve git toplevel for: {start}")
+    return Path(top)
+
+
+def _matcher_covers(matcher, tools):
+    """True iff `matcher` fires for every tool in `tools`.
+
+    An absent/empty matcher matches every tool in Claude Code, so it covers any
+    requirement. Otherwise this is alternative-set containment: a superset
+    matcher (`Write|Edit|Bash`) covers `Write|Edit`, and order is irrelevant.
+    """
+    if matcher is None or not str(matcher).strip():
+        return True
+    alternatives = {
+        _MATCHER_STRIP_RE.sub("", alt)
+        for alt in str(matcher).split("|")
+    }
+    return all(tool in alternatives for tool in tools)
+
+
+def _entry_commands(entry):
+    """Every command string in a settings.json hook entry, shape-tolerantly.
+
+    A wrong-shaped entry yields no commands rather than raising: the wiring it
+    was supposed to provide then reads as MISSING (a loud finding), which is the
+    honest answer for a settings file Claude Code could not act on either.
+    """
+    if not isinstance(entry, dict):
+        return []
+    hooks = entry.get("hooks", [])
+    if not isinstance(hooks, list):
+        return []
+    commands = []
+    for hook in hooks:
+        if isinstance(hook, dict) and isinstance(hook.get("command"), str):
+            commands.append(hook["command"])
+    return commands
+
+
+def _restore_snippet(required):
+    """The JSON entry to paste back when a wiring is missing (REQ-4)."""
+    guard = (
+        'HOOK="$(git rev-parse --show-toplevel 2>/dev/null)/'
+        + required["script"]
+        + '"; if [ -f "$HOOK" ]; then python3 "$HOOK"; else exit 0; fi'
+    )
+    entry = {
+        "hooks": [{"command": guard, "timeout": 5, "type": "command"}],
+        "matcher": "|".join(required["tools"]),
+    }
+    body = json.dumps(entry, indent=2, sort_keys=True)
+    return "\n".join(f"           {line}" for line in body.splitlines())
+
+
+def evaluate(root):
+    """Run the gate over `root`; return (exit_code, report_lines).
+
+    Never raises for a defect in the SUBJECT (that is a finding); raises
+    EnvironmentError3 only for an environment failure the caller maps to exit 3.
+    """
+    lines = []
+    settings_path = root / SETTINGS_RELPATH
+
+    if not settings_path.is_file():
+        lines.append(
+            f"{UNPARSEABLE}  {SETTINGS_RELPATH}  file not found — no hook is "
+            f"wired, so every gate below is dormant"
+        )
+        return EXIT_FAIL, lines
+
+    try:
+        with open(settings_path, "rb") as f:
+            settings = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        # Claude Code loads NO hooks from a settings file it cannot parse, so
+        # this is a dead gate (a finding), not an environment failure.
+        lines.append(
+            f"{UNPARSEABLE}  {SETTINGS_RELPATH}  {exc} — Claude Code loads no "
+            f"hooks from an unparseable settings file; every gate is dormant"
+        )
+        return EXIT_FAIL, lines
+
+    hooks_by_event = settings.get("hooks", {}) if isinstance(settings, dict) else {}
+    if not isinstance(hooks_by_event, dict):
+        lines.append(
+            f"{UNPARSEABLE}  {SETTINGS_RELPATH}  `hooks` must be an object, got "
+            f"{type(hooks_by_event).__name__} — every gate is dormant"
+        )
+        return EXIT_FAIL, lines
+
+    failed = False
+    for required in REQUIRED_HOOKS:
+        event = required["event"]
+        script = required["script"]
+        tools = required["tools"]
+        label = f"{event}/{'|'.join(tools)} -> {script}"
+
+        entries = hooks_by_event.get(event, [])
+        if not isinstance(entries, list):
+            entries = []
+
+        wired = any(
+            _matcher_covers(entry.get("matcher") if isinstance(entry, dict) else None, tools)
+            and any(script in cmd for cmd in _entry_commands(entry))
+            for entry in entries
+        )
+
+        if not wired:
+            failed = True
+            lines.append(
+                f"{MISSING_WIRING}  {label}\n"
+                f"           the docs claim this fires: {required['claim']}\n"
+                f"           restore this entry under hooks.{event} in "
+                f"{SETTINGS_RELPATH}:\n{_restore_snippet(required)}"
+            )
+            continue
+
+        if not (root / script).is_file():
+            failed = True
+            lines.append(
+                f"{MISSING_SCRIPT}  {label}\n"
+                f"           wired in {SETTINGS_RELPATH} but {script} is absent; "
+                f"the `if [ -f \"$HOOK\" ]` guard degrades it to a silent no-op"
+            )
+            continue
+
+        lines.append(f"{WIRED}  {label}")
+
+    return (EXIT_FAIL if failed else EXIT_OK), lines
+
+
+def _parse_args(argv):
+    root = None
+    rest = list(argv)
+    while rest:
+        arg = rest.pop(0)
+        if arg == "--root":
+            if not rest:
+                raise SystemExit("--root requires a path argument")
+            root = rest.pop(0)
+        elif arg in ("-h", "--help"):
+            print(__doc__.strip())
+            raise SystemExit(EXIT_OK)
+        else:
+            raise SystemExit(f"unrecognized argument: {arg}")
+    return root
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    try:
+        root_arg = _parse_args(argv)
+        root = Path(root_arg).resolve() if root_arg else _git_toplevel(Path.cwd())
+        code, lines = evaluate(root)
+    except EnvironmentError3 as exc:
+        print(f"control-plane: INCONCLUSIVE — {exc}", file=sys.stderr)
+        return EXIT_INCONCLUSIVE
+
+    for line in lines:
+        print(line)
+
+    if code == EXIT_OK:
+        print(
+            f"control-plane: all {len(REQUIRED_HOOKS)} required hooks wired in "
+            f"{SETTINGS_RELPATH}"
+        )
+    else:
+        print(
+            "control-plane: FAIL — a hook the docs claim enforces automatically "
+            "is not wired. This is how crosslink #93 happened: `crosslink init` "
+            "regenerates .claude/settings.json from a generic template and drops "
+            "the project-specific entries. Re-add them (above) and re-run.",
+            file=sys.stderr,
+        )
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tooling/spec-routes.toml
+++ b/tooling/spec-routes.toml
@@ -977,3 +977,40 @@ crate_pattern = "thermite-tv/src/strat_two_phase.rs"
 design = ".design/verified/strat-rust-lean-correspondence.md"
 reference = []
 conformance_ops = []
+
+# ---------------------------------------------------------------------
+# tooling — the control plane gating itself (crosslink #93)
+# ---------------------------------------------------------------------
+# The two agent-facing gates (spec-discipline.py, anti-pattern-gate.py) only
+# fire because .claude/settings.json WIRES them, and until #93 no route covered
+# that file — so commit 5581b65f could de-wire both gates for the whole Stage-3
+# arc while README/goal.md/the agent defs kept claiming they enforce
+# automatically, and nothing in the repo could see it.
+#
+# DECLARATIVE for spec-discipline, ENFORCED for doc-drift (the same split as the
+# doc-drift.py dogfood route above): is_gated_path requires TARGET_EXTENSION
+# ".rs" + a thermite-/forge crate dir + a src/ component, so the hook
+# structurally cannot gate a .json or .md control-plane file. These routes make
+# the control plane CONTENT-PINNED under doc-drift.py (which IS enforced via
+# `make doc-drift` + CI): editing the hook wiring or an agent def without
+# bumping .design/tooling/control-plane.md's audited-content-sha256 fires the
+# tripwire. The wiring itself is separately asserted by
+# tooling/control-plane-check.py (`make control-plane`).
+
+[[route]]
+crate_pattern = ".claude/settings.json"
+design = ".design/tooling/control-plane.md"
+reference = []
+conformance_ops = []
+
+[[route]]
+crate_pattern = ".claude/agents/*.md"
+design = ".design/tooling/control-plane.md"
+reference = []
+conformance_ops = []
+
+[[route]]
+crate_pattern = "tooling/control-plane-check.py"
+design = ".design/tooling/control-plane.md"
+reference = []
+conformance_ops = []

--- a/tooling/tests/test_control_plane.py
+++ b/tooling/tests/test_control_plane.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Oracle fixture tests for tooling/control-plane-check.py.
+
+Same convention as test_doc_drift.py: each test builds a throwaway control plane
+in a tmpdir (a .claude/settings.json + the tooling/ scripts it names), runs the
+gate via subprocess with `--root <fixture>`, and asserts against HAND-AUTHORED
+oracle facts — never the tool's own output (R-CHAR-3).
+
+O-2 is the load-bearing one: its fixture is the VERBATIM de-wired settings.json
+that commit 5581b65f left on main, so the suite fails if the gate ever stops
+catching the exact regression it was built for (crosslink #93).
+
+Runnable as:  python3 -m unittest discover -s tooling/tests
+
+The oracle (the spec's expected values, not the tool's):
+
+  O-1  (REQ-2 wired):     all three required hooks present + scripts on disk
+                          -> exit 0; one WIRED line each; no MISSING token.
+  O-2  (REQ-2 the #93 regression): the verbatim post-5581b65f settings.json
+                          (crosslink-generic hooks only) -> exit 1; three
+                          MISSING-WIRING lines naming spec-discipline.py twice
+                          and anti-pattern-gate.py once.
+  O-3  (REQ-3 dead hook): wiring present but the named script absent from disk
+                          -> exit 1; MISSING-SCRIPT (NOT MISSING-WIRING), since
+                          the `if [ -f "$HOOK" ]` guard makes it a silent no-op.
+  O-4  (REQ-1 malformed): settings.json that is not valid JSON -> exit 1;
+                          UNPARSEABLE; no Traceback (Claude Code loads no hooks
+                          from it, so it is a dead gate, not an env failure).
+  O-5  (REQ-1 absent):    no settings.json at all -> exit 1; UNPARSEABLE.
+  O-6  (REQ-2 superset):  matcher "Write|Edit|Bash" satisfies a Write|Edit
+                          requirement -> exit 0 (coverage, not equality).
+  O-7  (REQ-2 narrowed):  matcher "Write" alone does NOT satisfy Write|Edit
+                          -> exit 1; MISSING-WIRING.
+  O-8  (REQ-4 determinism): two runs on the unchanged fixture -> byte-identical
+                          stdout.
+  O-9  (REQ-5 inconclusive): no --root, cwd a non-git tmpdir -> exit 3, no
+                          Traceback on stderr, and NOT exit 0 (never fail open).
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# The gate under test: tooling/control-plane-check.py, two levels up.
+GATE = Path(__file__).resolve().parents[1] / "control-plane-check.py"
+
+# The two hook scripts the required wirings name.
+SPEC_DISCIPLINE = "tooling/spec-discipline.py"
+ANTI_PATTERN = "tooling/anti-pattern-gate.py"
+
+
+def _guard(script):
+    """The `if [ -f "$HOOK" ]`-guarded command form used throughout settings."""
+    return (
+        f'HOOK="$(git rev-parse --show-toplevel 2>/dev/null)/{script}"; '
+        f'if [ -f "$HOOK" ]; then python3 "$HOOK"; else exit 0; fi'
+    )
+
+
+def _entry(matcher, *scripts):
+    """A settings.json hook entry invoking `scripts` under `matcher`."""
+    hooks = [
+        {"command": _guard(s), "timeout": 5, "type": "command"} for s in scripts
+    ]
+    entry = {"hooks": hooks}
+    if matcher is not None:
+        entry["matcher"] = matcher
+    return entry
+
+
+# The crosslink-generic hooks that SURVIVED the 5581b65f clobber. Present in
+# every fixture so a test can never pass merely because the file is empty.
+def _crosslink_generic():
+    return {
+        "PostToolUse": [
+            _entry("Write|Edit", ".claude/hooks/post-edit-check.py"),
+            _entry(None, ".claude/hooks/heartbeat.py"),
+        ],
+        "PreToolUse": [
+            _entry("WebFetch|WebSearch", ".claude/hooks/pre-web-check.py"),
+            _entry("Write|Edit|Bash", ".claude/hooks/work-check.py"),
+        ],
+    }
+
+
+def _fully_wired():
+    """The pre-clobber (and now restored) hook set."""
+    hooks = _crosslink_generic()
+    hooks["PostToolUse"].insert(1, _entry("Read", SPEC_DISCIPLINE))
+    hooks["PreToolUse"].append(_entry("Write|Edit", SPEC_DISCIPLINE, ANTI_PATTERN))
+    return hooks
+
+
+def _make_fixture(tmp, hooks, *, scripts_present=True, raw_settings=None,
+                  write_settings=True):
+    """Build a control-plane fixture rooted at `tmp`; return that root."""
+    root = Path(tmp)
+    (root / ".claude").mkdir(parents=True, exist_ok=True)
+    (root / "tooling").mkdir(parents=True, exist_ok=True)
+
+    if scripts_present:
+        for script in (SPEC_DISCIPLINE, ANTI_PATTERN):
+            (root / script).write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+
+    if write_settings:
+        settings_path = root / ".claude" / "settings.json"
+        if raw_settings is not None:
+            settings_path.write_text(raw_settings, encoding="utf-8")
+        else:
+            settings_path.write_text(
+                json.dumps({"hooks": hooks}, indent=2), encoding="utf-8"
+            )
+    return root
+
+
+def _run(root=None, cwd=None):
+    """Invoke the gate; return (returncode, stdout, stderr)."""
+    argv = [sys.executable, str(GATE)]
+    if root is not None:
+        argv += ["--root", str(root)]
+    proc = subprocess.run(argv, capture_output=True, text=True, cwd=cwd)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+class TestControlPlaneGate(unittest.TestCase):
+
+    def test_o1_fully_wired_passes(self):
+        """O-1: all three required hooks wired + present -> exit 0."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_fixture(tmp, _fully_wired())
+            code, out, _ = _run(root)
+            self.assertEqual(code, 0, out)
+            self.assertEqual(out.count("WIRED "), 3, out)
+            self.assertNotIn("MISSING", out)
+
+    def test_o2_the_5581b65f_regression_is_caught(self):
+        """O-2: the verbatim post-clobber settings.json -> exit 1, 3 findings.
+
+        This is the crosslink #93 regression. If this test ever passes with
+        exit 0, the gate has stopped guarding the thing it exists to guard.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_fixture(tmp, _crosslink_generic())
+            code, out, err = _run(root)
+            self.assertEqual(code, 1, out + err)
+            self.assertEqual(out.count("MISSING-WIRING "), 3, out)
+            # spec-discipline is required twice (PostToolUse/Read +
+            # PreToolUse/Write|Edit), anti-pattern-gate once.
+            self.assertEqual(out.count(f"-> {SPEC_DISCIPLINE}"), 2, out)
+            self.assertEqual(out.count(f"-> {ANTI_PATTERN}"), 1, out)
+            self.assertNotIn("Traceback", err)
+
+    def test_o3_wired_but_script_absent_is_missing_script(self):
+        """O-3: the guard degrades an absent script to a no-op -> MISSING-SCRIPT."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_fixture(tmp, _fully_wired(), scripts_present=False)
+            code, out, _ = _run(root)
+            self.assertEqual(code, 1, out)
+            self.assertIn("MISSING-SCRIPT", out)
+            self.assertNotIn("MISSING-WIRING", out)
+
+    def test_o4_malformed_json_is_a_finding_not_a_traceback(self):
+        """O-4: unparseable settings -> exit 1 UNPARSEABLE, no traceback."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_fixture(tmp, None, raw_settings='{"hooks": {,,,}')
+            code, out, err = _run(root)
+            self.assertEqual(code, 1, out + err)
+            self.assertIn("UNPARSEABLE", out)
+            self.assertNotIn("Traceback", err)
+
+    def test_o5_absent_settings_is_a_finding(self):
+        """O-5: no settings.json -> exit 1 UNPARSEABLE."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_fixture(tmp, None, write_settings=False)
+            code, out, _ = _run(root)
+            self.assertEqual(code, 1, out)
+            self.assertIn("UNPARSEABLE", out)
+
+    def test_o6_superset_matcher_covers_requirement(self):
+        """O-6: `Write|Edit|Bash` satisfies a Write|Edit requirement."""
+        with tempfile.TemporaryDirectory() as tmp:
+            hooks = _crosslink_generic()
+            hooks["PostToolUse"].insert(1, _entry("Read", SPEC_DISCIPLINE))
+            hooks["PreToolUse"].append(
+                _entry("Write|Edit|Bash", SPEC_DISCIPLINE, ANTI_PATTERN)
+            )
+            root = _make_fixture(tmp, hooks)
+            code, out, _ = _run(root)
+            self.assertEqual(code, 0, out)
+            self.assertNotIn("MISSING", out)
+
+    def test_o7_narrowed_matcher_does_not_cover_requirement(self):
+        """O-7: a matcher that drops `Edit` is a MISSING-WIRING, not a pass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            hooks = _crosslink_generic()
+            hooks["PostToolUse"].insert(1, _entry("Read", SPEC_DISCIPLINE))
+            hooks["PreToolUse"].append(
+                _entry("Write", SPEC_DISCIPLINE, ANTI_PATTERN)
+            )
+            root = _make_fixture(tmp, hooks)
+            code, out, _ = _run(root)
+            self.assertEqual(code, 1, out)
+            self.assertEqual(out.count("MISSING-WIRING "), 2, out)
+
+    def test_o8_output_is_deterministic(self):
+        """O-8: two runs on an unchanged fixture -> byte-identical stdout."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_fixture(tmp, _crosslink_generic())
+            _, first, _ = _run(root)
+            _, second, _ = _run(root)
+            self.assertEqual(first, second)
+
+    def test_o9_non_git_cwd_is_inconclusive_never_a_pass(self):
+        """O-9: no --root outside a git repo -> exit 3, never a silent exit 0."""
+        with tempfile.TemporaryDirectory() as tmp:
+            code, out, err = _run(root=None, cwd=tmp)
+            self.assertEqual(code, 3, out + err)
+            self.assertNotEqual(code, 0)
+            self.assertNotIn("Traceback", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #93.

## What was broken

`5581b65f` ("Stage-3 REQ-1: the @bv clause tag, parse-gated") removed three hook entries from `.claude/settings.json` — the `PostToolUse`/`Read` recorder and the `PreToolUse`/`Write|Edit` pair invoking **both** `tooling/spec-discipline.py` and `tooling/anti-pattern-gate.py`. The commit message is entirely about the `@bv` clause tag and never mentions the settings change. The crosslink-generic entries survived; only the project-specific ones vanished — the signature of `crosslink init` regenerating a file that is tracked but machine-authored.

Both agent-facing gates were dormant for the **entire Stage-3 arc**, while `README.md:172` ("they enforce automatically — no setup"), `goal.md`'s R-XLATE-1/2/3, and all four `.claude/agents/acto-*.md` kept asserting they fire.

It stayed hidden because **no route covered the control plane**. `doc-drift.py` pins freshness for files reachable from `spec-routes.toml`, and `.claude/settings.json` was not one of them. The design layer governed everything except the file that decides whether the governance runs.

## What this does

| | |
|---|---|
| `.claude/settings.json` | Restores the three entries — **byte-identical** to the pre-clobber `c7dc32be` revision. |
| `tooling/control-plane-check.py` *(new)* | Asserts every hook the docs claim is live is wired and its script present on disk. |
| `tooling/tests/test_control_plane.py` *(new)* | Nine hand-authored oracle fixtures (R-CHAR-3). |
| `tooling/spec-routes.toml` | Routes `.claude/settings.json`, `.claude/agents/*.md`, and the new gate. |
| `.design/tooling/control-plane.md` *(new)* | Governing doc, REQ-1..REQ-7 + AC-1..AC-7, content-pinned. |
| CI + `Makefile` | `control-plane gate (hook wiring)` step; `make control-plane` / `control-plane-test`. |
| `README.md` | The enforcement claim now names the check that keeps it true. |

**Design choices worth a reviewer's attention:**

- **Assert, don't regenerate.** A merge step that silently re-injects the entries after `crosslink init` is silent repair of a control plane — you stop noticing something keeps breaking it. This fails loudly and prints the exact JSON to paste back.
- **Matcher coverage, not equality.** `Write|Edit|Bash` satisfies a `Write|Edit` requirement; `Write` alone does not. Equality false-fails on a harmless reorder, substring matching passes a matcher that silently dropped `Edit`.
- **An unparseable `settings.json` is a FINDING (exit 1), not INCONCLUSIVE** — Claude Code loads no hooks at all from one, so it is maximally gate-dead. Exit 3 is reserved for the gate's own environment failing (`doc-drift.py` REQ-9 / R-HONEST-3: a gate that fails open is a silent pass).
- **Wired-but-absent is its own class.** Every command is `if [ -f "$HOOK" ]`-guarded, so a wiring naming a missing script degrades to a silent no-op. `MISSING-SCRIPT` is separate from `MISSING-WIRING` because the fix differs.
- **The routes are DECLARATIVE for spec-discipline, ENFORCED for doc-drift.** `is_gated_path` requires `.rs` + a `thermite-`/`forge` crate dir + a `src/` component, so the hook structurally cannot gate a `.json`/`.md` file — the same honest limitation `doc-drift-tripwire.md` REQ-11 records for `tooling/*.py`. Same split as the existing `doc-drift.py` dogfood route.
- **Not in `make audit`.** Hook wiring is a development-discipline invariant, not a link in the proof-trust chain (doc-drift decision 5). `scripts/audit.sh` is byte-identical.

## Verification

```
control-plane exit=0    doc-drift exit=0 (control-plane.md CURRENT)
req-status    exit=0    req-registry exit=0 (453 reqs, 119 views)
46 tooling tests OK (37 existing + 9 new)
scripts/audit.sh byte-identical (AC-7)
```

**Dogfooded.** Removing the anti-pattern entry again fires **both** gates: `doc-drift` reports `DRIFT` on `control-plane.md`, and `control-plane-check` reports two `MISSING-WIRING` findings with paste-ready restore snippets. `O-2`'s test fixture is the *verbatim* post-`5581b65f` `settings.json`, so the suite goes red if the gate ever stops catching this exact regression.

## Deliberately left open (recorded as OQ-1..OQ-3 in the design doc)

These are the other findings from #93; each is a judgment call I did not want to make silently inside a wiring fix:

1. **OQ-1** — `acto-critic.md` / `acto-doc-author.md` declare `model: fable` in frontmatter while their bodies read *"Opus — always. … Never substitute."* Routing them means any future edit re-pins the doc, but **which side is correct is a harness-behavior decision for the maintainer.**
2. **OQ-2** — no `clippy.toml`; `ci.yml:95` is stock `cargo clippy -D warnings` with no `disallowed_*`/`unwrap_used`. The anti-pattern rules are still hook-only, so a clone that never runs Claude Code gets none of them.
3. **OQ-3** — `acto-critic` withholds `Edit` but retains `Write` + unrestricted `Bash`, so "cannot modify production code" is prose-patched. The critic genuinely needs `Write` for test files, so the fix is a read-only mount or path-scoped allowlist, not dropping `Write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)