### PR TITLE
Make setup and generated skill current

### DIFF
--- a/.design/basis/09-option-result.md
+++ b/.design/basis/09-option-result.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 46202bede5f263fcedce4791f1994cb1c74efc06c9016b3115239deec7653cd3 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 18ccaa9ecdaa08c4eea7820121bc06627aec1dd7845237c5295af7400d414a6a (re-pinned 2026-07-30 after the skill audit and the comment-only clarification of automatic BV/EPR routing; Option/Result behavior and renderer arms are unchanged)
 governs: thermite-syntax/src/ast.rs
 governs: thermite-syntax/src/parser.rs
 governs: thermite-spec/src/validator.rs

--- a/.design/basis/11-ergonomics.md
+++ b/.design/basis/11-ergonomics.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 46202bede5f263fcedce4791f1994cb1c74efc06c9016b3115239deec7653cd3 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 18ccaa9ecdaa08c4eea7820121bc06627aec1dd7845237c5295af7400d414a6a (re-pinned 2026-07-30 after the skill audit and the comment-only clarification of automatic BV/EPR routing; C10 behavior and renderer arms are unchanged)
 governs: thermite-syntax/src/parser.rs
 governs: thermite-syntax/src/ast.rs
 governs: thermite-lower/src/lower.rs

--- a/.design/basis/12-mutual-recursion.md
+++ b/.design/basis/12-mutual-recursion.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 3158984f966b99063a28ce692db077fbdde6e4b6bc4a1969ae56d4a1dac282a6 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 9629a375440c6e28914775c90610b4e7ce2e6beab3af0139982c5e8833ca4c2f (re-pinned 2026-07-30 for a comment-only clarification of the existing automatic BV/EPR overlay; mutual-recursion behavior is unchanged)
 governs: forge/src/check.rs
 governs: thermite-lower/src/lower.rs
 thesis-refs:

--- a/.design/forge/certificate-manifest.md
+++ b/.design/forge/certificate-manifest.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: a728d95ca3dbd4fbbee1cb496c003f408d82f327 (re-pinned 2026-06-16 for stage-1 increment 2f, REQ-8: the only change to this doc's governed file (manifest.rs) is the additive Level::L4 kernel-grounded rung (REQ-S1-8); the relax route is reached only via --engine nlsat, so the v1 corpus stays L3 and oracle_subset is byte-identical (check_conformance green).)
-audited-content-sha256: a3181b8e85794e381975bfaf77c7b66f00196e7d348a386ea428a027662d304b
+audited-content-sha256: 11cbbcfc4bb765edfe746c0a5e69e18c12ecb8322a2bf4be019b1b2335c78936 (re-pinned 2026-07-30 after the Level::L4 documentation was brought current with automatic BV and finite EPR reconstruction; schema and behavior are unchanged)
 governs: forge/src/manifest.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/check.md
+++ b/.design/forge/check.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 1d510c2fa2abf3818702f3908d8b13066e318dc80d12d45d5c069f971fe21d62 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 2bc2545cd90e7ad88f143c5a4b4a72882227d45a20310cfde5db92ff2d5e808f (re-pinned 2026-07-30 for a comment-only clarification that Auto includes Lean fallback and checked BV/EPR overlays; check behavior is unchanged)
 governs: forge/src/check.rs
 thesis-refs:
   - thermite-design.md §5.1

--- a/.design/forge/cli.md
+++ b/.design/forge/cli.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: shipped
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (content-sha256 re-pinned 2026-06-23 for stage-3 REQ-7 / AC-8 (#349), the automated Rust→Lean obligation exporter: the change to this doc's governed file (cli.rs) is the additive `forge smt-export [<file>] [--out <path>]` subcommand (`Command::SmtExport` → `run_smt_export`, emitting the `(P_prod) ⟺ (P_ref)` `by smt` Lean theorems + `#print axioms` probes via `lean_smt_export.rs`); every other subcommand + flag parse is unchanged. The legacy commit pin stays at the 5ae0816c stable-main ancestor; only the active content-sha256 digest moves. prior: 2026-06-21 stage-2 REQ-8 / AC-8 (#330) `forge strat-faithful-tv`; 2026-06-20 stage-2 REQ-4 / AC-4 (#326) `forge strat-tv` + `ForgeError::StratDifferential`; 2026-06-18 umbrella REQ-2c / AC-4 rotating-seed `--seed` flag on `forge tv`; §6 metrics dashboard `--metrics` value)
-audited-content-sha256: f5fda77ede58ab4a768d552e6946a26f8048f51c372c8ac9b54b5c71b9961cdb
+audited-content-sha256: fde26b43eddd39f0d6afc5e3523898c4c1760fe8f1b96278b4bf48a62f70f953 (re-pinned 2026-07-30 for the shared ForgeMethod registry, the implemented `forge skill` print/write/check command, and current Auto-routing documentation)
 governs: forge/src/cli.rs
 thesis-refs:
   - thermite-design.md §5
@@ -14,19 +14,26 @@ thesis-refs:
 
 ## Summary
 
-`forge/src/cli.rs` (2,778 lines) is the command surface of the `forge` driver:
-a hand-rolled argv matcher (`fn parse_args in cli.rs`) that dispatches FOURTEEN
-verbs — `new` / `check` / `audit` / `repair` / `review` / `build` / `tv` /
-`exec-tv` / `body-tv` / `goal` / `battery` / `edit` / `fill` / `smt-export` —
+`forge/src/cli.rs` is the command surface of the `forge` driver. Its hand-rolled
+argument matcher dispatches 18 top-level methods — `new`, `check`, `audit`,
+`repair`, `review`, `build`, `tv`, `exec-tv`, `strat-tv`,
+`strat-faithful-tv`, `g2-gate`, `body-tv`, `goal`, `battery`, `edit`, `fill`,
+`smt-export`, and `skill` —
 renders each verb's result as human-readable text or (under `--json`) the §5.1 structured
 document, owns `enum ForgeError in cli.rs` (the boundary error that AGGREGATES
 every driven library's error plus driver-native subprocess/environment
 variants), and maps every outcome to a typed exit code
 (`0` / `EXIT_VERIFICATION_FAILURE` = 1 / `EXIT_ENVIRONMENT` = 2). It is the
 only module that touches `std::env::args` / `std::process::ExitCode`
-(`pub fn run in cli.rs`, consumed by `fn main in main.rs`); all verb logic
+(`pub fn run in cli.rs`, consumed by `fn main in main.rs`); most method logic
 lives in the driven modules (`check.rs`, `audit.rs`, `repair.rs`, `review.rs`,
 `build.rs`, `contract_tv.rs`, `exec_tv.rs`, `body_tv.rs`, `goal_repl.rs`).
+
+The public method names, synopses, and short descriptions live in
+`thermite_skill::ForgeMethod`. The parser recognizes its first argument through
+that registry, the usage banner iterates it, and the generated language skill
+uses the same records. Forge still owns the detailed per-method flag parser and
+its private `Command` values.
 
 This amendment (#262) replaces the greenfield-era text wholesale: the previous
 revision's Summary claimed "This component is GREENFIELD … Every REQ below is
@@ -69,16 +76,18 @@ What the old doc never saw, grouped (each verb cites its issue in the code):
 
 ## Requirements
 
-- REQ-1 (command surface): `forge` exposes exactly the fourteen verbs above;
+- REQ-1 (command surface): `forge` exposes exactly the 18 methods above;
   no args, an unknown verb, a missing positional, or an unknown flag is a
   structured `ForgeError::Usage` carrying `fn usage_text in cli.rs`, never a
   panic and never exit 0.
   Source: `thermite-design.md` Appendix B (the verb inventory); §5.1.
 - REQ-2 (hand-rolled argv matcher): argv is parsed by `fn parse_args in cli.rs`
-  — a `match` over the verb with per-verb flag loops — NOT a derive-macro
+  — a registry lookup followed by an exhaustive `ForgeMethod` match with
+  per-method flag loops — NOT a derive-macro
   dependency (`forge/Cargo.toml` declares no `clap`). The original two-verb
   justification (§2.2/§2.3/§4.4 low-magic posture) was made when the grammar
-  was `new <name> | check <file> [--json]`; the decision SURVIVED to 14 verbs
+  was `new <name> | check <file> [--json]`; the decision survived as the
+  surface grew
   and ~650 lines of matcher. Honest assessment: it still holds — every flag
   error is a precise structured diagnostic and the dependency cost stays zero —
   but the per-verb flag loops are hand-duplicated (see OQ-1).
@@ -145,12 +154,18 @@ What the old doc never saw, grouped (each verb cites its issue in the code):
   Source: `.design/lower/l2-kani.md` REQ-7; `.design/forge/solver-profiles.md`
   REQ-5; `.design/forge/mutation-scoring.md` REQ-5;
   `.design/verified/proof-backends.md` OQ-1/REQ-5.
-- REQ-9 (usage-banner currency): `fn usage_text in cli.rs` names every verb and
-  every flag the parser accepts. The #257 fix (commit `6368550a`) closed the
-  one known drift — the banner had been missing `[--engine verus|lean|auto]`
-  after #247 landed the flag.
+- REQ-9 (usage-banner currency): `fn usage_text in cli.rs` iterates
+  `ForgeMethod::ALL`; every registered method and its synopsis therefore appear
+  in help automatically. Detailed flag parsing remains hand-written, and each
+  registry synopsis must match it.
   Source: `thermite-design.md` §5.1 ("every message is a prompt" — the banner
   is the agent-facing grammar).
+- REQ-11 (`forge skill`): `forge skill` prints the canonical generated
+  `THERMITE.skill.md`. `--claude` adds valid Claude skill frontmatter;
+  `--write <path>` writes the selected format; `--check <path>` exits nonzero
+  when an existing file differs. `--write` and `--check` are mutually
+  exclusive. The content comes from `thermite-skill`, the same crate that owns
+  the method registry and 6,000-token gate.
 - REQ-10 (project assurance display, #10): without `--json`, `run_check`
   renders `fn render_assurance in cli.rs` after the per-cert text — the per-fn
   `lowered-assurance` flags plus the project headline (min over functions, or
@@ -188,6 +203,10 @@ What the old doc never saw, grouped (each verb cites its issue in the code):
   target (`scaffold_writes_layout_and_refuses_clobber`).
 - AC-8: `cargo clippy -p forge --all-targets -- -D warnings` + the
   anti-pattern gate are clean of non-test `unwrap`/`expect`/`panic!`.
+- AC-9: `ForgeMethod::ALL` is present in the generated skill and usage text;
+  `forge skill --check` accepts a fresh canonical file and rejects stale bytes;
+  `forge skill --claude` starts with valid `name` and `description`
+  frontmatter.
 
 ## Architecture
 
@@ -196,7 +215,7 @@ The flow is `fn main in main.rs` → `pub fn run in cli.rs` (the ONLY reader of
 `enum Command in cli.rs` → `fn dispatch` (split from `run` so it is
 unit-testable without real argv) → one `run_<verb>` function per verb.
 
-The verbs fall into four families, each with its own exit-code convention
+The methods fall into five families, each with its own exit-code convention
 (REQ-5):
 
 1. **Certification gates** — `check` (`run_check`: the four-way
@@ -223,6 +242,9 @@ The verbs fall into four families, each with its own exit-code convention
    (`run_goal`/`run_battery`/`run_edit`/`run_fill` → `goal_repl::*`): a render
    is a successful query; the verdict lives in the rendered goal state.
 4. **Scaffold** — `new` → `pub fn scaffold_project` (REQ-7).
+5. **Toolchain reference** — `skill` → `run_skill`: render the matching
+   canonical or Claude-compatible skill, optionally write it, or compare an
+   existing copy for drift.
 
 `ForgeError` (REQ-3) is where the leaf-first DAG's many error channels
 converge: the driven crates keep their own error types, `cli.rs` wraps them so
@@ -259,34 +281,34 @@ a reader cannot mistake it for an oracle field.
 
 | REQ | Status | Evidence |
 |---|---|---|
-| REQ-1 (14-verb command surface) | SHIPPED | `fn parse_args in cli.rs` matches `new`/`check`/`audit`/`repair`/`review`/`build`/`tv`/`exec-tv`/`body-tv`/`goal`/`battery`/`edit`/`fill`/`smt-export`; the fall-through arm is `Err(ForgeError::Usage(format!("unknown command \`{other}\`. {}", usage_text())))`. Non-test consumer: `fn main in main.rs` → `cli::run`. Verification: unit `usage_errors`; integration `missing_file_is_usage_error_nonzero`. |
-| REQ-2 (hand-rolled argv matcher) | SHIPPED | `fn parse_args in cli.rs` (~650 lines, verb `match` + per-verb flag loops); `grep clap forge/Cargo.toml` → no hit. Consumer: `fn dispatch in cli.rs`. Verification: the six `parses_*` unit tests. Decision survived the 2-verb → 14-verb growth; duplication cost named in OQ-1. |
+| REQ-1 (18-method command surface) | SHIPPED | `fn parse_args in cli.rs` resolves every entry in `ForgeMethod::ALL`, including `skill`, then exhaustively matches it. Unknown names return `ForgeError::Usage` with generated usage text. |
+| REQ-2 (hand-rolled argv matcher) | SHIPPED | `fn parse_args in cli.rs` uses a registry lookup plus per-method flag loops; `forge/Cargo.toml` has no CLI parser dependency. Consumer: `fn dispatch in cli.rs`. |
 | REQ-3 (`ForgeError` aggregation) | SHIPPED | `enum ForgeError in cli.rs`: `Parse(Vec<SyntaxError>)`/`Spec`/`Effects`/`Lower` + the verus/kani/rustc/reviewer Absent-Spawn-Output families + `Io`/`Usage` + `SoundnessAlarm(crate::engine::Disagreement)`; `impl fmt::Display` forwards inner diagnostics. Non-test consumers: every driven module returns it (`check::check_file -> Result<_, ForgeError>`, `pub fn check_disagreement in engine.rs` surfaces the alarm). Verification: `aggregation_preserves_inner_diagnostics`. |
 | REQ-4 (human + `--json` dual rendering) | SHIPPED | `fn run_check in cli.rs`: `serde_json::to_string_pretty(&certs)` under `--json`, else `render_human` per cert + `render_assurance`; parallel paths in `run_audit`/`run_repair`/`run_review`/`run_build`/`run_tv`/`run_exec_tv`/`run_body_tv`; stderr for diagnostics (e.g. `run_review`'s `eprintln!` keeps `--json` stdout clean). Verification: `run_check_json` harness parses stdout whole in `check_conformance.rs`. |
 | REQ-5 (typed exit codes) | SHIPPED | `pub const EXIT_VERIFICATION_FAILURE: u8 = 1` / `EXIT_ENVIRONMENT: u8 = 2` in `cli.rs`; `run_check`/`run_audit` gate on `matches!(.., ProjectAssurance::Certified(_))`; `run_repair` on `report.all_upgraded()`; the TV trio on `counts.divergent == 0`; `fn exit_code in cli.rs` maps every `ForgeError` to `EXIT_ENVIRONMENT`. Verification: `errors_map_to_environment_exit_code`, `broken_contract_is_reported_failure_with_counterexample` (exit 1), `divergence_audit_check2_exit_swallow.rs` (the TV exit discipline). |
 | REQ-6 (no panics; Result discipline) | SHIPPED | every `run_*`/`parse_args` path returns `Result<_, ForgeError>`; no `unwrap`/`expect`/`panic!` outside `#[cfg(test)]` in `cli.rs`. Verification: clippy `-D warnings` + the anti-pattern gate in the gauntlet (HEAD commit `93d3cbc0` chain is gauntlet-green). |
 | REQ-7 (`forge new` scaffold) | SHIPPED | `pub fn scaffold_project in cli.rs` writes `forge.toml`/`forge.lock` (`seed = {DEFAULT_SOLVER_SEED}`)/`THERMITE.skill.pin`; non-empty target → `ForgeError::Usage("… refusing to overwrite")`. Non-test consumer: `fn dispatch` (`Command::New` arm). Verification: `scaffold_writes_layout_and_refuses_clobber`. |
 | REQ-8 (`check` flags + engine routing) | SHIPPED | `Command::Check { file, json, level, rlimit, mutation_floor, engine }`; the parser defaults `engine` to `Auto`, and `fn run_check` sends normal L3 checks through `check_file_with_engine` for per-clause BV/EPR routing. Explicit `--engine verus` uses the byte-stable legacy entries; `(CheckLevel::L2, _)` uses `check_l2_file`. Verification: the flag parser tests, `engine_verus_flag_is_byte_identical_oracle`, automatic-route tests, and the engine disagreement halt. |
-| REQ-9 (usage-banner currency, #257) | SHIPPED | `fn usage_text in cli.rs` names all 14 verbs and the full flag surface including `[--engine verus|lean|auto]` — added by commit `6368550a` ("forge usage banner gains [--engine verus|lean|auto] (drift fix)"). Non-test consumer: `parse_args`'s no-verb and unknown-verb arms. Verification: `usage_errors` exercises both arms; `l2_check.rs` checks the banner rejects a bogus `--level`. |
+| REQ-9 (usage-banner currency) | SHIPPED | `fn usage_text in cli.rs` iterates `ForgeMethod::ALL`; method names and synopses share their source with parsing and the generated skill. |
 | REQ-10 (project assurance display, #10) | SHIPPED | `fn render_assurance in cli.rs` prints per-fn `lowered-assurance:` lines + the `project assurance:` headline; `run_check` computes `AssuranceManifest::aggregate(&certs)` once for both the display and the exit gate. Verification: `render_assurance_shows_headline_and_lowered_flags`, `render_assurance_shows_failed_headline`. |
+| REQ-11 (`forge skill`) | SHIPPED | `Command::Skill` dispatches to `run_skill`; canonical and Claude-compatible output are sourced from `thermite-skill`, with stdout, write, and check modes covered by unit tests. |
 
 ## Open questions
 
-- **OQ-1 (matcher scale):** the hand-rolled matcher survived to 14 verbs, but
+- **OQ-1 (matcher scale):** the hand-rolled matcher has grown substantially, but
   the per-verb flag loops duplicate the
   `--json`/unknown-flag/extra-positional boilerplate ~10 times and the
   value-taking-flag pattern (`iter.next().ok_or_else(Usage)`) ~9 times. The
   no-`clap` decision still pays (zero deps, precise diagnostics, REQ-9's
-  banner is the single grammar source) — but a shared flag-loop helper inside
-  `cli.rs` would cut the duplication without a dependency. Revisit if a 14th
-  verb lands.
+  registry is the method-level grammar source) — but a shared flag-loop helper
+  inside `cli.rs` would cut the duplication without a dependency. Revisit when
+  another flag-heavy method lands.
 - **OQ-2 (REPL views have no `--json`):** `goal`/`battery`/`edit`/`fill` emit
   human text only ("pure views — no flags"). An agent-facing machine form of
   the goal state is plausibly wanted by the #21 REPL arc; not designed here.
-- **OQ-3 (Appendix B `forge skill` verb):** Appendix B names a `skill` verb;
-  no such verb exists in `parse_args`. The skill artifact is generated by the
-  `thermite-skill` crate instead (#7 arc). Whether a CLI verb should front it
-  is unowned by this doc.
+- **OQ-3 (Appendix B `forge skill` verb):** RESOLVED. Forge fronts the
+  `thermite-skill` generator and can emit, write, or check both canonical and
+  Claude-compatible forms.
 - **OQ-4 (`SoundnessAlarm` exit class):** the uniform `fn exit_code` maps
   `SoundnessAlarm` to `EXIT_ENVIRONMENT` (2) — the same class as a missing
   binary. A soundness alarm is arguably a third kind of outcome (worse than

--- a/.design/lower/boundary-composition.md
+++ b/.design/lower/boundary-composition.md
@@ -2,7 +2,7 @@
 <!--
 tier: 3-component
 status: draft
-audited-content-sha256: 3158984f966b99063a28ce692db077fbdde6e4b6bc4a1969ae56d4a1dac282a6 (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 9629a375440c6e28914775c90610b4e7ce2e6beab3af0139982c5e8833ca4c2f (re-pinned 2026-07-30 for a comment-only clarification of the existing automatic BV/EPR overlay; boundary composition is unchanged)
 governs: thermite-lower/src/lower.rs, forge/src/check.rs
 thesis-refs:
   - thermite-design.md §9

--- a/.design/scaffold/workspace.md
+++ b/.design/scaffold/workspace.md
@@ -3,7 +3,7 @@
 tier: 3-component
 status: draft
 audited-sha: 5ae0816c042debb01c70eb9b89c775837f0c0f24 (content-sha256 re-pinned 2026-06-23 for stage-3 REQ-7 (#349), the Rust→Lean obligation exporter: the change to this doc's governed lib roots is additive — `mod lean_smt_export;` in forge/src/main.rs (the SMT-tactic obligation exporter module); the workspace/crate structure is otherwise unchanged. The legacy commit pin stays at the 5ae0816c stable-main ancestor; only the active content-sha256 digest moves. prior: 2026-06-20 stage-2 REQ-4 / AC-4 (#326) `pub mod classifier;` + `mod strat_tv;`; 2026-06-17 umbrella REQ-7 / AC-12 §6 metrics dashboard `mod metrics;`; stage-1 REQ-10/AC-14 G1 gate seven-verdict test module)
-audited-content-sha256: 2ea7841eacb6c286571ee0140eedb5837b86f5688ae77405284a73f485df70c4
+audited-content-sha256: 438a4eb179569ce233fbfbfaad738938588d62b7f0e8c29f09cb980f9fb1cfb2 (re-pinned 2026-07-30 after thermite-skill's crate root began re-exporting the shared Forge method registry and Claude renderer; workspace topology and dependencies are unchanged)
 governs:
   - Cargo.toml (virtual workspace manifest)
   - rust-toolchain.toml

--- a/.design/skill/skill-generator.md
+++ b/.design/skill/skill-generator.md
@@ -4,7 +4,7 @@
 tier: 3-component
 status: draft
 audited-sha: 92396428567edc6940a9e2845217f5ff4c2ea3c6 (re-pinned 2026-06-16, user-authorized: the only change to this doc's governed files since the prior pin is the additive stage-1 forge-tier increment 2a — the new Item::Forge surface + inert Item::Forge match arms, verified net-additive with no substantive removal of existing v1 logic (git log <main>..HEAD = the 8 forge commits); the v1 behavior this doc governs is unchanged, and the new forge-tier surface is specified in .design/stage1-forge-tier.md / REQ-S1-3)
-audited-content-sha256: 18bc37d3f4c06ccfc7137f4bfafeec744d64d8fb079d713e4fc583574596f9e9
+audited-content-sha256: d23215ddb533259f63d9eb1efc1d7d58ff8f7a7e3b6cfca1903299a630f9250e (re-pinned 2026-07-30 for the shared Forge method registry, Claude frontmatter renderer, current L4 routing text, and the 5,385-token generated reference)
 governs: thermite-skill/src/generate.rs
 thesis-refs:
   - thermite-design.md §2.2
@@ -27,7 +27,7 @@ token hard budget** that `thermite-design.md` §2.2 makes a pillar and §10 make
 CI gate.
 
 The skill has two content kinds, and **§10's "the skill IS the spec, no version
-skew" pillar is realized MECHANICALLY for the part that drifts**:
+skew" pillar is realized mechanically for the parts that drift**:
 
 1. The **SURFACE INVENTORY** (the drifty part — the language's constructs) is
    DYNAMIC, by one of two compiler-backed mechanisms (REQ-8):
@@ -48,6 +48,13 @@ skew" pillar is realized MECHANICALLY for the part that drifts**:
    rules, the §5.1 Forge framing, the §4.2 flat-closure rule) stays CURATED, but
    guarded by the committed-`==-generate()` freshness test (REQ-5) and the 6k-
    token budget gate (REQ-4) (REQ-11).
+
+The Forge method inventory is no longer prose. `ForgeMethod` and its metadata
+registry live in `thermite-skill`; Forge consumes the same registry to recognize
+top-level methods and build its usage text, while `render_forge` consumes it to
+write the skill. The dependency already points from Forge to `thermite-skill`,
+so this removes the old cycle concern without exposing Forge's private parsed
+`Command` values.
 
 The crate exposes `generate() -> String` (the library API) and a `thermite-skill`
 binary (`--emit`, `--check-budget`) that the CI gauntlet runs. The committed
@@ -78,12 +85,11 @@ exhaustive-match renderers (`render_{type,expr,item,pattern,effect,binop,prim}_a
 - **Owns** `thermite-skill/src/generate.rs` (the generator), `src/main.rs` (the
   `--emit` / `--check-budget` CLI), the committed `THERMITE.skill.md` at the repo
   root, the up-to-date `cargo test`, and the `--check-budget` CI step.
-- **Does NOT own** the Forge CLI verb `forge skill` (Appendix B). The v0.1
-  serving path is `cargo run -p thermite-skill -- --emit`; `forge skill` is a
-  deferred thin wrapper (OQ-3). NB: `forge` DEPENDS ON `thermite-skill` (per
-  `forge/Cargo.toml`), so the dependency edge runs forge → thermite-skill, not
-  the reverse — `thermite-skill` cannot import anything from `forge` (OQ-5,
-  REQ-11 honesty note on the forge command list).
+- **Owns** the public Forge method registry and the two generated skill formats:
+  canonical Markdown and Claude-compatible Markdown with frontmatter.
+- **Does NOT own** Forge's parsed arguments, dispatch, filesystem writes, or
+  exit-code behavior. Those remain in `forge/src/cli.rs`; Forge reads this
+  crate's registry and generated strings through its existing dependency.
 - **Does NOT mutate any toolchain enum.** The exhaustive-match mechanism READS
   the definitional enums (`thermite_syntax::Type`/`Expr`/`Item`/`Pattern`/
   `Effect`); it adds no variant and changes no AST. The doc adapts to the AST,
@@ -107,7 +113,7 @@ gap by pinning, per surface-inventory section, **WHICH mechanism keeps it fresh*
 | Item grammar | `thermite_syntax::Item` | exhaustive `match` (REQ-10) | **compiler** + AC-10 |
 | Pattern grammar | `thermite_syntax::Pattern` | exhaustive `match` (REQ-10) | **compiler** + AC-10 |
 | Effect atoms | `thermite_syntax::Effect` | exhaustive `match` (REQ-10) | **compiler** + AC-10 |
-| Forge command list | (none importable — see below) | curated table + freshness test | committed-==-generate (REQ-5) + AC-4 (OQ-5) |
+| Forge command list | `thermite_skill::ForgeMethod::ALL` | shared registry | Forge's exhaustive method dispatch + iterate-all coverage |
 | Thesis / ladder / slag / §5.1 framing prose | the design narrative | curated (REQ-11) | committed-==-generate (REQ-5) |
 
 **The exhaustive-`match` mechanism (REQ-10), and why it gives the compile-error-
@@ -158,22 +164,15 @@ SkillEntry` impl or a `static SKILL: &[…]` table. Rationale:
   rendered by exhaustive `match` so a new operator/primitive also compile-forces
   a skill entry.
 
-**The forge command list — the honest exception (OQ-5, REQ-11).** The task asks
-that the `forge` CLI `Command` enum also drive an exhaustive match. This is NOT
-mechanically achievable in `thermite-skill` for two grounded reasons read from
-the code: (a) `forge`'s `Command` enum is **private** (`enum Command` in
-`forge/src/cli.rs`, not `pub`), so it is not importable even in principle; and
-(b) `forge` **depends on** `thermite-skill` (`forge/Cargo.toml` lists
-`thermite-skill` as a dep), so `thermite-skill` importing `forge` would be a
-dependency CYCLE. The skill's Forge command section therefore stays a CURATED
-table, kept honest by the committed-`==-generate()` freshness test (REQ-5) and
-AC-4's verb-coverage assertion. This is documented as a deliberate, honest
-scoping of the §10 mechanism (the same posture REQ-3's original grammar-is-
-curated note took), NOT a deferral and NOT a code-change proposal. If the
-orchestrator wants the forge command list ALSO compile-forced, the cleanest path
-is to make `forge`'s `Command` enum `pub` and exhaustively match it in `forge`'s
-OWN `forge skill` renderer (which CAN see its own enum) — that is a `forge`-side
-change owned by the forge CLI design doc, recorded in OQ-5, not authored here.
+**The Forge command list.** `thermite-skill` owns a small public
+`ForgeMethod` enum plus one metadata record per variant (verb, synopsis, and
+plain-language purpose). A single macro invocation declares the enum and
+registry together, so there is no separately maintained list. Forge parses the
+first argument through this registry and exhaustively matches `ForgeMethod` to
+produce its private `Command`; the skill and usage banner iterate the same
+records. This preserves the dependency direction (`forge` →
+`thermite-skill`) and makes the public method surface mechanically current
+without exposing Forge internals.
 
 ## Requirements
 
@@ -225,12 +224,12 @@ change owned by the forge CLI design doc, recorded in OQ-5, not authored here.
 
 - **REQ-5 (committed `THERMITE.skill.md` + the up-to-date freshness check):** The
   generator's output is committed at the repo root as `THERMITE.skill.md`,
-  regenerated by `cargo run -p thermite-skill -- --emit > THERMITE.skill.md`. A
+  regenerated by `forge skill --write THERMITE.skill.md` (the lower-level
+  `cargo run -p thermite-skill -- --emit` stdout interface remains available). A
   `cargo test` asserts the committed bytes equal `generate()` exactly, so the
   committed skill can never go stale relative to the generator (§10 "no version
-  skew"). RETAINED unchanged — and is the freshness enforcer for the one surface-
-  inventory section that cannot be compiler-forced (the forge command list,
-  REQ-11/OQ-5). Source: §10; R-CHAR-3 (committed artifact == its generator).
+  skew"). `forge skill --check THERMITE.skill.md` exposes the same comparison to
+  contributors and CI. Source: §10; R-CHAR-3 (committed artifact == its generator).
   **SHIPPED** (`committed_skill_is_fresh`).
 
 - **REQ-6 (the `thermite-skill` bin — `--emit` / `--check-budget`):** a
@@ -244,7 +243,7 @@ change owned by the forge CLI design doc, recorded in OQ-5, not authored here.
   as a must-pass step. Source: §2.2/§10; `.design/scaffold/workspace.md` REQ-7.
   **SHIPPED** (the step is in `ci.yml`).
 
-### New REQs — the dynamic surface inventory (this amendment)
+### Dynamic surface requirements
 
 - **REQ-8 (the compiler-enforced no-staleness GUARANTEE — the key property):**
   The skill's SURFACE INVENTORY (the set of language constructs an agent must
@@ -261,7 +260,7 @@ change owned by the forge CLI design doc, recorded in OQ-5, not authored here.
   mechanical realization of the §10 "the skill IS the spec, no version skew"
   pillar (the curated-string version of which repeatedly drifted: it missed
   `forge build`, the sandbox, then the whole ADT/scheme/`Vec`/`String`/effects
-  basis). Source: `thermite-design.md` §10; §2.2. **NOT-STARTED** (blocker #84).
+  basis). Source: `thermite-design.md` §10; §2.2. **SHIPPED**.
 
 - **REQ-9 (recursion-scheme section is REGISTRY-DRIVEN from `schemes::all()`):**
   A new skill section (2b, after the combinator library) iterates
@@ -279,7 +278,7 @@ change owned by the forge CLI design doc, recorded in OQ-5, not authored here.
   production consumer (R-DEFER-1 — `schemes::all()` is an existing pub API; REQ-9
   is its skill consumer). Source: `thermite-design.md` §4.4 (closed built-in
   scheme set), §10 (anti-drift); `.design/basis/02-recursion-schemes.md` REQ-1.
-  **NOT-STARTED** (blocker #84).
+  **SHIPPED**.
 
 - **REQ-10 (type/expr/item/pattern/effect grammar is EXHAUSTIVE-MATCH-DRIVEN):**
   The surface-grammar section's CONSTRUCT INVENTORY — the type forms, the
@@ -299,22 +298,17 @@ change owned by the forge CLI design doc, recorded in OQ-5, not authored here.
   text is a skill concern, not an AST concern (R-DOC-1 — REQ-10 reads the enums,
   never mutates them). Source: `thermite-design.md` §4/§4.2/§4.4/§10;
   `thermite-syntax/src/ast.rs` (`enum Type`/`Expr`/`Item`/`Pattern`/`Effect`).
-  **NOT-STARTED** (blocker #84).
+  **SHIPPED**.
 
-- **REQ-11 (the explanatory PROSE stays curated + freshness-tested; the forge
-  command list is the honest exception):** The narrative that cannot be
+- **REQ-11 (the explanatory PROSE stays curated + freshness-tested):** The
+  narrative that cannot be
   mechanically derived from a registry or an enum — the thesis framing, the §6
   ladder semantics, the §8 slag rules, the §5.1 Forge framing, the §4.2 flat-
   closure rule, and the "removed from Rust" motivation — stays CURATED (REQ-3),
   guarded by the committed-`==-generate()` freshness test (REQ-5) and the 6k
-  budget gate (REQ-4). Additionally, the **forge command LIST** stays a curated
-  table (it cannot be exhaustive-match-driven: `forge`'s `Command` enum is
-  private and `forge` depends on `thermite-skill`, a cycle — OQ-5), kept honest by
-  REQ-5 + AC-4's verb-coverage assertion. This REQ pins the PROSE/DERIVED
-  boundary so the builder knows precisely what to keep as a string vs. what to
-  drive from a registry/enum. Source: §10; the dependency facts in
-  `forge/Cargo.toml` / `forge/src/cli.rs`. **NOT-STARTED** (blocker #84 — the
-  re-scoping lands with the refactor; the prose strings themselves are shipped).
+  budget gate (REQ-4). The Forge command list is excluded from this requirement:
+  it is generated from the shared method registry. This REQ pins the
+  prose/derived boundary. Source: §10. **SHIPPED**.
 
 ## Acceptance criteria
 
@@ -332,17 +326,11 @@ change owned by the forge CLI design doc, recorded in OQ-5, not authored here.
 - **AC-3 (ladder coverage — L0–L3 all present + the L0/slag clarification):**
   substring assertions, expected strings from §6. (REQ-3, REQ-11)
 
-- **AC-4 (forge / slag / grammar-keyword coverage):** `generate()` contains every
-  Appendix B forge verb (`forge new`/`goal`/`fill`/`edit`/`check`/`build`/
-  `battery`/`audit`/`skill`/`repair`), the three mandatory slag fields, and the
-  mandatory grammar clause keywords (`req`/`ens`/`fx`/`inv`/`dec`/`spec fn`/
-  `#[slag]`). Expected strings from Appendix B / §8 / §4. Note: `forge build` is
-  added to this list (it shipped in `forge/src/cli.rs` `Command::Build` and was
-  one of the historically-missed verbs). The curated table additionally carries
-  the post-Appendix-B SHIPPED verbs — `forge review` and the translation-
-  validation phases `forge tv` / `forge exec-tv` / `forge body-tv` (the
-  lowering-soundness program, epic #169/#162) — kept honest by the same REQ-5
-  freshness test. (REQ-3, REQ-11)
+- **AC-4 (Forge / slag / grammar-keyword coverage):** for every entry in
+  `ForgeMethod::ALL`, `generate()` contains its verb and synopsis. The test also
+  checks the three mandatory slag fields and grammar clause keywords
+  (`req`/`ens`/`fx`/`inv`/`dec`/`spec fn`/`#[slag]`). Adding a Forge method
+  expands this check automatically.
 
 - **AC-9 (recursion-scheme coverage — every entry in `schemes::all()`, with an
   example):** for every `SchemeSig` in `thermite_spec::schemes::all()`,
@@ -374,8 +362,7 @@ change owned by the forge CLI design doc, recorded in OQ-5, not authored here.
 
 - **AC-5 (committed `THERMITE.skill.md` == generate()):** the repo-root file's
   bytes equal `generate()` exactly (regeneration command in the failure message)
-  — the generated-file freshness check; the enforcer for the curated forge
-  command list (REQ-11). (REQ-5)
+  — the generated-file freshness check. (REQ-5)
 
 - **AC-6 (determinism — generate() is pure):** two `generate()` calls and two
   `--emit` runs are byte-identical; no timestamp/path/env/RNG/wall-clock content.
@@ -405,8 +392,8 @@ numbers (R-CITE-2b).
 `pub fn generate() -> String` concatenates the section renderers in §10 order:
 `render_grammar` (curated framing + the REQ-10 exhaustive-match construct
 inventory), `render_combinators` (REQ-2, registry-driven), `render_schemes`
-(REQ-9, registry-driven — NEW), `render_forge` (curated framing + the REQ-11
-curated verb table), `render_ladder` (curated prose), `render_slag` (curated
+(REQ-9, registry-driven), `render_forge` (curated framing + the shared
+`ForgeMethod` registry), `render_ladder` (curated prose), `render_slag` (curated
 prose). Pure: no I/O, env, clock, or RNG (R-CODE-5, AC-6).
 
 ### `render_combinators` — the shipped registry renderer (REQ-2)
@@ -501,12 +488,12 @@ rationale (a `thermite-design.md` §2.2 amendment), and does NOT silently overfl
 (R-SPEC-4). The conservative `/3.5` divisor over-counts vs. a real tokenizer, so
 the heuristic failing early is the safe direction.
 
-### The bin, the committed artifact, the forge boundary
+### The bin, the committed artifact, and Forge
 
 `--emit`/`--check-budget` (REQ-6), the committed `THERMITE.skill.md` + freshness
-test (REQ-5), and the `forge skill` boundary (OQ-3) are unchanged from the
-shipped #7 (see the original Architecture in this doc's history; the bin and
-freshness test gain nothing but the larger generated output).
+test (REQ-5), and the 6,000-token gate remain. Forge adds the user-facing
+`forge skill` wrapper: raw or Claude-compatible output can go to stdout, be
+written to a path, or be compared with an existing path.
 
 ## Verification
 
@@ -522,8 +509,8 @@ constants and the live registries/enums (R-CHAR-3):
   variant fails to compile). **AC-10 (ii):** assert a representative substring per
   current Stage-1–8 construct (`struct`, `enum`, `String`, `Vec`, `Box`, `is`,
   `match`, `StructLit`, deref, each effect atom) appears in `generate()`.
-- **AC-3/AC-4:** ladder labels + L0/slag clarification; forge verbs (incl.
-  `forge build`), slag fields, grammar keywords.
+- **AC-3/AC-4:** ladder labels + L0/slag clarification; every
+  `ForgeMethod::ALL` entry, slag fields, and grammar keywords.
 - **AC-5:** `committed_skill_is_fresh` reads repo-root `THERMITE.skill.md` and
   asserts `== generate()`.
 - **AC-6:** `assert_eq!(generate(), generate())` + a no-timestamp grep.
@@ -551,7 +538,7 @@ determinism tests above, not by the cert oracle (which is forge / thermite-lower
 | REQ-8 (compiler-enforced no-staleness GUARANTEE) | SHIPPED | #84. The surface inventory is rendered ONLY by registry iteration (`render_combinators`/`render_schemes`) or by exhaustive `match` with NO `_` arm (`render_{type,expr,item,pattern,effect,binop,prim}_arm` in `generate.rs`); consumed by `render_grammar`/`render_schemes` in `generate`. A new variant FAILS TO COMPILE (`E0004`); a new registry entry auto-renders. Verified: `surface_construct_coverage` (output, in `tests/skill.rs`) + `renderers_are_exhaustive_no_wildcard` (structural, the no-`_` invariant; the green build is the compile-forced proof). The committed skill's "no struct/enum" lie is gone (the test asserts `!contains("no \`struct\`")`). |
 | REQ-9 (recursion-scheme section registry-driven from `schemes::all()`) | SHIPPED | #84. `render_schemes in generate.rs` iterates `thermite_spec::schemes::all()`, renders each `SchemeSig`'s call shape (`scrutinee_args` + `step_shape`) + `SchemeResult` + one `scheme_example_for` example; consumed by `generate`. This is `thermite-skill`'s non-test consumer of `schemes::all()` (R-DEFER-1). Verified: `every_scheme_appears_with_an_example` (AC-9) iterates `schemes::all()` and asserts name + call shape per entry. The 5 schemes (`fold`/`map`/`for_all`/`exists`/`traverse`) now appear in the committed skill. |
 | REQ-10 (type/expr/item/pattern/effect grammar exhaustive-match-driven) | SHIPPED | #84. `render_{type,expr,item,pattern,effect,binop,prim}_arm in generate.rs` are exhaustive `match`es (NO `_` arm) over `thermite_syntax::{Type,Expr,Item,Pattern,Effect,BinOp,PrimType}`, each arm a `SkillFragment { fragment, description, example }`; driven over per-variant inventories (`type_inventory`/`item_inventory`/`expr_inventory`/`pattern_inventory`/`effect_inventory`/`prim_inventory`/`binop_inventory`) by `render_grammar`. Verified: `surface_construct_coverage` asserts the Stage-1–8 surface (`struct`/`enum`, `Box`/`Vec`/`String`, `is`/`*`/`StructLit`/`match`, each effect atom). |
-| REQ-11 (prose curated + freshness-tested; forge command list the honest exception) | SHIPPED | #84. The irreducible PROSE stays curated in `render_grammar`'s framing + `render_forge`/`render_ladder`/`render_slag`; the forge verb LIST stays a curated table (forge's `Command` is private + `forge` → `thermite-skill` dep, so it cannot be compile-forced from here — OQ-5), kept honest by `committed_skill_is_fresh` (REQ-5/AC-5) + `forge_slag_grammar_markers_present` (AC-4). #199 (post-#193/#164 currency + readability): `HEADER` gained the "How to read this file / 60-second workflow" comprehension intro; `render_grammar`'s Statements prose gained the `?N` body-hole token + the `forge goal`/`fill` tie-in (`.design/forge/goal-repl.md` REQ-4); `render_forge`'s curated table gained `forge build --target kernel` (the `no_std`+`alloc` rlib; ambient-syscall `fx` refused — `.design/build/kernel-target.md` REQ-1/REQ-3). Concise-rendering trims kept `--check-budget` at 5,988 ≤ 6,000. #257 (proof-backends currency, post-pin — verified at the #262 re-audit): `render_forge`'s curated table gained the `forge check --engine lean|auto` row, `render_ladder`'s L3 line now reads "machine proof (Verus/Z3; or Lean via `--engine`)", and the `forge build --target kernel` row was TRIMMED to hold the budget — still 5,988 ≤ 6,000 (`budget_gate` + `committed_skill_is_fresh` green). |
+| REQ-11 (prose curated + freshness-tested) | SHIPPED | The irreducible prose stays curated in `render_grammar`'s framing and `render_ladder`/`render_slag`/the Forge introduction. The Forge method list is generated from `ForgeMethod::ALL`, consumed by Forge parsing/help and checked by iterate-all tests. `committed_skill_is_fresh` and the token budget guard the resulting document. |
 
 ## Open questions (for the orchestrator before the builder runs)
 
@@ -565,19 +552,15 @@ determinism tests above, not by the cert oracle (which is forge / thermite-lower
   grammar fragments are generator-side, NOT fields on `SchemeSig` / the AST enums.
   RECOMMENDATION: keep examples/fragments generator-side. Not a blocker.
 
-- **OQ-3 (`forge skill` ownership):** RESOLVED at #7 — `--emit` is the v0.1
-  serving path; `forge skill` is a deferred thin wrapper. Unchanged.
+- **OQ-3 (`forge skill` ownership):** RESOLVED — `thermite-skill` owns the
+  generated content and formats; Forge owns the user-facing print/write/check
+  command.
 
-- **OQ-5 (the forge command list — can it be compile-forced?):** NO, not from
-  `thermite-skill`: `forge`'s `Command` enum is PRIVATE (`enum Command` in
-  `forge/src/cli.rs`) and `forge` DEPENDS ON `thermite-skill` (`forge/Cargo.toml`),
-  so importing it would be a private-item access AND a dependency cycle. The skill
-  keeps a curated forge-verb table, freshness-tested (REQ-5) + verb-coverage-
-  asserted (AC-4). RECOMMENDATION (for the orchestrator, NOT authored here): if
-  the forge command list should ALSO be compile-forced, make `forge::Command`
-  `pub` and put an exhaustive-match `forge skill` renderer in `forge` itself
-  (which can see its own enum) — a `forge`-side change owned by `.design/forge/
-  cli.md`. Flagged; not a blocker for this component.
+- **OQ-5 (the Forge command list — can it be compile-forced?):** RESOLVED. The
+  public `ForgeMethod` registry lives in the dependency both consumers can
+  already see. Forge's private parser exhaustively matches its variants; the
+  skill and usage text iterate the same registry. No dependency cycle or public
+  parsed-command type is required.
 
 - **OQ-6 (exhaustive `match` vs. `trait SkillEntry`/`SKILL: &[…]` table — the
   DECISION):** this doc DECIDES the exhaustive `match` in `generate.rs` (REQ-10

--- a/.design/stage4-epr-reconstruction.md
+++ b/.design/stage4-epr-reconstruction.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: shipped
-audited-content-sha256: 61a1208f3f224ffbd4798b1d853f779cf34acb383f632904d05dd94a646c5a90
+audited-content-sha256: 3bf5f4ca9ef2439c201525d8d336225d04bbb10b30f2b55080b3e1a84b27480b (re-pinned 2026-07-30 for a comment-only clarification of the already-shipped automatic routing behavior)
 governs: canonical S₂.0 bridge, typed Lean reconstruction, production routing,
          audit boundary, proof tooling, and Gate G4 (see tooling/spec-routes.toml)
 -->

--- a/.design/stage4-epr-reconstruction.md
+++ b/.design/stage4-epr-reconstruction.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: shipped
-audited-content-sha256: 3bf5f4ca9ef2439c201525d8d336225d04bbb10b30f2b55080b3e1a84b27480b (re-pinned 2026-07-30 for a comment-only clarification of the already-shipped automatic routing behavior)
+audited-content-sha256: bf98d22e303f34628e7e3daffe7cd2c69fe0765bd0bcd060cfeb6433e1b91413 (re-pinned 2026-07-30 after CI began prebuilding the EPR replay/model modules before parallel nextest processes)
 governs: canonical S₂.0 bridge, typed Lean reconstruction, production routing,
          audit boundary, proof tooling, and Gate G4 (see tooling/spec-routes.toml)
 -->
@@ -148,6 +148,9 @@ Rust/Lean/solver differential tests, the axiom allowlist, and the absence of
 `sorry`, `admit`, custom axioms, and `native_decide`. The gate applies a 6 GiB
 address-space ceiling, serializes Rust tests and reconstruction runs, and uses
 one Lean worker so the same command is safe on low-memory builders.
+The sharded CI jobs prebuild `Thermite.Strat.EprReplay` and
+`Thermite.Strat.TestModel` before nextest starts, so separate test processes do
+not race to compile the shared Lean artifacts.
 
 ## Acceptance criteria
 

--- a/.design/verified/proof-backends.md
+++ b/.design/verified/proof-backends.md
@@ -3,7 +3,7 @@
 <!--
 tier: 3-component
 status: draft (v-next architecture — the obligation/engine interface; most REQs NOT-STARTED
-audited-content-sha256: 8e809a4bc5f6df0599fbe458d9feb6b5b7c2a418b7806edec4a9ea3b2637e81c (migrated from legacy audited-sha commit pin to a squash-stable content digest; doc-drift-tripwire.md REQ-2 — content pin is primary, commit pin is a migration fallback)
+audited-content-sha256: 00615f3a7ed31e346b6763b4fb4fbbe582c24a768d6211076ce304ab15300267 (re-pinned 2026-07-30 for a comment-only clarification that Auto includes Lean fallback and checked BV/EPR overlays; backend behavior is unchanged)
         behind build blockers. The SHIPPED substrates this builds on are quoted-code-grounded.)
 governs: forge/src/check.rs + forge/src/degrade.rs + forge/src/manifest.rs (the discharge
          pipeline, the ladder, the certificate this interface generalizes) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,8 @@ jobs:
           Thermite.Exec.Stmt
           Thermite.Exec.WhileBody
           Thermite.Strat.Cls.Wire
+          Thermite.Strat.EprReplay
+          Thermite.Strat.TestModel
           Thermite.Reconstruct
 
       - name: Install toolchain (pinned to rust-toolchain.toml channel)
@@ -329,17 +331,19 @@ jobs:
         # `Exec.WhileBody` (NOT the root `Thermite`, which pulls the cvc5-FFI `SmtDemo`);
         # the REQ-4 differential battery runs `lake env lean --run Thermite/Strat/Cls/Wire.lean`,
         # which needs `Thermite.Strat.Cls.Wire` built (it pulls Fragment/Graph/Nnf
-        # transitively). The old monolithic job got the Strat oleans for free from the
-        # axiom-probe's `lake build`; this split moved the probe to `lean-probe`, so the
-        # forge job must build Wire itself. Without these the live tests fail with
-        # "unknown module prefix 'Thermite'" / "spine may not be built". Incremental on a
-        # warm `.lake` cache.
+        # transitively). EPR tests run as separate nextest processes, so EprReplay and
+        # TestModel must also be built here instead of racing to compile them inside
+        # each test process. The old monolithic job got the Strat oleans for free from
+        # the axiom-probe's `lake build`; this split moved the probe to `lean-probe`.
+        # Incremental on a warm `.lake` cache.
         run: >-
           lake build
           Thermite.Stabilize
           Thermite.Exec.Stmt
           Thermite.Exec.WhileBody
           Thermite.Strat.Cls.Wire
+          Thermite.Strat.EprReplay
+          Thermite.Strat.TestModel
           Thermite.Reconstruct
 
       - name: Install Rust toolchain (pinned)

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -134,10 +134,12 @@ a smaller trusted base. The downward degrade above applies to an *inconclusive
 in-cage* goal (a solver timeout); an obligation the decidable cage cannot hold at
 all now escalates **up** to the **forge** — an agent-authored proof term checked
 by the Lean 4 kernel, falsified first by a mandatory covenant — instead of the
-whole function sliding down. This forge tier and the L4 relax route are the
-Stage-1 deliverable of the Thermite 2 program ([RFC-1, GH #2](https://github.com/dollspace-gay/Thermite/issues/2)); today only the relax
-route reaches L4, and lifting the whole cage to L4 (a stratified-FOL spine
-extension) is Stage 2.
+whole function sliding down. This forge tier and the L4 relax route were the
+Stage-1 deliverable of the Thermite 2 program
+([RFC-1, GH #2](https://github.com/dollspace-gay/Thermite/issues/2)). The
+shipped ladder now also places reconstructed fixed-width BV clauses and
+admitted finite relation/array clauses at L4. Plain `forge check` selects those
+routes automatically when a clause qualifies.
 
 ---
 
@@ -785,31 +787,25 @@ verified-microkernel convergence (§13).
 their own machine, ending with the honest residual-trust statement. The README's
 "don't trust us — audit it."
 
-**Mechanism.** `Makefile` `audit` target → `scripts/audit.sh` runs six checks:
-**[1]** builds the `lean/` spine from source and parses `#print axioms` for the
-five load-bearing theorems (`lowering_faithful`, `ref_sound`, `exec_ref_sound`,
-`body_ref_sound`, `while_rule`), passing only if each depends on nothing beyond
-`{propext, Classical.choice, Quot.sound}` (no `sorry`, no custom axiom);
-**[2]** full-corpus translation validation (`forge tv`/`exec-tv`/`body-tv` over
-every `conformance/` program, zero divergences); **[3]** the falsification
-battery (inject known translation-bug classes, assert Z3 catches each) + one
-visible end-to-end mutant; **[4]** the Rust↔Lean correspondence drift tripwire
-(pinned SHAs vs current); **[5]** the committed proof re-verified under
-third-party Verus/Z3 with `forge` excluded; **[6]** the verdict + the residual
-trust statement. Each guarantee-bearing check **skips visibly** (degrading the
-verdict to `INCONCLUSIVE`, nonzero exit) when its tool is absent, so it cannot be
-mistaken for a pass. `make audit-fast` is the 60-second A/B demo. See
+**Mechanism.** `make audit` runs five primary checks plus the Stage-2 G2 gate:
+the Lean spine and axiom allowlist; full-corpus contract/expression/body
+translation validation; a multi-class falsification battery; the Rust↔Lean
+correspondence drift tripwire; and an independent Verus replay with Forge
+excluded. G2 additionally combines the stratified axiom probe, mirrored-code
+drift check, Rust↔Lean classifier differential, and two-phase faithfulness
+sweep through `forge g2-gate`.
+
+The script then prints the verdict and residual-trust statement. A missing
+guarantee-bearing tool is a visible skip that makes the result `INCONCLUSIVE`
+and nonzero; it cannot be mistaken for a pass. `make audit-fast` is the
+60-second A/B demo. See
 [`.design/forge/audit-manifest.md`](.design/forge/audit-manifest.md) for the
 `forge audit` manifest format.
 
-**What each check re-derives, and the residual.** Checks [1]–[5] re-derive,
-respectively, the universal faithfulness theorem (the auditor's Lean kernel), the
-per-run TV agreement (the auditor's Z3, every corpus program), the falsification
-teeth, the correspondence-non-drift, and the third-party proof re-check. What
-remains **trusted** after a clean run (check [6]'s list): the Lean kernel + its
-three standard axioms; Z3/Verus soundness (with the `z3-demotion.md` PoC already
-covering the scalar core); the spec↔intent gap; the pinned inspection audit;
-rustc/LLVM. Everything else is re-derived on the auditor's machine.
+**Residual trust.** After a clean run, the script still names the Lean kernel
+and its three standard axioms, the remaining solver assumptions, the
+specification-to-intent gap, the pinned inspection audit, and rustc/LLVM. It
+does not pretend these assumptions disappeared.
 
 **Why this design.** A trust statement is only useful if it enumerates its
 assumptions, so the audit lists the residual trust items rather than claiming

--- a/README.md
+++ b/README.md
@@ -1,64 +1,34 @@
 # Thermite
 
-**A programming language where the code has to prove it works.**
+Thermite is a programming language for code that must explain why it is
+correct. Functions state:
 
-*Every plain-language term in this README resolves to a precise mechanism in [RATIONALE.md](RATIONALE.md).*
+- `req`: what callers must establish;
+- `ens`: what the function guarantees;
+- `fx`: what the function may affect.
 
-> Thermite is what you get when you add energy to rust. Iron oxide plus aluminum: inert powder until ignited, then it burns at 2,500 °C and cuts through steel. Take Rust's substrate, add the energy budget AI agents bring (compute, patience, token spend), and produce something hot enough to weld trust into software.
+Forge checks those contracts, returns concrete counterexamples when they fail,
+and records the result in an assurance manifest. The long-term goal is simple:
+compose a small set of known primitives in known-safe ways.
 
-## The problem
+Thermite is experimental research software. The complete build and proof stack
+is currently tested on x86-64 Linux, including Ubuntu and WSL2. The Rust crates
+may build elsewhere, but the Verus distribution, Lean/CVC5 bridge, and
+seccomp-backed runtime path are Linux-oriented.
 
-When an AI writes code for you, how do you know it's right? Today the answer is "read it yourself" or "trust the vibes." Neither scales. Code review by humans is the bottleneck AI was supposed to remove, and "the tests pass" only covers the cases somebody thought to test.
-
-Formal verification — mathematically proving code correct — has existed for decades. It never caught on because writing the proofs is expensive for humans, who pay for it in attention. Agents pay in compute, which is cheap and parallel. Thermite's bet is that this flips the economics of proof: burn the cheap resource (tokens) to buy the expensive one (trust).
-
-Thermite is strict in a way no human would tolerate, because humans are not the intended author. People decide what the software should do and read the resulting certificates; the agent writes the proofs.
-
-## How it works, in plain terms
-
-Every function carries three promises, enforced as syntax. Leaving one out is a compile error:
-
-- `req` — *"here's what must be true before you call me"* (e.g. "the list is sorted")
-- `ens` — *"here's what I guarantee about my answer"* (e.g. "if I return an index, the item is really there")
-- `fx` — *"here's everything I'm allowed to touch"* (e.g. "nothing — I'm pure", or "I may read this one file")
-
-Each promise is graded on a **five-rung ladder by *refutation quality*** — how good the evidence is when a promise fails — and `forge` aims for the top rung. An obligation the prover's decidable **cage** cannot hold no longer slides *down* the ladder; it escalates *up* to the **forge**, a kernel-checked proof tier (see [RATIONALE.md](RATIONALE.md#the-ladder-l4--l3--l2--l1--l0)):
-
-| Rung | What it means |
-|---|---|
-| **L4** | A **kernel-grounded** proof. For nonlinear arithmetic, the relax route discharges the claim over the reals (Z3's nlsat) and ties it back to the integers through a **Lean-kernel-checked soundness lemma**. |
-| **L3** | A machine-checked proof that the promise holds for every input — SMT-backed deductive verification via the Verus prover and the Z3 logic engine, **or**, for an obligation past the decidable cage, an agent-authored proof term checked by the Lean 4 kernel. |
-| **L2** | Proven for all inputs up to a stated size. (Bounded model checking, via Kani/CBMC.) |
-| **L1** | The promise is checked **while the program runs**; violations stop it on the spot. (Runtime contract monitoring.) |
-| **L0** | Trusted by fiat. The escape hatch, spelled `#[slag]` (a greppable [trusted-code annotation](RATIONALE.md#slag), cf. `unsafe`/`axiom`/`admit`), so `grep slag` lists every line taken on faith. |
-
-An item lands at the highest rung it reaches. A counterexample — a concrete input where the promise fails, such as n = 3 — is a hard failure; it is never recorded as a lower grade. (Today **L4** is the kernel-grounded relax route for nonlinear arithmetic; ordinary cage proofs sit at L3, and lifting the whole decidable cage to L4 is the next stage of the [Thermite 2 program](https://github.com/dollspace-gay/Thermite/issues/2).)
-
-Grading also covers the contract itself. A promise that promises nothing (`ens true`) would pass trivially, so every contract goes through an anti-Goodhart battery ([vacuity detection plus mutation testing](RATIONALE.md#the-vacuity-battery-the-anti-goodhart-layer)): it is checked for emptiness, then run against mutant copies of the code that introduce bugs. A contract that fails to catch them is rejected.
-
-The `fx` promise is enforced at runtime as well. When you build a binary, Thermite derives a syscall filter (seccomp-BPF, the kernel mechanism Docker and Chrome use; see [RATIONALE.md](RATIONALE.md#the-cage--seccomp-sandbox)) from the declared effects. A function that declared `pure` and then opens a network connection is killed by the OS mid-syscall. The static effect check and the runtime cage come from the same `fx` declaration.
-
-An agent writes Thermite incrementally. Declare the contract with a hole where the body goes (`?0`, a [typed hole](RATIONALE.md#typed-holes-n--the-goal-repl), the Agda/Idris/Lean `sorry` idea). `forge goal` shows what is given and what must hold; `forge fill` puts code in the hole and re-checks, returning counterexamples on failure. Repeat until `ALL GOALS DISCHARGED ✓ certified L3`. An item with an unfilled hole cannot be built or certified.
-
-Thermite translates to Rust annotated for the [Verus](https://github.com/verus-lang/verus) prover (which uses the Z3 logic engine), so it inherits Rust's compiler, optimizer, and ecosystem. The specification language is a small [caged quantifier fragment](RATIONALE.md#the-combinator-cage): a fixed set of bounded combinators with frozen SMT triggers and no raw `forall`. That fragment is what makes the [soundness proof](RATIONALE.md#the-frozen-subset-the-central-design-why) below feasible. The full design rationale lives in [`thermite-design.md`](./thermite-design.md).
-
-## A worked example
-
-We built a text editor in Thermite — a small one, like a tiny nano you run in a terminal. Its editing logic, line navigation, and cursor math are proven correct for every input (L3), and it runs inside the syscall cage with only the permissions its `fx` declares. (See [`examples/editor/`](examples/), plus a formatter, a calculator, and a CSV parser, all proven and runnable.)
-
-Here is a function that sums a list, with its three promises:
+## A small example
 
 ```thermite
 fn sum(xs: &[u32]) -> u64
-  req xs.len() <= 1_000_000        // what I need
-  ens result == spec_sum(xs)       // what I guarantee
-  fx  pure                         // what I touch: nothing
+  req xs.len() <= 1_000_000
+  ens result == spec_sum(xs)
+  fx  pure
 {
   let mut acc: u64 = 0;
   let mut i: usize = 0;
   while i < xs.len()
-    inv acc == spec_sum(&xs[..i])  // why this loop is right
-    dec xs.len() - i               // why this loop ends
+    inv acc == spec_sum(&xs[..i])
+    dec xs.len() - i
   {
     acc = acc + xs[i] as u64;
     i = i + 1;
@@ -67,168 +37,307 @@ fn sum(xs: &[u32]) -> u64
 }
 ```
 
-`forge check` turns that into a certificate (a JSON manifest; [schema](RATIONALE.md#the-certificate)): proven for all inputs, promise non-empty, mutants killed. `forge build` turns it into a runnable binary with the cage enabled.
+`forge check` proves the contract or reports why it could not. `forge build`
+lowers the program to Rust with runtime contract checks; hosted executables are
+confined by an `fx`-derived seccomp filter unless the sandbox is explicitly
+disabled.
 
-## Audit it yourself
+## Install
 
-The repo ships an audit ([`make audit`](RATIONALE.md#make-audit)) that re-derives the trust chain on your machine:
+There are two useful installation levels:
+
+1. A Rust-only build compiles Forge and the supporting crates.
+2. The full proof stack also installs Verus, Lean, Z3, and the pinned
+   reconstruction tools. Use this if you want meaningful `forge check`, the
+   complete test suite, or the trust-chain audit.
+
+The commands below match the versions used by CI. Allow several gigabytes of
+disk for Rust, Verus, Lean, Mathlib, and solver caches.
+
+### 1. System packages
+
+On Ubuntu or Debian:
 
 ```sh
-make audit        # the full re-derivation (slow — minutes)
-make audit-fast   # the 60-second demonstration (one program, one injected bug)
+sudo apt-get update
+sudo apt-get install --yes \
+  build-essential ca-certificates clang curl git \
+  libc++-dev libc++abi-dev python3 unzip util-linux z3
 ```
 
-The fast version shows the essentials: a correct program certifies; the same program with one injected bug is refused with a counterexample; and the emitted proof re-verifies under an independent copy of the prover, with our tooling excluded.
+What these provide:
 
-The deep version re-checks every link of the guarantee: your own Lean proof checker re-verifies the central theorem (described below), the translation cross-checks re-run over every program in the test corpus (thousands of live proof obligations), and the forty-odd sabotage tests re-run to confirm the prover catches each known class of translation bug. At the end it prints the list of what you are still trusting (five items, mostly industry-standard tools). If any tool is missing it says so and refuses to claim success.
-
-<details>
-<summary><b>The six checks</b> (click to expand)</summary>
-
-- **[1] The universal theorem, re-verified by <i>your</i> Lean kernel.** Builds the [`lean/`](lean/) proof spine from source and checks the axiom footprint of the five load-bearing theorems (`lowering_faithful`, `ref_sound`, `exec_ref_sound`, `body_ref_sound`, `while_rule`); passes only if each depends on nothing beyond `{propext, Classical.choice, Quot.sound}`, with no `sorry` and no custom axioms. Skips (and downgrades the verdict) if Lean isn't installed.
-- **[2] Full-corpus translation validation.** Runs `forge tv` / `exec-tv` / `body-tv` over every program in [`conformance/`](conformance/); requires zero divergences across thousands of live Z3-checked obligations; prints skip reasons.
-- **[3] The falsification battery.** Runs the live "teeth" suites that inject known classes of translation bugs (wrong operator, dropped parenthesis, mis-dispatched method, swapped match arms, dropped statements, broken loop invariants…) and asserts Z3 catches every one — plus one visible end-to-end mutant for legibility.
-- **[4] Correspondence drift tripwire.** The Rust encoders are tied to their Lean models by an arm-by-arm [inspection audit](.design/verified/rust-lean-correspondence.md) that pins the exact commits inspected; this check fails if the code has drifted past its audit.
-- **[5] Third-party prover re-check.** The committed proof re-verifies under your own Verus/Z3 with `forge` excluded.
-- **[6] The residual-trust statement.** Pass requires 1–5; then it prints exactly what remains trusted: the Lean kernel + its three standard axioms; Z3/Verus soundness (with a [kernel-replay proof-of-concept](.design/verified/z3-demotion.md) already covering part of it); the gap between formal spec and human intent; the pinned inspection audit; rustc/LLVM. Everything else was re-derived on your machine.
-
-A run with a skipped guarantee prints `INCONCLUSIVE` and exits nonzero.
-</details>
-
-## How the translation is verified
-
-Thermite translates your code into the prover's language, so a buggy translator could prove the wrong statement — promise `=`, prove `≤`, and the certificate would read L3 while the code is wrong. Two mechanisms prevent that, both machine-checked:
-
-1. Per run: a second, independent translator (forbidden by the build system from sharing code with the first) re-translates your contracts and bodies, and Z3 must prove the two translations equivalent on your program. A mistranslation does not pass the check.
-2. Across all programs: that independent translator is small enough to prove correct in Lean. The theorem ([`lean/`](lean/), `Thermite.lowering_faithful`) states that every program passing the cross-check is translated meaning-for-meaning; it is quantified over all programs, checked by Lean's kernel, and re-checkable by yours (audit check [1]). Each translation bug previously found by testing is now refuted by that theorem.
-
-This is the [verified-validator architecture](RATIONALE.md#translation-validation--the-lean-proof-spine) from the compiler-verification literature (the CompCert lineage: translation validation plus a kernel-checked Lean proof spine). Thermite's meaning is defined by the Lean semantics; Verus is the first proof engine against it, proven faithful.
-
-Lean is also a second proof engine. [`forge check --engine lean|auto`](RATIONALE.md#proof-backends-the-second-engine) discharges proof obligations in Lean directly, kernel-checked, with a replay that rejects `sorry` and non-standard axioms; the certificate records which engine proved each obligation and under which trust assumptions. If the two engines contradict each other on the same obligation (one proves it, the other produces a counterexample), `forge` halts with a soundness alarm rather than resolving the disagreement by preference.
-
-## What works today
-
-The language is complete enough to write real programs, and the pipeline (prove, build, run, cage) works end to end.
-
-- A general-purpose surface: integers, strings, vectors, maps, structs/enums with invariants, pattern matching, tuples, recursion (including mutual), `for`/`while` loops, `Option`/`Result` — all provable to L3.
-- Four finished example programs, all proven and runnable — including the sandboxed text editor.
-- The conversational workflow (`forge goal` / `fill` / `edit`) with holes, for incremental agent-driven development.
-- A [`--target kernel`](RATIONALE.md#the-kernel-target) build mode that emits freestanding, OS-less libraries (the road toward a verified microkernel) — code that needs ambient OS access is refused at compile time.
-- Two independent proof engines: L3 obligations are discharged by Verus by default, or by Lean under `--engine lean|auto`. Each certificate names the engine and its trust assumptions, and an engine disagreement halts the run with a soundness alarm.
-- The toolchain verifies its own soundness-critical core in Verus, and the translation layer carries the Lean theorem above.
-- Built almost entirely by AI agents, adversarially: every component was audited by an independent critic agent, and every divergence found (dozens) was pinned by a failing test and fixed.
-
-<details>
-<summary><b>The full component inventory</b> (click to expand — dense, for the technically inclined)</summary>
-
-- ✅ **Frontend** (`thermite-syntax`) — lexer, recovering per-item parser, AST (literals keep verbatim text), stable semantic addressing
-- ✅ **SpecTherm** (`thermite-spec`) — the frozen bounded-combinator registry + the cage validator (no anonymous nested quantifiers; closure bodies are flat predicates)
-- ✅ **Lowering** (`thermite-lower`) — Thermite → Verus (L3), Kani harnesses (L2), executable Rust + always-active runtime checks (L1); compile-time effect-row subsumption; a `req`-bounded `var*var` overflow proof aid discharges multiplication overflow from declared bounds
-- ✅ **Forge** (`forge`) — `check` (per-item certificate with content-addressed proof caching), the goal-state REPL (`goal`/`fill`/`edit`/`battery` over `?N` holes — a holed item never certifies), `build` (native binary with runtime checks + the fx-derived seccomp sandbox; `--target kernel` emits a freestanding `no_std`+`alloc` rlib and refuses ambient-syscall `fx`), `audit`, `review`, `repair`, and the translation-validation phases `tv`/`exec-tv`/`body-tv` (four-way `Faithful`/`Divergent`/`Unverifiable`/`Skipped`, skips honest, divergences loud). An obligation past the decidable cage **escalates to the forge tier** (an L3 Lean-kernel proof, falsified first by a mandatory covenant) rather than degrading; *within* the cage a solver timeout still degrades L3 → L2 → L1, and a counterexample never degrades. Every obligation settles to one of **seven verdicts** (`Proved`/`Counterexample`/`RealWitness`/`CovenantRefuted`/`Stuck`/`KernelBudget`/`Timeout`) — none silently becomes `Proved`.
-- ✅ **Anti-Goodhart battery** — structural vacuity triage, solver tautology/unsat-precondition checks, mutation scoring with a kill-ratio floor (excluding only prover-proved-equivalent mutants), strengthening probes
-- ✅ **Boundaries** — crates.io FFI + `#[slag]` modules, L1-enforced and runtime-confined to their declared `fx`; the manifest distinguishes *verified-to-the-boundary* from *verified, period*
-- ✅ **Self-verification** (`thermite-verified`) — the soundness-critical pure core is itself Verus-verified (`--no-cheating`, no `assume`/`external_body`): effect subsumption, the degrade anti-cheat, the seccomp allowlist, the boundary honesty gate, project aggregation, the mutation floor
-- ✅ **Proof backends** ([`.design/verified/proof-backends.md`](.design/verified/proof-backends.md)) — the backend-neutral Obligation + `Engine` interface with Verus and Lean as independent L3 engines (`forge check --engine verus|lean|auto`); per-obligation engine attribution (`{engine, trust_profile}`) in the certificate; the engine-disagreement soundness alarm (`Proven ⊕ Refuted` on the same obligation halts the run — never resolved by preference); interactive Lean proofs with hardened kernel replay (evidence-key staleness gate, `sorry`/non-standard-axiom rejection, and the canonical-reconstruction architecture that closed five generations of elaborator-injection bypasses); the engine-generic mutation battery; the exec-body bridge for straight-line bodies
-- ✅ **Fixed-width clauses and checked reconstruction** ([`.design/stage3-bv-reconstruction.md`](.design/stage3-bv-reconstruction.md)) — `ens@bvN`, `inv@bvN`, and `@bvN(nowrap)` use explicit 8/16/32/64-bit semantics with certificate shadows, width-aware mutation, and fail-closed overflow checks. QF_LIA and QF_BV solver results move to kernel trust only after Lean accepts the route's actual `req → clause` theorem and its axiom report.
-- ✅ **Universal lowering soundness** (`thermite-tv` + [`lean/`](lean/)) — per-run translation validation by an independent reference encoder + the kernel-checked Lean proof spine (`ref_sound` over all 8 contract construct classes, `exec_ref_sound`, `body_ref_sound`, the loop `while_rule`, composed into `lowering_faithful`); 13+ negative lemmas machine-refute the historical infidelity classes; arm-by-arm Rust↔Lean [correspondence audit](.design/verified/rust-lean-correspondence.md); [checked replay](.design/verified/z3-demotion.md) covers QF_LIA and the shipped QF_BV surface
-- ✅ **The verified primitive basis** (Stages 1–8) + the **primitive-completeness campaign** (C1–C12) — recursive ADTs with invariants, recursion schemes with prove-once induction laws, the contracted effect stdlib, bounded collections, compositional reasoning (callers verify *through* callee contracts; assurance aggregates as the honest min), security-by-construction marked types (SQL injection is *untypeable*), strings, and the full ergonomics layer (destructuring, `for`, guards, or-patterns, `if let`, `Map<K,V>`)
-- ✅ **`THERMITE.skill.md`** — the entire language in ≤ 6,000 tokens, regenerated from the compiler's own definitions (a new construct without a skill entry is a compile error), CI-gated
-- 🔭 Deferred (tracked): direct MIR-level lowering (transpile-to-Verus stands in, #21); the contract-TV parallel seam (#166); the basis v1.1 layer; widening the Lean engine's exportable fragment past straight-line bodies (#253); and the named proof-spine residuals — full Z3 demotion (upstream-gated), the Lean→Rust extraction bridge, user-ADT `match`/`is` in the proven fragment
-
-Roadmap v0.1 → v0.5: all shipped (milestones #1–#5 closed).
-</details>
-
-## Repository layout
-
-| Path | What |
+| Package | Used for |
 |---|---|
-| [`thermite-design.md`](./thermite-design.md) | The design document — why Thermite exists and how it's meant to work |
-| [`goal.md`](./goal.md) | The binding contract for the AI agents that build Thermite (the ACToR loop + anti-drift rules) |
-| `conformance/` | Golden test programs with hand-certified expected results — the oracle the toolchain is checked against |
-| [`examples/`](examples/) | The proven, runnable programs (editor, formatter, calculator, parser) + how to build and run each |
-| `.design/` | Per-component design docs — each part of the toolchain answers to one |
-| `tooling/` | The enforcement gates (no editing a component without reading its design; no stubs/TODOs) |
-| [`lean/`](lean/) | The kernel-checked Lean proof spine (`ref_sound` → … → `lowering_faithful`) + the Lean-SMT demotion PoC |
-| `.claude/agents/` | The four ACToR sub-agents that build this repo — auto-discovered by Claude Code (see below) |
-| `thermite-*/`, `forge/` | The toolchain itself: `thermite-syntax`, `thermite-spec`, `thermite-lower`, `thermite-tv` (translation validation), `thermite-verified`, `forge` (the CLI), `thermite-skill` |
+| `git`, `curl`, `ca-certificates`, `unzip` | Fetching pinned Rust, Lean, Verus, CVC5, and solver artifacts |
+| `build-essential`, `clang`, `libc++-dev`, `libc++abi-dev` | Building the Stage 4 SAT tools and Lean's CVC5 bridge |
+| `python3` | Repository gates and proof-artifact checks |
+| `util-linux` | `prlimit`, used by the memory-bounded G4 gate |
+| `z3` | Normal reconstruction and G4 checks; Verus also ships its matching private Z3 |
 
-## Working on Thermite as an agent — the ACToR loop
+You do not need a system CVC5 package. Lean's pinned dependency downloads the
+matching CVC5 distribution and builds its bridge.
 
-Thermite is built by AI agents using a four-role adversarial loop, and everything an
-agent needs to work the repo **ships in the repo**:
+### 2. Rust
 
-- **`goal.md`** — the binding contract: the full ACToR loop, the verification model
-  (corpus + golden oracles), **R-CHAR-3** (the toolchain never authors its own
-  oracle), and the anti-drift rules. Read it first, every session.
-- **`THERMITE.skill.md`** — the entire surface language + toolchain in ≤ 6,000 tokens,
-  generated from the registry (CI-gated). Load it as context before writing any `.th`.
-- **`.claude/agents/acto-*.md`** — the four sub-agents below, auto-discovered by Claude
-  Code as the `acto-doc-author` / `acto-builder` / `acto-critic` / `acto-fixer`
-  subagent types (dispatch them with the Task/Agent tool — no setup needed).
-- **`tooling/`** (tracked — ships + fires on a fresh clone) — the enforcement layer:
-  the **spec-discipline gate** (`spec-discipline.py`: a routed file can't be edited
-  until its `.design/` doc exists), the **anti-pattern gate** (`anti-pattern-gate.py`:
-  no stubs/TODOs), and the **route table** (`spec-routes.toml`: which file maps to
-  which design doc). `.claude/settings.json` (also tracked) wires these into Claude
-  Code's `PreToolUse`/`PostToolUse` events, so they enforce automatically — no setup.
-  That last sentence is itself CI-checked: `crosslink init` regenerates
-  `settings.json` from a generic template and once silently dropped both gates for
-  a whole stage (#93), so the **control-plane gate** (`control-plane-check.py`,
-  `make control-plane`) asserts every hook the docs claim is live is actually wired,
-  and the route table pins the control plane under `doc-drift.py`.
-- **`.claude/hooks/`** (gitignored — environment infra, *not* project source) — the
-  crosslink issue-tracking + session machinery (`work-check.py` = an active issue is
-  required before any edit, plus session/heartbeat/prompt hooks). These are regenerated
-  by `crosslink init` and depend on the `crosslink` CLI + the `.crosslink/` DB, so they
-  ship with the *harness*, not the repo. Every hook in `settings.json` is guarded with
-  `if [ -f "$HOOK" ]` — so a clone **without** crosslink degrades them to no-ops while
-  the `tooling/` gates still fire.
-
-### Setting up a fresh clone
-
-The verification gates work immediately (`tooling/` + `settings.json` are tracked). To
-also get the crosslink issue-tracking discipline (the `acto-*` agents assume it), install
-the `crosslink` CLI and run `crosslink init` at the repo root —
-it regenerates `.claude/hooks/` + the `.crosslink/` DB and leaves the tracked
-`settings.json` (with its `tooling/` wiring) intact. Without it, you can still build and
-verify; you just won't get the issue-before-edit enforcement.
-
-### The four roles
-
-| Agent | Does | Never |
-|---|---|---|
-| **acto-doc-author** | Writes `.design/<area>/<doc>.md` grounded in real code + the thesis; classifies each REQ **SHIPPED** or **NOT-STARTED** (+ a blocker #). | Touches toolchain code. |
-| **acto-builder** | Ships a missing component against a pre-declared ≤ ~10-file manifest; tests + production in one commit. | Widens scope mid-dispatch. |
-| **acto-critic** | Adversarially audits a "done" claim; pins each divergence as a **failing test** + files a `-l blocker`. | Fixes anything. |
-| **acto-fixer** | Minimal fix for **one** pinned divergence, root cause in the owning crate. | Bundles fixes / refactors. |
-
-The loop: **doc-author → (orchestrator hand-authors the R-CHAR-3 oracle) → builder →
-critic → (GENERATOR MUST FIX) → fixer → critic → … until clean.** Every builder/fixer
-on novel code is followed by a critic. A "divergence" is anchored to two things the
-toolchain may not author for itself — the **conformance corpus**
-(`conformance/<name>.cert.json`) and the **Verus golden lowerings**
-(`tests/golden/lower/<name>.verus.rs`).
-
-### Session start (any Claude on this machine)
-
-1. Read `goal.md`.
-2. Load the language reference. Install it once as a user-level skill so every future
-   session auto-discovers it (or just read `THERMITE.skill.md` directly):
-   ```sh
-   mkdir -p ~/.claude/skills/thermite
-   { printf -- '---\nname: thermite\ndescription: Thermite language + Forge toolchain reference.\n---\n\n'; cat THERMITE.skill.md; } > ~/.claude/skills/thermite/SKILL.md
-   ```
-3. Work the loop. The orchestrator stays hands-on-the-wheel: load context, hand off
-   implementation with a clear manifest, and **verify every result** — read the diff,
-   re-run the gauntlet, cross-check the critic. Agents are capable and also make
-   mistakes; the loop's adversarial structure is what keeps them honest.
-
-Every change must pass the gauntlet (also the CI gate in `.github/workflows/ci.yml`):
+Install rustup if necessary:
 
 ```sh
-cargo build --workspace
-cargo test --workspace          # with `verus` on PATH for the L3 tier
+curl --proto '=https' --tlsv1.2 -sSf \
+  https://sh.rustup.rs -o /tmp/rustup-init.sh
+sh /tmp/rustup-init.sh -y
+. "$HOME/.cargo/env"
+```
+
+The repository's [`rust-toolchain.toml`](rust-toolchain.toml) selects Rust
+1.95.0 and installs `rustfmt` and Clippy automatically.
+
+For a Rust-only build:
+
+```sh
+cargo build --release -p forge
+```
+
+To put Forge on your path:
+
+```sh
+mkdir -p "$HOME/.local/bin"
+install -m 0755 target/release/forge "$HOME/.local/bin/forge"
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Add that `PATH` export to your shell profile if `~/.local/bin` is not already
+present.
+
+### 3. Verus
+
+Thermite's L3 path invokes `verus` from `PATH`. Install the exact CI release:
+
+```sh
+VERUS_VERSION="0.2026.05.24.ecee80a"
+VERUS_ROOT="$HOME/.local/share/thermite/verus-$VERUS_VERSION"
+
+mkdir -p "$VERUS_ROOT" "$HOME/.local/bin"
+curl -fsSL -o /tmp/verus.zip \
+  "https://github.com/verus-lang/verus/releases/download/release/$VERUS_VERSION/verus-$VERUS_VERSION-x86-linux.zip"
+unzip -q /tmp/verus.zip -d "$VERUS_ROOT"
+VERUS_BIN="$(find "$VERUS_ROOT" -type f -name verus -print -quit)"
+test -n "$VERUS_BIN"
+ln -sf "$VERUS_BIN" "$HOME/.local/bin/verus"
+verus --version
+```
+
+Keep the Verus directory intact: its binary expects the bundled Rust toolchain
+and Z3 beside it.
+
+### 4. Lean and the proof spine
+
+Install elan, then let the repository select Lean 4.29.0:
+
+```sh
+curl -fsSL \
+  https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+  -o /tmp/elan-init.sh
+bash /tmp/elan-init.sh -y --default-toolchain none
+export PATH="$HOME/.elan/bin:$PATH"
+
+cd lean
+lake exe cache get
+lake build
+cd ..
+```
+
+`lake exe cache get` is important: without the prebuilt Mathlib cache, a first
+build can spend hours rebuilding dependencies.
+
+### 5. Checked BV and EPR reconstruction
+
+Normal release builds include fixed-width `@bvN` syntax and automatic routing.
+The finite relation/array reconstruction path additionally needs the exact
+CaDiCaL and `drat-trim` revisions pinned in
+[`scripts/g4-toolchain.env`](scripts/g4-toolchain.env):
+
+```sh
+bash scripts/install-g4-tools.sh
+```
+
+They are installed under `target/g4-tools`. Forge finds that directory
+automatically when run from this checkout. The G4 gate also exports explicit
+paths before it runs:
+
+```sh
+bash scripts/g4-gate.sh
+```
+
+The gate applies a 6 GiB address-space ceiling and serializes the expensive
+work, so it is suitable for smaller development machines.
+
+### 6. Optional: Kani for explicit L2 checks
+
+Kani is only needed for `forge check --level l2` and the live Kani tests:
+
+```sh
+cargo install --locked kani-verifier --version 0.67.0
+cargo kani setup
+```
+
+Kani installs its own nightly Rust and CBMC toolchain. It is not required for a
+normal L3/L4 check.
+
+### Dependency check
+
+After installing the full stack:
+
+```sh
+rustc --version
+cargo --version
+verus --version
+lake --version
+z3 --version
+python3 --version
+
+cargo build --release -p forge
+forge check conformance/sum.th
+```
+
+Missing proof tools are errors in the proof-bearing gates; they are not treated
+as successful skips.
+
+## Everyday Forge commands
+
+The complete method list is generated from the same registry the CLI parses:
+
+```sh
+forge check program.th
+forge goal program.th item
+forge fill program.th item.?0 'replacement code'
+forge build program.th --entry main --out ./program
+forge audit program.th
+forge skill
+```
+
+Run `forge` with no arguments for the current full synopsis. The primary
+workflow is:
+
+1. Write the contract and leave a hole if the body is unfinished.
+2. Run `forge check`.
+3. Read the counterexample or open goal.
+4. Use `goal`, `fill`, or `edit`, then check again.
+5. Build only after every required obligation is discharged.
+
+## Assurance levels
+
+The level records refutation quality; each clause separately records its engine
+and trust profile.
+
+| Level | Meaning |
+|---|---|
+| **L4** | An admitted decidable route with checked reconstruction and concrete failures: nonlinear relaxation, fixed-width BV, or finite EPR relation/array clauses |
+| **L3** | An all-input machine proof through Verus/Z3 or the Lean engine |
+| **L2** | A bounded Kani/CBMC result with the bound recorded |
+| **L1** | An always-active runtime contract check |
+| **L0** | Body trusted by fiat through the explicit `#[slag]` escape hatch |
+
+Plain `forge check` uses automatic routing, including eligible BV and EPR
+reconstruction. A counterexample is a failure, never a downgrade. Timeouts and
+unsupported shapes remain named outcomes rather than being laundered into a
+proof.
+
+For the detailed trust argument, see [RATIONALE.md](RATIONALE.md) and
+[thermite-design.md](thermite-design.md).
+
+## Generated skill and Claude Code
+
+[`THERMITE.skill.md`](THERMITE.skill.md) is the generated language and Forge
+reference. Its surface grammar comes from exhaustive compiler matches, its
+combinators and methods come from registries, and CI keeps it below 6,000
+estimated tokens.
+
+Regenerate or check the canonical copy:
+
+```sh
+forge skill --write THERMITE.skill.md
+forge skill --check THERMITE.skill.md
+```
+
+Install the matching Claude Code skill:
+
+```sh
+forge skill --claude --write "$HOME/.claude/skills/thermite/SKILL.md"
+forge skill --claude --check "$HOME/.claude/skills/thermite/SKILL.md"
+```
+
+The `--claude` form adds the required frontmatter. It is generated from the
+same content as the committed reference, so there is no hand-maintained Claude
+copy to drift.
+
+The tracked `.claude/agents/` files and repository gates support the ACToR
+development workflow. Crosslink is optional issue/session infrastructure; it is
+not a Thermite build dependency.
+
+## Tests and audits
+
+Focused development checks:
+
+```sh
+cargo test -p thermite-skill
+cargo test -p forge
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all --check
-cargo run -p thermite-skill -- --check-budget
+python3 tooling/doc-drift.py
+tooling/reqs check
 ```
+
+Run the Rust/control-plane gauntlet with:
+
+```sh
+make gauntlet
+```
+
+Proof-bearing gates:
+
+```sh
+bash scripts/g3-gate.sh
+bash scripts/g4-gate.sh
+make audit-fast
+make audit
+```
+
+`make audit` re-derives the trust chain, including the Lean axiom probe,
+translation-validation batteries, correspondence drift checks, and independent
+Verus replay. A missing guarantee-bearing dependency makes the final result
+inconclusive and nonzero.
+
+On a memory-constrained machine, keep Rust compilation and test execution
+serial:
+
+```sh
+CARGO_BUILD_JOBS=1 cargo test --workspace -- --test-threads=1
+```
+
+## Examples and repository map
+
+Runnable examples live under [`examples/`](examples/):
+
+- [`editor`](examples/editor/README.md)
+- [`calculator`](examples/calculator/README.md)
+- [`formatter`](examples/formatter/README.md)
+- [`parser`](examples/parser/README.md)
+
+Important paths:
+
+| Path | Purpose |
+|---|---|
+| [`THERMITE.skill.md`](THERMITE.skill.md) | Generated language and Forge reference |
+| [`thermite-design.md`](thermite-design.md) | Language and verification design |
+| [`RATIONALE.md`](RATIONALE.md) | Plain-language trust rationale |
+| [`goal.md`](goal.md) | Repository development and anti-drift contract |
+| [`conformance/`](conformance/) | Hand-authored programs and certificate oracles |
+| [`lean/`](lean/) | Lean proof spine and checked reconstruction |
+| [`.design/`](.design/) | Component-level requirements and audit pins |
+| [`tooling/`](tooling/) | Documentation, requirement, and anti-pattern gates |
+| `thermite-*`, `forge/` | Compiler, verifier, translation validator, and CLI crates |
+
+## License
+
+Thermite is open source under the [MIT License](LICENSE).

--- a/THERMITE.skill.md
+++ b/THERMITE.skill.md
@@ -1,26 +1,16 @@
-# THERMITE.skill.md
+# Thermite language and Forge reference
 
-The complete Thermite v0.1 surface language and toolchain, in one file. This is
-the canonical language definition (`thermite-design.md` §10): an agent reads it
-at session start and holds the entire language in context. It is GENERATED — do
-not edit by hand. Regenerate with:
+This generated file matches the toolchain that produced it. Do not edit it by
+hand; refresh it with `forge skill --write THERMITE.skill.md`. The canonical
+file stays below the 6,000-token CI budget.
 
-    cargo run -p thermite-skill -- --emit > THERMITE.skill.md
+Start with a contract-first `fn`: write `req`, `ens`, and `fx`, then its body.
+Run `forge check <file>`. Fix any concrete counterexample, or leave a `?0` hole
+and use `forge goal` and `forge fill`. A function with a hole never certifies.
 
-Budget: this file must stay under 6,000 tokens (a hard CI gate, design §2.2).
-
-## How to read this file — the 60-second workflow
-
-You write verified code. The loop: (1) write a `fn` CONTRACT-FIRST — `req`/`ens`/`fx`,
-THEN the body (§1); the contract is mandatory. (2) `forge check <file>` (§3) returns a
-PER-OBLIGATION result — each goal discharged or `Failed` with a CONCRETE
-counterexample (e.g. `lo=3, hi=3`), never a bare "verification failed". (3) Fix and
-re-check; or drop a HOLE `?0` (§1) and work `forge goal`/`forge fill` — a holed item
-never certifies.
-
-Map: §1 grammar, §2/§2b combinators + recursion schemes (the ONLY way to
-quantify/recurse), §3 Forge verbs, §4 the assurance ladder, §5 `#[slag]`, §6 the
-forge tier (verdicts, routing, covenants, proofs).
+Sections: grammar (§1), bounded combinators and recursion schemes (§2/§2b),
+Forge methods (§3), assurance levels (§4), `#[slag]` (§5), and the forge proof
+tier (§6).
 
 ## 1. Surface grammar
 
@@ -260,38 +250,33 @@ The schemes (call shape, result, then one example each):
 - `exists(l, |x| …) -> bool`
   // scheme: exists(list, |x| x == needle)
 
-## 3. Forge command set
+## 3. Forge methods
 
-Forge is your interface — a goal-state REPL. Every reply inlines the source and
-returns a CONCRETE counterexample, not an adjective, when an obligation fails, and
-DEGRADES (L3 -> L2 -> L1) rather than blocking on a solver timeout. Day-to-day:
-`check`, `goal`/`fill` (work open holes), `build` (runnable binary).
+Use `check` for normal certification, `goal`/`fill` for open holes, and `build`
+for artifacts. Failures carry witnesses; timeouts remain named resource events.
+Plain `check` automatically routes eligible fixed-width and finite EPR clauses
+through checked reconstruction.
 
-```
-forge new <name>                   create project (manifest, lockfile, skill pin)
-forge check [item]                 run the ladder; per-obligation results +
-                                   counterexamples (your primary verb)
-forge check --engine lean|auto|nlsat|forge   pick the engine (§6.2); disagree = HALT
-forge goal <item> [--proof]        goal state: given / want / open holes ?N
-                                   (--proof = the forge-tier proof view, §6.4)
-forge fill <fn>.?N <code>          splice code at hole ?N + re-check (may surface
-                                   new holes); proof holes ?pN too (§6.4)
-forge edit <addr> --replace <code> splice at any semantic address + re-check
-forge build [item] --entry <fn>    lower to Rust + rustc -> a native binary whose
-                                   contract checks fire at runtime, fx-sandboxed
-forge build --target kernel <file> freestanding no_std+alloc rlib (no main/seccomp,
-                                   panic=abort); ambient-syscall fx is REFUSED
-forge battery [item]               run vacuity battery + mutation scoring
-forge audit                        full slag + boundary + assurance inventory
-forge review <file> [item]         pluggable spec-intent review slot
-forge tv | exec-tv | body-tv <file>   translation-validate the CONTRACT / exec
-                                   EXPRESSION / exec BODY lowering vs the reference
-forge skill                        emit the canonical THERMITE.skill.md
-forge repair [item]                background L1/L2 -> L3 upgrade loop
-```
+- `forge new <name>` — Create a pinned project.
+- `forge check <file> [--json] [--level l2|l3] [--rlimit FLOAT] [--mutation-floor FLOAT] [--engine auto|verus|lean|nlsat|forge|bv]` — Certify; auto-routes eligible BV and EPR clauses.
+- `forge audit <file> [--json] [--meaning] [--metrics]` — Show assurance, boundaries, meaning, and metrics.
+- `forge repair <file> [item] [--json]` — Retry timeout-lowered items.
+- `forge review <file> [item] [--json] [--reviewer <cmd>]` — Emit contracts for intent review.
+- `forge build <file> [--entry <fn>] [--out <path>] [--target std|kernel] [--json] [--no-sandbox] [--sandbox-self-test]` — Build checked Rust; sandbox hosted executables.
+- `forge tv <file> [--generated [N]] [--seed <u64>] [--json]` — Validate contract lowering.
+- `forge exec-tv <file> [--generated [N]] [--no-generated] [--json]` — Validate expression lowering.
+- `forge strat-tv [--generated N] [--seed <u64>] [--json]` — Compare Rust and Lean cage classifiers.
+- `forge strat-faithful-tv [--generated N] [--seed <u64>] [--json]` — Run two-phase stratified validation.
+- `forge g2-gate --axiom-probe 0|1 --doc-drift 0|1 --differential 0|1 --two-phase 0|1 [--json]` — Combine the Stage 2 gate results.
+- `forge body-tv <file> [--json]` — Validate statement and loop lowering.
+- `forge goal <file> [item] [--proof]` — Show goals, witnesses, and holes.
+- `forge battery <file> [item]` — Show vacuity and mutation results.
+- `forge edit <file> <addr> --replace <code> | forge edit --restratify [--json]` — Edit by address or demonstrate restratification.
+- `forge fill <file> <hole-addr> <code>` — Fill a body or proof hole.
+- `forge smt-export [<file>] [--out <path>]` — Export Rust-to-Lean SMT obligations.
+- `forge skill [--claude] [--write <path> | --check <path>]` — Print, write, or check this reference.
 
-Items and blocks have stable semantic addresses (`binary_search.loop#1.inv#2`,
-a hole is `<fn>.?N`); `edit`/`fill` take addresses, not string matches.
+Items and blocks have stable semantic addresses such as `binary_search.loop#1.inv#2`; holes use `<fn>.?N` or `<fn>.?pN`.
 
 ## 4. Verification ladder
 
@@ -299,8 +284,9 @@ Every function targets L3; downgrades are automatic, logged, and surfaced in the
 build manifest; upgrades are a standing background task. The certificate lists every
 function's level — this manifest IS the deliverable's trust statement.
 
-- L4 — KERNEL-grounded proof: the relax route's nlsat discharge, trust `solver(nlsat)
-  + spine-lemma(kernel)` (§6.2). The top rung, above L3.
+- L4 — admitted, decidable clauses with checked reconstruction: nonlinear
+  relaxation, fixed-width BV, and finite EPR relation/array clauses. Failures
+  carry a real, bit-pattern, or finite-structure witness.
 - L3 — machine proof (Verus/Z3, or Lean via `--engine`): holds for ALL inputs. Not
   guaranteed to terminate -> solver budget + automatic downgrade.
 - L2 — bounded model check (Kani/CBMC): holds for all inputs UP TO a bound (stated
@@ -350,70 +336,47 @@ The polarity inversion is the point: verification is the default and free;
 non-verification is the exotic add-on that costs more keystrokes and visibility.
 ## 6. Forge tier (Stage-1)
 
-Beyond exec contracts the forge proves PROPOSITIONS. Forge items: `prop fn` (a bool
-spec predicate), `lemma N(..) req .. ens .. { proof }`, `proof for f` (discharge one
-`ens#k` of an exec `fn`), and `witness { .. }` covenants.
+The forge tier proves propositions as `prop fn`, `lemma`, or `proof for f`
+items. A `witness` block gives its covenant.
 
 ### 6.1 The seven verdicts
 
-`forge check` settles every clause to ONE of seven cert-level verdicts (a closed
-set; no "Unknown" survives into a cert). What each means, and your move:
+Every clause receives one final verdict:
 
-- **Proved** — holds for ALL inputs at the clause's level. Done.
-- **Counterexample** — a witnessed countermodel with concrete inputs (e.g. `lo=3,
-  hi=3`). Hard fail, never degrades — fix the body or the contract.
-- **RealWitness** — the `ens` is false over the REALS (a real point, e.g. √2) though
-  it may hold over ℤ; escalated UP to you, never downgraded to a Counterexample. Add
-  the integrality `req` so the relaxation can't reach it.
-- **CovenantRefuted** — a `falsify` input refuted the covenant: the carried
-  counterexample IS the bug. Hard fail — fix the body/contract, never weaken `falsify`.
-- **Stuck** — the proof elaborated but left a residual `⊢ goal`; it carries the goal +
-  a missing-bridge hint. Add the named simp bridge from the frozen battery and re-check.
-- **KernelBudget** — Lean's kernel/elaboration budget (heartbeats) was exhausted: a
-  budget event, NOT a refutation. Split the lemma or shrink the proof.
-- **Timeout** — the SMT solver hit its rlimit: a resource event, not a refutation.
-  Lower the goal or raise `--rlimit`.
+- **Proved** — holds at the stated level.
+- **Counterexample** — concrete failing inputs; fix code or contract.
+- **RealWitness** — false over the reals but possibly true over integers; add the
+  missing integrality `req`.
+- **CovenantRefuted** — `falsify` found a contract violation.
+- **Stuck** — Lean left a residual `⊢ goal`; add the named bridge.
+- **KernelBudget** — Lean exhausted its budget; split or shrink the proof.
+- **Timeout** — SMT exhausted its rlimit; simplify or raise `--rlimit`.
 
 ### 6.2 Routing + per-clause attribution
 
-Each clause routes by its SHAPE; the cert attributes `engine`/`trust`/`verdict` PER
-CLAUSE, so you read which machine carried it at what trust:
+Certificates record `engine`, `trust`, and `verdict` per clause:
 
-- a RELAXABLE polynomial clause — universal over integer-scalar params, atoms from
-  only `+ - *`, comparisons, and `&&`/`||` (NO `/ % << >> & | ^`, no `as`) → the
-  **nlsat** engine (Z3 QF_NRA), at **L4** (`solver(nlsat) + spine-lemma(kernel)` —
-  the kernel-checked real→ℤ bridge).
-- an in-cage v1 contract → **verus**, at **L3** (an SMT solver proof).
-- a `lemma` / `proof for` → the **lean** engine, at **L3** (the Lean-kernel base).
+- relaxable integer polynomials → **nlsat** plus the kernel-checked real-to-integer
+  bridge, at **L4**;
+- an `@bvN` fixed-width clause → QF_BV solving plus Lean replay of the actual
+  theorem, at **L4**; false returns a bit pattern;
+- an admitted finite S₂.0 relation/sequence clause → grounded SAT plus LRAT and
+  Lean replay, at **L4**; false returns a finite model;
+- an ordinary in-cage contract → **verus**, at **L3**;
+- a `lemma` or `proof for` item → **lean**, at **L3**.
 
-`--engine forge` drives this hybrid per-clause route end to end; `--engine
-nlsat|verus|lean` pins a single engine.
+Plain `forge check` uses automatic routing. `--engine
+auto|nlsat|verus|lean|forge|bv` selects a diagnostic override.
 
 ### 6.3 Covenant authoring
 
-A `witness { inhabit (..); falsify N; }` block covenants the `fn` it immediately
-FOLLOWS in source order — the covenant-BEFORE-burn gate: a forge-routed `fn` must
-PASS its covenant before any proof is attempted (structural).
-
-- `inhabit (args)` — an author-stated witness that `req` is inhabited. At least ONE
-  is MANDATORY; each tuple's arity + types must match the params, and each must
-  SATISFY `req` (an `inhabit` that fails `req` is a loud author error, refused before
-  burn).
-- `falsify N` — draw N inputs from the deterministic SplitMix64 generator (default
-  fixed-seed `falsify 50_000`), run each body, check the contract. A `req`-satisfying
-  input whose body breaks `ens` is a **CovenantRefuted** hit, carried into the cert.
-
-A covenant that refutes — or whose `inhabit` set is missing, ill-typed, or
-`req`-violating — blocks the burn: you never prove a `fn` whose witnesses already
-break it.
+`witness { inhabit (args); falsify N; }` follows the function it covenants.
+At least one well-typed `inhabit` tuple must satisfy `req`. `falsify N` checks a
+deterministic sample; any violation yields **CovenantRefuted** and blocks proof.
 
 ### 6.4 Forge-tier verbs + the burn receipt
 
-- `forge goal <f> --proof` — the PROOF VIEW of a forge-routed goal (`lemma` / `proof
-  for f`): its hypotheses in scope, the `⊢ goal`, and any open `?pN` PROOF holes.
-- `forge fill <f>.?pN <proof>` — splice proof text at a `?pN` proof hole and re-check
-  (the proof analogue of body-hole `fill`; may surface new `?pN`).
-- closing an L3/L4 goal attaches a **burn receipt** to the cert: the lexer-token
-  count of the committed proof, the lemmas it cited, and (optionally) the LLM
-  authoring spend. It records HOW MUCH proof was spent, never WHAT was proved —
-  oracle-excluded, so it never changes the verdict.
+- `forge goal <f> --proof` shows hypotheses, the goal, and open `?pN` holes.
+- `forge fill <f>.?pN <proof>` fills a proof hole and re-checks.
+- A closed L3/L4 goal gets a **burn receipt** recording proof size and cited
+  lemmas. This metadata never changes the verdict.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -24,15 +24,16 @@ aims for the top rung and records where each clause landed.
 
 | Rung | Meaning |
 |---|---|
-| **L4** | A kernel-grounded proof. The nonlinear-arithmetic route combines a Z3 nlsat result with Lean-checked soundness lemmas that connect the real relaxation back to integer semantics. |
-| **L3** | A machine-checked proof that the clause holds for every input. (SMT-backed deductive verification via the Verus prover and the Z3 solver.) |
+| **L4** | An admitted decidable route with checked reconstruction and concrete failures: nonlinear relaxation, fixed-width bit-vectors, or finite relation/array clauses. |
+| **L3** | A machine-checked proof that the clause holds for every input through Verus/Z3 or the Lean engine. |
 | **L2** | Proven for all inputs up to a stated size. (Bounded model checking, via Kani/CBMC.) |
 | **L1** | Checked while the program runs; a violation stops it. (Runtime contract monitoring.) |
 | **L0** | Trusted by fiat — the `#[slag]` escape hatch, greppable so the trusted lines are enumerable. |
 
 A function's level is the minimum over its clauses. A counterexample — a
 concrete input where a clause fails — is a hard failure; it is never recorded
-as a lower grade.
+as a lower grade. Plain `forge check` automatically routes eligible BV and EPR
+clauses through their L4 reconstruction paths.
 
 [Verification](verification.md) explains how the upper rungs are discharged and
 re-checked. [Trust](trust.md) lists what remains trusted after a clean run.

--- a/forge/src/check.rs
+++ b/forge/src/check.rs
@@ -224,8 +224,9 @@ pub enum EngineSelection {
     /// (with the smaller trust base, attributed); a non-exportable item is reported as
     /// a skip (the Lean engine `Unknown`, not a false verdict).
     Lean,
-    /// `--engine auto`: Verus first; on a Verus Unknown/timeout, try Lean (the §6
-    /// ordering — Verus push-button common case, Lean as the smaller-base fallback).
+    /// `--engine auto`: run the base Verus path, use Lean on an eligible
+    /// Unknown/timeout, and overlay checked BV/EPR reconstruction for admitted
+    /// clauses. This is the normal CLI default.
     Auto,
     /// `--engine nlsat` (`.design/stage1-forge-tier.md` REQ-8 / Q-NLSAT / AC-12,
     /// increment 2f): the relax route — the [`crate::engine::NlsatEngine`] only. A

--- a/forge/src/cli.rs
+++ b/forge/src/cli.rs
@@ -1,10 +1,8 @@
-//! `forge/src/cli.rs` — the command surface of the `forge` driver. It parses
-//! `argv` with a minimal hand-rolled matcher (REQ-2, not a derive macro),
-//! dispatches `forge new <name>` and `forge check [<file>] [--json]`, renders the
-//! certificate as human-readable text or (under `--json`) the §5.1 structured
-//! JSON, and owns [`ForgeError`] — the boundary error that aggregates each driven
-//! crate's error (`thermite_syntax::SyntaxError`, `thermite_spec::SpecError`,
-//! `thermite_lower::LowerError`) plus driver-native verus/io/usage variants.
+//! Forge's command-line boundary. It parses the shared top-level
+//! [`ForgeMethod`] registry with a small hand-written flag parser, dispatches
+//! private [`Command`] values, and renders either readable text or the stable
+//! JSON form requested by a method. [`ForgeError`] preserves errors from the
+//! driven crates and adds CLI, process, and filesystem failures.
 //!
 //! Governing design: `.design/forge/cli.md`.
 //!
@@ -39,6 +37,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use thermite_lower::LowerError;
+use thermite_skill::{forge_usage, generate, generate_claude, ForgeMethod};
 use thermite_spec::SpecError;
 use thermite_syntax::SyntaxError;
 
@@ -282,9 +281,9 @@ enum Command {
         /// low value (e.g. `0.2`) flips a weak contract back to certified (AC-3).
         mutation_floor: f64,
         /// The proof-backend engine (`--engine verus|lean|auto|nlsat`; `.design/verified/
-        /// proof-backends.md` OQ-1, #247). `verus` (the default) is byte-identical; `lean`
-        /// runs the LeanEngine only (exportable items discharged by Lean, attributed);
-        /// `auto` runs Verus first and tries Lean on a Verus Unknown/timeout.
+        /// proof-backends.md` OQ-1, #247). The CLI defaults to `auto`, which preserves
+        /// the base Verus result and adds eligible Lean, BV, and EPR routing. Explicit
+        /// `verus` keeps the byte-identical legacy path.
         engine: check::EngineSelection,
     },
     /// `forge audit <file> [--json] [--meaning]` — emit the project audit manifest v1
@@ -535,6 +534,18 @@ enum Command {
         file: Option<PathBuf>,
         out: Option<PathBuf>,
     },
+    /// `forge skill [--claude] [--write <path> | --check <path>]` — serve the
+    /// toolchain-matched language reference. The canonical form is the committed
+    /// `THERMITE.skill.md`; `--claude` adds skill frontmatter. With no action the
+    /// selected form is printed to stdout.
+    Skill { claude: bool, action: SkillAction },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum SkillAction {
+    Print,
+    Write(PathBuf),
+    Check(PathBuf),
 }
 
 /// The default generated-clause count for `forge tv --generated` (REQ-3 / AC-7).
@@ -555,16 +566,16 @@ enum CheckLevel {
 }
 
 /// Parse `argv[1..]` (the arguments after the program name) into a [`Command`]
-/// (REQ-2 — hand-rolled, no derive macro). The v0.1 grammar is
-/// `new <name>` | `check <file> [--json]`. An unknown verb, a missing
-/// positional, or an unexpected flag is a `ForgeError::Usage`, never a panic.
+/// (REQ-2 — hand-rolled, no derive macro). Top-level names come from
+/// [`ForgeMethod`]; detailed flags remain local to each branch. Bad input is a
+/// [`ForgeError::Usage`], never a panic.
 fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
     let mut iter = args.iter();
-    let verb = iter
-        .next()
-        .ok_or_else(|| ForgeError::Usage(usage_text().to_string()))?;
-    match verb.as_str() {
-        "new" => {
+    let verb = iter.next().ok_or_else(|| ForgeError::Usage(usage_text()))?;
+    let method = ForgeMethod::parse(verb)
+        .ok_or_else(|| ForgeError::Usage(format!("unknown command `{verb}`.\n{}", usage_text())))?;
+    match method {
+        ForgeMethod::New => {
             let name = iter
                 .next()
                 .ok_or_else(|| ForgeError::Usage("`forge new` requires a <name>".to_string()))?;
@@ -577,7 +588,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 name: name.to_string(),
             })
         }
-        "check" => {
+        ForgeMethod::Check => {
             let mut file: Option<PathBuf> = None;
             let mut json = false;
             let mut level = CheckLevel::L3;
@@ -711,7 +722,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 engine,
             })
         }
-        "audit" => {
+        ForgeMethod::Audit => {
             // `forge audit <file> [--json]` (#15; `.design/forge/audit-manifest.md`
             // REQ-2). The canonical audit deliverable runs at the pinned default
             // config (OQ-3 — the reproducible trust statement), so this verb takes
@@ -759,7 +770,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 metrics,
             })
         }
-        "repair" => {
+        ForgeMethod::Repair => {
             // `forge repair <file> [item] [--json]` (#18;
             // `.design/forge/proof-repair.md` REQ-1). The first positional is the
             // file (required); an optional second positional restricts repair to a
@@ -794,7 +805,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
             })?;
             Ok(Command::Repair { file, item, json })
         }
-        "review" => {
+        ForgeMethod::Review => {
             // `forge review <file> [item] [--json] [--reviewer <cmd>]` (#19;
             // `.design/forge/spec-review.md` REQ-7). The first positional is the
             // file (required); an optional second positional restricts the artifact
@@ -852,7 +863,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 reviewer,
             })
         }
-        "build" => {
+        ForgeMethod::Build => {
             // `forge build <file> [--entry <fn>] [--json] [--sandbox|--no-sandbox]
             // [--sandbox-self-test]` (#56/#57; `.design/forge/build.md` REQ-1/REQ-3 +
             // `.design/forge/runtime-sandbox.md` REQ-4/REQ-6). The first positional is
@@ -954,7 +965,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 target,
             })
         }
-        "tv" => {
+        ForgeMethod::Tv => {
             // `forge tv <file> [--generated [N]] [--json]` (#144;
             // `.design/verified/contract-tv.md` REQ-5). The first positional is the
             // file (required). `--generated` opts into the off-corpus generated run
@@ -1020,7 +1031,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 seed,
             })
         }
-        "exec-tv" => {
+        ForgeMethod::ExecTv => {
             // `forge exec-tv <file> [--generated [N]] [--no-generated] [--json]`
             // (#154/#156; `.design/verified/exec-tv.md` REQ-5). The first positional
             // is the file (required). The off-corpus generated run is the primary
@@ -1073,7 +1084,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 generated,
             })
         }
-        "strat-tv" => {
+        ForgeMethod::StratTv => {
             // `forge strat-tv [--generated [N]] [--seed <u64>] [--json]`
             // (`.design/stage2-stratified-cage.md` REQ-4 / AC-4). No file positional —
             // the clause source is the deterministic generator, not a corpus program.
@@ -1118,7 +1129,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 seed,
             })
         }
-        "strat-faithful-tv" => {
+        ForgeMethod::StratFaithfulTv => {
             // `forge strat-faithful-tv [--generated [N]] [--seed <u64>] [--json]`
             // (`.design/stage2-stratified-cage.md` REQ-8 / AC-8). The two-phase TV sweep
             // over generated stratified clauses, reporting the phase split + the trust
@@ -1162,7 +1173,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 seed,
             })
         }
-        "g2-gate" => {
+        ForgeMethod::G2Gate => {
             // `forge g2-gate --axiom-probe <0|1> --doc-drift <0|1> --differential <0|1>
             // --two-phase <0|1> [--json]` (`.design/stage2-stratified-cage.md` REQ-9 /
             // AC-9). Each of the four flags takes a 0/1 (or pass/fail / true/false)
@@ -1223,7 +1234,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 two_phase: two_phase.ok_or_else(|| missing("--two-phase"))?,
             })
         }
-        "body-tv" => {
+        ForgeMethod::BodyTv => {
             // `forge body-tv <file> [--json]` (#162; `.design/verified/exec-stmt-tv.md`
             // REQ-5 + `.design/verified/loop-tv.md` REQ-5). The first positional is the
             // file (required). Like the other deeper-audit verbs, it runs at the pinned
@@ -1253,7 +1264,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
             })?;
             Ok(Command::BodyTv { file, json })
         }
-        "goal" | "battery" => {
+        ForgeMethod::Goal | ForgeMethod::Battery => {
             // `forge goal <file> [item]` / `forge battery <file> [item]` (#193
             // increment (i); `.design/forge/goal-repl.md` REQ-1/REQ-2). The first
             // positional is the file (required); an optional second positional
@@ -1264,7 +1275,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
             for arg in iter {
                 match arg.as_str() {
                     // `--proof` is the forge-tier proof view, a `goal`-only flag (REQ-7).
-                    "--proof" if verb == "goal" => proof = true,
+                    "--proof" if method == ForgeMethod::Goal => proof = true,
                     flag if flag.starts_with("--") => {
                         return Err(ForgeError::Usage(format!("unknown flag `{flag}`")));
                     }
@@ -1285,13 +1296,13 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
             let file = file.ok_or_else(|| {
                 ForgeError::Usage(format!("`forge {verb}` requires a <file> [item]"))
             })?;
-            if verb == "goal" {
+            if method == ForgeMethod::Goal {
                 Ok(Command::Goal { file, item, proof })
             } else {
                 Ok(Command::Battery { file, item })
             }
         }
-        "edit" => {
+        ForgeMethod::Edit => {
             // `forge edit <file> <addr> --replace <code>` (#193 increment (ii);
             // `.design/forge/goal-repl.md` REQ-3). Two required positionals (the
             // file then the semantic address) + the required `--replace <code>`
@@ -1379,7 +1390,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
                 replace,
             })
         }
-        "fill" => {
+        ForgeMethod::Fill => {
             // `forge fill <file> <hole-addr> <code>` (#193 increment (iii);
             // `.design/forge/goal-repl.md` REQ-6). Three required positionals: the
             // file, the `<fn>.?N` hole address, and the fill code (a single token;
@@ -1425,7 +1436,7 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
             })?;
             Ok(Command::Fill { file, addr, code })
         }
-        "smt-export" => {
+        ForgeMethod::SmtExport => {
             // `forge smt-export [<file>] [--out <path>]` (stage-3 REQ-7 / AC-8). An
             // optional file positional and an optional `--out` path; no file means the
             // canonical demo batch. A missing `--out` value is a Usage error.
@@ -1455,27 +1466,51 @@ fn parse_args(args: &[String]) -> Result<Command, ForgeError> {
             }
             Ok(Command::SmtExport { file, out })
         }
-        other => Err(ForgeError::Usage(format!(
-            "unknown command `{other}`. {}",
-            usage_text()
-        ))),
+        ForgeMethod::Skill => {
+            let mut claude = false;
+            let mut action: Option<SkillAction> = None;
+            while let Some(arg) = iter.next() {
+                match arg.as_str() {
+                    "--claude" => claude = true,
+                    "--write" | "--check" => {
+                        if action.is_some() {
+                            return Err(ForgeError::Usage(
+                                "`forge skill` accepts only one of `--write` or `--check`"
+                                    .to_string(),
+                            ));
+                        }
+                        let path = iter.next().ok_or_else(|| {
+                            ForgeError::Usage(format!("`{arg}` requires a <path>"))
+                        })?;
+                        action = Some(if arg == "--write" {
+                            SkillAction::Write(PathBuf::from(path))
+                        } else {
+                            SkillAction::Check(PathBuf::from(path))
+                        });
+                    }
+                    flag if flag.starts_with('-') => {
+                        return Err(ForgeError::Usage(format!("unknown flag `{flag}`")));
+                    }
+                    positional => {
+                        return Err(ForgeError::Usage(format!(
+                            "`forge skill` takes no positional arguments; unexpected \
+                             `{positional}`"
+                        )));
+                    }
+                }
+            }
+            let action = match action {
+                Some(action) => action,
+                None => SkillAction::Print,
+            };
+            Ok(Command::Skill { claude, action })
+        }
     }
 }
 
-/// The usage banner (REQ-1: the v0.1 verb subset).
-fn usage_text() -> &'static str {
-    "usage: forge new <name> | forge check <file> [--json] [--level l2|l3] [--rlimit <FLOAT>] \
-     [--mutation-floor <FLOAT>] [--engine verus|lean|auto|nlsat] | forge audit <file> [--json] \
-     [--meaning] | \
-     forge repair <file> [item] [--json] \
-     | forge review <file> [item] [--json] [--reviewer <cmd>] | forge build <file> [--entry <fn>] \
-     [--out <PATH>] [--target std|kernel] [--json] [--no-sandbox] [--sandbox-self-test] | forge tv \
-     <file> \
-     [--generated [N]] [--seed <u64>] [--json] | forge exec-tv <file> [--generated [N]] [--no-generated] \
-     [--json] | forge body-tv <file> [--json] | forge goal <file> [item] [--proof] | forge \
-     battery <file> [item] | forge edit <file> <addr> --replace <code> | forge edit \
-     --restratify [--json] | forge fill <file> \
-     <hole-addr> <code> | forge smt-export [<file>] [--out <PATH>]"
+/// The usage banner generated from the same method registry as the skill.
+fn usage_text() -> String {
+    forge_usage()
 }
 
 /// The entry boundary (`.design/forge/cli.md` Architecture): reads `argv`,
@@ -1576,6 +1611,56 @@ fn dispatch(args: &[String]) -> Result<ExitCode, ForgeError> {
         Command::Fill { file, addr, code } => run_fill(&file, &addr, &code),
         Command::Restratify { json } => run_restratify(json),
         Command::SmtExport { file, out } => run_smt_export(file.as_deref(), out.as_deref()),
+        Command::Skill { claude, action } => run_skill(claude, action),
+    }
+}
+
+/// Serve the language reference that matches this Forge binary.
+fn run_skill(claude: bool, action: SkillAction) -> Result<ExitCode, ForgeError> {
+    let content = if claude {
+        generate_claude()
+    } else {
+        generate()
+    };
+    match action {
+        SkillAction::Print => {
+            print!("{content}");
+            Ok(ExitCode::SUCCESS)
+        }
+        SkillAction::Write(path) => {
+            if let Some(parent) = path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(parent).map_err(|source| ForgeError::Io {
+                        path: parent.display().to_string(),
+                        source,
+                    })?;
+                }
+            }
+            std::fs::write(&path, content).map_err(|source| ForgeError::Io {
+                path: path.display().to_string(),
+                source,
+            })?;
+            println!("wrote {}", path.display());
+            Ok(ExitCode::SUCCESS)
+        }
+        SkillAction::Check(path) => {
+            let existing = std::fs::read_to_string(&path).map_err(|source| ForgeError::Io {
+                path: path.display().to_string(),
+                source,
+            })?;
+            if existing == content {
+                println!("skill is current: {}", path.display());
+                Ok(ExitCode::SUCCESS)
+            } else {
+                eprintln!(
+                    "skill is stale: {}; refresh it with `forge skill{} --write {}`",
+                    path.display(),
+                    if claude { " --claude" } else { "" },
+                    path.display()
+                );
+                Ok(ExitCode::from(EXIT_VERIFICATION_FAILURE))
+            }
+        }
     }
 }
 
@@ -3339,6 +3424,39 @@ mod tests {
                 engine: check::EngineSelection::Auto,
             })
         );
+    }
+
+    #[test]
+    fn parses_skill_modes() {
+        assert_eq!(
+            parse_args(&argv(&["skill"])).ok(),
+            Some(Command::Skill {
+                claude: false,
+                action: SkillAction::Print,
+            })
+        );
+        assert_eq!(
+            parse_args(&argv(&["skill", "--claude", "--write", "SKILL.md"])).ok(),
+            Some(Command::Skill {
+                claude: true,
+                action: SkillAction::Write(PathBuf::from("SKILL.md")),
+            })
+        );
+        assert_eq!(
+            parse_args(&argv(&["skill", "--check", "THERMITE.skill.md"])).ok(),
+            Some(Command::Skill {
+                claude: false,
+                action: SkillAction::Check(PathBuf::from("THERMITE.skill.md")),
+            })
+        );
+        assert!(matches!(
+            parse_args(&argv(&["skill", "--write", "one.md", "--check", "two.md"])),
+            Err(ForgeError::Usage(_))
+        ));
+        assert!(matches!(
+            parse_args(&argv(&["skill", "--write"])),
+            Err(ForgeError::Usage(_))
+        ));
     }
 
     // Stage-2 REQ-7 (`.design/stage2-stratified-cage.md` REQ-7 / AC-7): `forge edit

--- a/forge/src/manifest.rs
+++ b/forge/src/manifest.rs
@@ -184,20 +184,22 @@ fn scope_is_end_to_end(scope: &Option<AssuranceScope>) -> bool {
 /// push-button, *every failure a concrete countermodel* (finite structure, integer
 /// point, or bit pattern), never degraded. RUNG and TRUST BASE are orthogonal axes:
 /// the rung records refutation quality; what is trusted is recorded separately per
-/// clause in the engine attribution. Two L4 routes exist today, same rung, different
+/// clause in the engine attribution. Three L4 route families exist today, same rung,
+/// different
 /// trust bases:
 ///
 /// - the **nlsat real-relaxation** discharge (Stage-1 REQ-8, `--engine nlsat`):
 ///   trust `solver(nlsat) + spine-lemma(kernel)`, the ℝ→ℤ bridge sound by the
 ///   kernel-checked `r_relax_sound` + `rencode_sound` (`lean/Thermite/Relax.lean`);
-/// - the **`@bv` machine-width** discharge (Stage-3 REQ-2, `--engine bv`): trust
-///   `solver(Z3 QF_BV)`, kernel-grounded by REQ-7/8 reconstruction at the same rung.
+/// - the **`@bv` machine-width** discharge (Stage-3 REQ-2, `--engine bv`): QF_BV
+///   solving followed by checked reconstruction of the actual clause theorem;
+/// - admitted **finite relation/sequence** clauses (Stage 4): grounded SAT/LRAT
+///   reconstruction and Lean replay, with false clauses returning finite models.
 ///
 /// (The general Verus/Z3 cage still certifies at L3 in code pending its own promotion
 /// — a follow-up; the RFC ladder eventually places the whole decidable cage at L4.)
-/// Adding L4 is additive: the v1 conformance corpus stays at L3 (the L4 routes are new
-/// engine routes reached only via `--engine nlsat`/`--engine bv`, never the default
-/// Verus path), so the v1 `oracle_subset` is byte-identical.
+/// Automatic CLI routing overlays eligible BV and EPR reconstruction on the base
+/// engine path; explicit engine flags remain diagnostic overrides.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Level {
     /// L0 — unverified / `#[slag]` escape hatch (§6, §8).
@@ -211,12 +213,9 @@ pub enum Level {
     L3,
     /// L4 — CAGED (RFC-1 §2): decidable, push-button, every failure a concrete
     /// countermodel; never degraded. The rung is refutation quality; the trust base is
-    /// recorded separately per clause. Two routes today (same rung, different trust):
-    /// nlsat real-relaxation (`--engine nlsat`, trust `solver(nlsat) +
-    /// spine-lemma(kernel)`, `r_relax_sound`); and `@bv` machine-width (`--engine bv`,
-    /// trust `solver(Z3 QF_BV)`, kernel-grounded by REQ-7/8 at the same rung). Above L3
-    /// on the ladder; reached only by these new engine routes, so v1 items are
-    /// unperturbed.
+    /// recorded separately per clause. Current routes cover nlsat real-relaxation,
+    /// reconstructed fixed-width BV, and reconstructed finite relation/sequence
+    /// clauses. Above L3 on the ladder.
     L4,
 }
 

--- a/thermite-design.md
+++ b/thermite-design.md
@@ -47,7 +47,7 @@ A Thermite artifact ships with a certificate: the implementation satisfies these
 │  Forge (toolchain + goal-state REPL)           │   the agent's actual interface
 ├────────────────────────────────────────────────┤
 │  Verification ladder                           │
-│   L4  kernel-grounded    (nlsat + spine lemma) │
+│   L4  checked cage       (relax / BV / EPR)    │
 │   L3  SMT proof          (Verus/Z3)            │
 │   L2  bounded check      (Kani/CBMC)           │
 │   L1  runtime contracts  (active all profiles) │
@@ -197,17 +197,23 @@ Builds, formatting, codegen, and check results are bit-reproducible given the sa
 
 | Level | Mechanism | Guarantee | Termination of the check |
 |---|---|---|---|
-| **L4** | Kernel-grounded (nlsat real-relaxation + spine lemma) | Contract holds for **all** inputs, soundness witnessed by a kernel-checked lemma | Not guaranteed → forge escalation |
-| **L3** | SMT proof (Verus-derived) | Contract holds for **all** inputs | Not guaranteed → budget + downgrade |
+| **L4** | Admitted decidable route with checked reconstruction (relaxation, fixed-width BV, or finite EPR) | Contract holds for **all** inputs; false clauses return a concrete real, bit-pattern, or finite-structure witness | Route-specific budget |
+| **L3** | Verus/Z3 or Lean proof | Contract holds for **all** inputs | Not guaranteed → budget + downgrade |
 | **L2** | Bounded model check (Kani-derived) | Contract holds for all inputs **up to bound** | Guaranteed |
 | **L1** | Runtime contract checks | Violations **detected at the call site**, in every build profile (not just debug) | Guaranteed |
 | **L0** | `#[slag]` | Nothing. Trusted by fiat | — |
 
 Rules:
 
-- L3 is the default target for every function; **L4** is the kernel-grounded rung the Stage-1 forge tier adds above it (RFC-1 / GH #2).
+- L3 is the default target for general functions. **L4** is the caged rung for
+  admitted decidable clauses whose result is checked through the route's
+  reconstruction path.
 - Downgrades are automatic, logged, and surfaced in the build manifest; upgrades are a standing background task.
 - **Out-of-cage clauses escalate UP to the forge, they do not degrade down.** A clause outside the v1 combinator cage is no longer lowered by inspection down the L3→L2→L1 ladder; it routes UP to the forge, where the relax route (REQ-8) discharges a relaxable polynomial clause via a direct Z3 nlsat (QF_NRA) query and certifies it at the kernel-grounded **L4** — its trust profile is `solver(nlsat) + spine-lemma(kernel)`, the real→integer soundness bridge being the kernel-checked spine lemmas `r_relax_sound` + `rencode_sound` (`lean/Thermite/Relax.lean`). A clause true over ℤ but false over ℝ is not refuted: the route yields a `RealWitness` carrying the real point, escalated to the forge as goal metadata (never a counterexample). (Authority: RFC-1 / GH #2; `.design/stage1-forge-tier.md` REQ-8.)
+- Plain `forge check` also routes eligible `@bvN` clauses and admitted finite
+  relation/array clauses through checked QF_BV or EPR reconstruction. They
+  certify at L4 only after replay of the actual `req → clause` obligation;
+  false clauses return concrete countermodels.
 - The certificate attached to a build artifact lists every function's level, every `#[slag]` block, and the contract-quality scores from §7. This manifest **is** the deliverable's trust statement.
 - **`#[slag]`, the L0 row, and L1 enforcement.** The L0 row measures assurance about the *body*: nothing is proved about the implementation — it is trusted by fiat. But a `#[slag]` function's *contract* is still mandatory and is enforced at runtime (§8), so its certificate carries level **L1** with a `slag: true` flag — `L1` because the contract is L1-checked at the call site, `slag` because the body is unproven. The L0 row therefore names the body-proof aspect (recorded by the `slag` flag), never an unchecked contract: slag exempts *proving*, never *stating and checking*. (`fx` effect rows are likewise enforced — at compile time in v0.1, at the syscall boundary later — independent of the proof level.)
 
@@ -273,7 +279,11 @@ Composition rule (the reason any of this scales): if `g` calls `f` only through 
 
 ## 10. The Skill is the Spec
 
-The canonical language definition is `THERMITE.skill.md`: the complete surface grammar, the SpecTherm combinator library with one example each, the Forge command set, the ladder semantics, and the slag rules — budgeted at **≤ 6,000 tokens, enforced in CI** (the skill is regenerated from the grammar and combinator registry; if it exceeds budget, the feature that pushed it over is reverted).
+The canonical language definition is `THERMITE.skill.md`: the complete surface
+grammar, SpecTherm library, Forge method set, ladder semantics, and slag rules,
+budgeted at **≤ 6,000 tokens and enforced in CI**. Grammar variants are
+compile-forced through exhaustive renderers; combinators, recursion schemes,
+and Forge methods come from the same registries their implementations consume.
 
 Consequences:
 
@@ -368,16 +378,10 @@ Certificate (excerpt of build manifest):
 }
 ```
 
-## Appendix B — Forge command surface (v0.1)
+## Appendix B — Forge method surface
 
-```
-forge new <name>                      create project (manifest, lockfile, skill pin)
-forge goal <item>                     print goal state for an item
-forge fill <hole-addr> <code>         fill a hole; returns new goal state
-forge edit <addr> --replace <code>    semantic edit by address
-forge check [item]                    run the ladder; returns per-obligation results
-forge battery [item]                  run vacuity battery + mutation scoring
-forge audit                           full slag + boundary + assurance inventory
-forge skill                           emit the canonical THERMITE.skill.md for this toolchain
-forge repair [item]                   background L1/L2 → L3 upgrade loop
-```
+The live method inventory is `thermite_skill::ForgeMethod::ALL`. Forge uses it
+to recognize top-level methods and render help; the skill generator uses the
+same records. Run `forge` for current synopses or `forge skill` for the
+toolchain-matched language reference. This avoids a second hand-maintained
+command list in the design document.

--- a/thermite-skill/src/generate.rs
+++ b/thermite-skill/src/generate.rs
@@ -21,11 +21,13 @@
 //! is rendered by an exhaustive `match` (no `_` wildcard) over the definitional
 //! enums `thermite_syntax::{Type,Expr,Item,Pattern,Effect}` (+ `BinOp`/
 //! `PrimType`), so a new variant fails TO compile until its skill arm is added
-//! (REQ-10 — the compiler is the freshness enforcer). The explanatory prose (the
-//! framing, the ladder, the slag rules, the forge verb table) stays curated,
+//! (REQ-10 — the compiler is the freshness enforcer). Section (3) iterates the
+//! shared [`ForgeMethod`] registry. The explanatory prose (the framing, ladder,
+//! and slag rules) stays curated,
 //! guarded by the freshness + budget tests (REQ-11). No I/O, no env, no
 //! wall-clock, no RNG — a pure function of the compiled-in text, the static
-//! registries, and the per-variant match arms (R-CODE-5).
+//! registries (including [`ForgeMethod::ALL`]), and the per-variant match arms
+//! (R-CODE-5).
 //!
 //! ## REQ status
 //!
@@ -90,6 +92,175 @@ pub fn token_count(s: &str) -> usize {
     (s.chars().count() * 2).div_ceil(7)
 }
 
+/// A public Forge method and the documentation shared by the CLI and skill.
+///
+/// The registry is declared once by `forge_methods!`. Forge resolves its first
+/// argument through [`ForgeMethod::parse`] and exhaustively dispatches the
+/// result; this generator iterates [`ForgeMethod::ALL`]. A newly registered
+/// method therefore becomes visible in help and the skill in the same build.
+macro_rules! forge_methods {
+    (
+        $(
+            $variant:ident {
+                name: $name:literal,
+                usage: $usage:literal,
+                purpose: $purpose:literal,
+            }
+        )+
+    ) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum ForgeMethod {
+            $($variant,)+
+        }
+
+        impl ForgeMethod {
+            pub const ALL: &'static [Self] = &[$(Self::$variant,)+];
+
+            pub const fn name(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name,)+
+                }
+            }
+
+            pub const fn usage(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $usage,)+
+                }
+            }
+
+            pub const fn purpose(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $purpose,)+
+                }
+            }
+
+            pub fn parse(name: &str) -> Option<Self> {
+                Self::ALL
+                    .iter()
+                    .copied()
+                    .find(|method| method.name() == name)
+            }
+        }
+    };
+}
+
+forge_methods! {
+    New {
+        name: "new",
+        usage: "forge new <name>",
+        purpose: "Create a pinned project.",
+    }
+    Check {
+        name: "check",
+        usage: "forge check <file> [--json] [--level l2|l3] [--rlimit FLOAT] [--mutation-floor FLOAT] [--engine auto|verus|lean|nlsat|forge|bv]",
+        purpose: "Certify; auto-routes eligible BV and EPR clauses.",
+    }
+    Audit {
+        name: "audit",
+        usage: "forge audit <file> [--json] [--meaning] [--metrics]",
+        purpose: "Show assurance, boundaries, meaning, and metrics.",
+    }
+    Repair {
+        name: "repair",
+        usage: "forge repair <file> [item] [--json]",
+        purpose: "Retry timeout-lowered items.",
+    }
+    Review {
+        name: "review",
+        usage: "forge review <file> [item] [--json] [--reviewer <cmd>]",
+        purpose: "Emit contracts for intent review.",
+    }
+    Build {
+        name: "build",
+        usage: "forge build <file> [--entry <fn>] [--out <path>] [--target std|kernel] [--json] [--no-sandbox] [--sandbox-self-test]",
+        purpose: "Build checked Rust; sandbox hosted executables.",
+    }
+    Tv {
+        name: "tv",
+        usage: "forge tv <file> [--generated [N]] [--seed <u64>] [--json]",
+        purpose: "Validate contract lowering.",
+    }
+    ExecTv {
+        name: "exec-tv",
+        usage: "forge exec-tv <file> [--generated [N]] [--no-generated] [--json]",
+        purpose: "Validate expression lowering.",
+    }
+    StratTv {
+        name: "strat-tv",
+        usage: "forge strat-tv [--generated N] [--seed <u64>] [--json]",
+        purpose: "Compare Rust and Lean cage classifiers.",
+    }
+    StratFaithfulTv {
+        name: "strat-faithful-tv",
+        usage: "forge strat-faithful-tv [--generated N] [--seed <u64>] [--json]",
+        purpose: "Run two-phase stratified validation.",
+    }
+    G2Gate {
+        name: "g2-gate",
+        usage: "forge g2-gate --axiom-probe 0|1 --doc-drift 0|1 --differential 0|1 --two-phase 0|1 [--json]",
+        purpose: "Combine the Stage 2 gate results.",
+    }
+    BodyTv {
+        name: "body-tv",
+        usage: "forge body-tv <file> [--json]",
+        purpose: "Validate statement and loop lowering.",
+    }
+    Goal {
+        name: "goal",
+        usage: "forge goal <file> [item] [--proof]",
+        purpose: "Show goals, witnesses, and holes.",
+    }
+    Battery {
+        name: "battery",
+        usage: "forge battery <file> [item]",
+        purpose: "Show vacuity and mutation results.",
+    }
+    Edit {
+        name: "edit",
+        usage: "forge edit <file> <addr> --replace <code> | forge edit --restratify [--json]",
+        purpose: "Edit by address or demonstrate restratification.",
+    }
+    Fill {
+        name: "fill",
+        usage: "forge fill <file> <hole-addr> <code>",
+        purpose: "Fill a body or proof hole.",
+    }
+    SmtExport {
+        name: "smt-export",
+        usage: "forge smt-export [<file>] [--out <path>]",
+        purpose: "Export Rust-to-Lean SMT obligations.",
+    }
+    Skill {
+        name: "skill",
+        usage: "forge skill [--claude] [--write <path> | --check <path>]",
+        purpose: "Print, write, or check this reference.",
+    }
+}
+
+/// Render the full Forge usage banner from the shared method registry.
+pub fn forge_usage() -> String {
+    let mut out = String::from("usage:\n");
+    for method in ForgeMethod::ALL {
+        out.push_str("  ");
+        out.push_str(method.usage());
+        out.push('\n');
+    }
+    out
+}
+
+/// Render a Claude Code skill by adding the required frontmatter to the
+/// canonical, toolchain-matched reference.
+pub fn generate_claude() -> String {
+    let mut out = String::from(
+        "---\n\
+name: thermite\n\
+description: Use when writing, checking, building, or reviewing Thermite programs with Forge.\n\
+---\n\n",
+    );
+    out.push_str(&generate());
+    out
+}
+
 /// Assemble the canonical `THERMITE.skill.md` as one deterministic `String`.
 ///
 /// The sections appear in `thermite-design.md` §10 order: (1) surface grammar,
@@ -99,7 +270,7 @@ pub fn token_count(s: &str) -> usize {
 /// over the `thermite_syntax` enums (REQ-10), (2) is registry-driven from
 /// `thermite_spec::all()` (REQ-2), (2b) is registry-driven from
 /// `thermite_spec::schemes::all()` (REQ-9); the curated prose (the framing, ladder,
-/// slag, forge verb table, the §6 forge-tier semantics) stays templated (REQ-11).
+/// slag, and §6 forge-tier semantics) stays templated (REQ-11).
 /// Pure: no I/O, no env, no clock, no RNG (REQ-1 / R-CODE-5 / AC-6).
 pub fn generate() -> String {
     let mut out = String::new();
@@ -114,35 +285,21 @@ pub fn generate() -> String {
     out
 }
 
-/// The skill preamble: title + the regeneration command (so an editor knows the
-/// file is generated and how to refresh it — REQ-5) + the "How to read this
-/// file / 60-second workflow" comprehension intro (curated prose, REQ-11; the
-/// cold-agent reader's entry point — write contract-first fn -> `forge check` ->
-/// read the per-obligation result -> fix or `?N`-hole it and work `goal`/`fill`).
+/// The short entry point for a reader who has not used Thermite before.
 const HEADER: &str = "\
-# THERMITE.skill.md
+# Thermite language and Forge reference
 
-The complete Thermite v0.1 surface language and toolchain, in one file. This is
-the canonical language definition (`thermite-design.md` §10): an agent reads it
-at session start and holds the entire language in context. It is GENERATED — do
-not edit by hand. Regenerate with:
+This generated file matches the toolchain that produced it. Do not edit it by
+hand; refresh it with `forge skill --write THERMITE.skill.md`. The canonical
+file stays below the 6,000-token CI budget.
 
-    cargo run -p thermite-skill -- --emit > THERMITE.skill.md
+Start with a contract-first `fn`: write `req`, `ens`, and `fx`, then its body.
+Run `forge check <file>`. Fix any concrete counterexample, or leave a `?0` hole
+and use `forge goal` and `forge fill`. A function with a hole never certifies.
 
-Budget: this file must stay under 6,000 tokens (a hard CI gate, design §2.2).
-
-## How to read this file — the 60-second workflow
-
-You write verified code. The loop: (1) write a `fn` CONTRACT-FIRST — `req`/`ens`/`fx`,
-THEN the body (§1); the contract is mandatory. (2) `forge check <file>` (§3) returns a
-PER-OBLIGATION result — each goal discharged or `Failed` with a CONCRETE
-counterexample (e.g. `lo=3, hi=3`), never a bare \"verification failed\". (3) Fix and
-re-check; or drop a HOLE `?0` (§1) and work `forge goal`/`forge fill` — a holed item
-never certifies.
-
-Map: §1 grammar, §2/§2b combinators + recursion schemes (the ONLY way to
-quantify/recurse), §3 Forge verbs, §4 the assurance ladder, §5 `#[slag]`, §6 the
-forge tier (verdicts, routing, covenants, proofs).
+Sections: grammar (§1), bounded combinators and recursion schemes (§2/§2b),
+Forge methods (§3), assurance levels (§4), `#[slag]` (§5), and the forge proof
+tier (§6).
 
 ";
 
@@ -1324,46 +1481,31 @@ The schemes (call shape, result, then one example each):
     s
 }
 
-/// Section (3) — the Forge command set. curated from `thermite-design.md`
-/// Appendix B (the v0.1 command surface) + §5.1 framing (REQ-3).
+/// Section (3) — the Forge method set from the shared registry.
 fn render_forge() -> String {
-    String::from(
+    let mut out = String::from(
         "\n\
-## 3. Forge command set
+## 3. Forge methods
 
-Forge is your interface — a goal-state REPL. Every reply inlines the source and
-returns a CONCRETE counterexample, not an adjective, when an obligation fails, and
-DEGRADES (L3 -> L2 -> L1) rather than blocking on a solver timeout. Day-to-day:
-`check`, `goal`/`fill` (work open holes), `build` (runnable binary).
-
-```
-forge new <name>                   create project (manifest, lockfile, skill pin)
-forge check [item]                 run the ladder; per-obligation results +
-                                   counterexamples (your primary verb)
-forge check --engine lean|auto|nlsat|forge   pick the engine (§6.2); disagree = HALT
-forge goal <item> [--proof]        goal state: given / want / open holes ?N
-                                   (--proof = the forge-tier proof view, §6.4)
-forge fill <fn>.?N <code>          splice code at hole ?N + re-check (may surface
-                                   new holes); proof holes ?pN too (§6.4)
-forge edit <addr> --replace <code> splice at any semantic address + re-check
-forge build [item] --entry <fn>    lower to Rust + rustc -> a native binary whose
-                                   contract checks fire at runtime, fx-sandboxed
-forge build --target kernel <file> freestanding no_std+alloc rlib (no main/seccomp,
-                                   panic=abort); ambient-syscall fx is REFUSED
-forge battery [item]               run vacuity battery + mutation scoring
-forge audit                        full slag + boundary + assurance inventory
-forge review <file> [item]         pluggable spec-intent review slot
-forge tv | exec-tv | body-tv <file>   translation-validate the CONTRACT / exec
-                                   EXPRESSION / exec BODY lowering vs the reference
-forge skill                        emit the canonical THERMITE.skill.md
-forge repair [item]                background L1/L2 -> L3 upgrade loop
-```
-
-Items and blocks have stable semantic addresses (`binary_search.loop#1.inv#2`,
-a hole is `<fn>.?N`); `edit`/`fill` take addresses, not string matches.
+Use `check` for normal certification, `goal`/`fill` for open holes, and `build`
+for artifacts. Failures carry witnesses; timeouts remain named resource events.
+Plain `check` automatically routes eligible fixed-width and finite EPR clauses
+through checked reconstruction.
 
 ",
-    )
+    );
+    for method in ForgeMethod::ALL {
+        out.push_str("- `");
+        out.push_str(method.usage());
+        out.push_str("` — ");
+        out.push_str(method.purpose());
+        out.push('\n');
+    }
+    out.push_str(
+        "\nItems and blocks have stable semantic addresses such as \
+`binary_search.loop#1.inv#2`; holes use `<fn>.?N` or `<fn>.?pN`.\n\n",
+    );
+    out
 }
 
 /// Section (4) — the ladder semantics. curated from `thermite-design.md` §6
@@ -1378,8 +1520,9 @@ Every function targets L3; downgrades are automatic, logged, and surfaced in the
 build manifest; upgrades are a standing background task. The certificate lists every
 function's level — this manifest IS the deliverable's trust statement.
 
-- L4 — KERNEL-grounded proof: the relax route's nlsat discharge, trust `solver(nlsat)
-  + spine-lemma(kernel)` (§6.2). The top rung, above L3.
+- L4 — admitted, decidable clauses with checked reconstruction: nonlinear
+  relaxation, fixed-width BV, and finite EPR relation/array clauses. Failures
+  carry a real, bit-pattern, or finite-structure witness.
 - L3 — machine proof (Verus/Z3, or Lean via `--engine`): holds for ALL inputs. Not
   guaranteed to terminate -> solver budget + automatic downgrade.
 - L2 — bounded model check (Kani/CBMC): holds for all inputs UP TO a bound (stated
@@ -1456,73 +1599,50 @@ fn render_forge_tier() -> String {
         "\
 ## 6. Forge tier (Stage-1)
 
-Beyond exec contracts the forge proves PROPOSITIONS. Forge items: `prop fn` (a bool
-spec predicate), `lemma N(..) req .. ens .. { proof }`, `proof for f` (discharge one
-`ens#k` of an exec `fn`), and `witness { .. }` covenants.
+The forge tier proves propositions as `prop fn`, `lemma`, or `proof for f`
+items. A `witness` block gives its covenant.
 
 ### 6.1 The seven verdicts
 
-`forge check` settles every clause to ONE of seven cert-level verdicts (a closed
-set; no \"Unknown\" survives into a cert). What each means, and your move:
+Every clause receives one final verdict:
 
-- **Proved** — holds for ALL inputs at the clause's level. Done.
-- **Counterexample** — a witnessed countermodel with concrete inputs (e.g. `lo=3,
-  hi=3`). Hard fail, never degrades — fix the body or the contract.
-- **RealWitness** — the `ens` is false over the REALS (a real point, e.g. √2) though
-  it may hold over ℤ; escalated UP to you, never downgraded to a Counterexample. Add
-  the integrality `req` so the relaxation can't reach it.
-- **CovenantRefuted** — a `falsify` input refuted the covenant: the carried
-  counterexample IS the bug. Hard fail — fix the body/contract, never weaken `falsify`.
-- **Stuck** — the proof elaborated but left a residual `⊢ goal`; it carries the goal +
-  a missing-bridge hint. Add the named simp bridge from the frozen battery and re-check.
-- **KernelBudget** — Lean's kernel/elaboration budget (heartbeats) was exhausted: a
-  budget event, NOT a refutation. Split the lemma or shrink the proof.
-- **Timeout** — the SMT solver hit its rlimit: a resource event, not a refutation.
-  Lower the goal or raise `--rlimit`.
+- **Proved** — holds at the stated level.
+- **Counterexample** — concrete failing inputs; fix code or contract.
+- **RealWitness** — false over the reals but possibly true over integers; add the
+  missing integrality `req`.
+- **CovenantRefuted** — `falsify` found a contract violation.
+- **Stuck** — Lean left a residual `⊢ goal`; add the named bridge.
+- **KernelBudget** — Lean exhausted its budget; split or shrink the proof.
+- **Timeout** — SMT exhausted its rlimit; simplify or raise `--rlimit`.
 
 ### 6.2 Routing + per-clause attribution
 
-Each clause routes by its SHAPE; the cert attributes `engine`/`trust`/`verdict` PER
-CLAUSE, so you read which machine carried it at what trust:
+Certificates record `engine`, `trust`, and `verdict` per clause:
 
-- a RELAXABLE polynomial clause — universal over integer-scalar params, atoms from
-  only `+ - *`, comparisons, and `&&`/`||` (NO `/ % << >> & | ^`, no `as`) → the
-  **nlsat** engine (Z3 QF_NRA), at **L4** (`solver(nlsat) + spine-lemma(kernel)` —
-  the kernel-checked real→ℤ bridge).
-- an in-cage v1 contract → **verus**, at **L3** (an SMT solver proof).
-- a `lemma` / `proof for` → the **lean** engine, at **L3** (the Lean-kernel base).
+- relaxable integer polynomials → **nlsat** plus the kernel-checked real-to-integer
+  bridge, at **L4**;
+- an `@bvN` fixed-width clause → QF_BV solving plus Lean replay of the actual
+  theorem, at **L4**; false returns a bit pattern;
+- an admitted finite S₂.0 relation/sequence clause → grounded SAT plus LRAT and
+  Lean replay, at **L4**; false returns a finite model;
+- an ordinary in-cage contract → **verus**, at **L3**;
+- a `lemma` or `proof for` item → **lean**, at **L3**.
 
-`--engine forge` drives this hybrid per-clause route end to end; `--engine
-nlsat|verus|lean` pins a single engine.
+Plain `forge check` uses automatic routing. `--engine
+auto|nlsat|verus|lean|forge|bv` selects a diagnostic override.
 
 ### 6.3 Covenant authoring
 
-A `witness { inhabit (..); falsify N; }` block covenants the `fn` it immediately
-FOLLOWS in source order — the covenant-BEFORE-burn gate: a forge-routed `fn` must
-PASS its covenant before any proof is attempted (structural).
-
-- `inhabit (args)` — an author-stated witness that `req` is inhabited. At least ONE
-  is MANDATORY; each tuple's arity + types must match the params, and each must
-  SATISFY `req` (an `inhabit` that fails `req` is a loud author error, refused before
-  burn).
-- `falsify N` — draw N inputs from the deterministic SplitMix64 generator (default
-  fixed-seed `falsify 50_000`), run each body, check the contract. A `req`-satisfying
-  input whose body breaks `ens` is a **CovenantRefuted** hit, carried into the cert.
-
-A covenant that refutes — or whose `inhabit` set is missing, ill-typed, or
-`req`-violating — blocks the burn: you never prove a `fn` whose witnesses already
-break it.
+`witness { inhabit (args); falsify N; }` follows the function it covenants.
+At least one well-typed `inhabit` tuple must satisfy `req`. `falsify N` checks a
+deterministic sample; any violation yields **CovenantRefuted** and blocks proof.
 
 ### 6.4 Forge-tier verbs + the burn receipt
 
-- `forge goal <f> --proof` — the PROOF VIEW of a forge-routed goal (`lemma` / `proof
-  for f`): its hypotheses in scope, the `⊢ goal`, and any open `?pN` PROOF holes.
-- `forge fill <f>.?pN <proof>` — splice proof text at a `?pN` proof hole and re-check
-  (the proof analogue of body-hole `fill`; may surface new `?pN`).
-- closing an L3/L4 goal attaches a **burn receipt** to the cert: the lexer-token
-  count of the committed proof, the lemmas it cited, and (optionally) the LLM
-  authoring spend. It records HOW MUCH proof was spent, never WHAT was proved —
-  oracle-excluded, so it never changes the verdict.
+- `forge goal <f> --proof` shows hypotheses, the goal, and open `?pN` holes.
+- `forge fill <f>.?pN <proof>` fills a proof hole and re-checks.
+- A closed L3/L4 goal gets a **burn receipt** recording proof size and cited
+  lemmas. This metadata never changes the verdict.
 ",
     )
 }
@@ -1651,21 +1771,14 @@ mod tests {
 
     #[test]
     fn grammar_forge_slag_coverage() {
-        // AC-4: forge verbs, slag fields, grammar keywords (expected strings
-        // derived from Appendix B / §8 / §4).
+        // AC-4: every shared Forge method, slag fields, and grammar keywords.
         let skill = generate();
-        for verb in [
-            "forge new",
-            "forge goal",
-            "forge fill",
-            "forge edit",
-            "forge check",
-            "forge battery",
-            "forge audit",
-            "forge skill",
-            "forge repair",
-        ] {
-            assert!(skill.contains(verb), "skill is missing `{verb}`");
+        for method in ForgeMethod::ALL {
+            assert!(
+                skill.contains(method.usage()),
+                "skill is missing `{}`",
+                method.usage()
+            );
         }
         for field in ["reason", "owner", "review"] {
             assert!(

--- a/thermite-skill/src/lib.rs
+++ b/thermite-skill/src/lib.rs
@@ -21,4 +21,6 @@
 
 pub mod generate;
 
-pub use generate::{generate, token_count, SKILL_TOKEN_BUDGET};
+pub use generate::{
+    forge_usage, generate, generate_claude, token_count, ForgeMethod, SKILL_TOKEN_BUDGET,
+};

--- a/thermite-skill/tests/skill.rs
+++ b/thermite-skill/tests/skill.rs
@@ -6,7 +6,9 @@
 //! list, the §8 slag fields, and the registry itself; never literals copied back
 //! from the generator).
 
-use thermite_skill::{generate, token_count, SKILL_TOKEN_BUDGET};
+use thermite_skill::{
+    forge_usage, generate, generate_claude, token_count, ForgeMethod, SKILL_TOKEN_BUDGET,
+};
 
 /// AC-1 — the generated skill is under the §2.2 hard budget (6,000 tokens),
 /// with the real measured headroom reported on success for the grader.
@@ -234,18 +236,17 @@ fn ladder_levels_and_slag_clarification_present() {
 #[test]
 fn forge_slag_grammar_markers_present() {
     let skill = generate();
-    for verb in [
-        "forge new",
-        "forge goal",
-        "forge fill",
-        "forge edit",
-        "forge check",
-        "forge battery",
-        "forge audit",
-        "forge skill",
-        "forge repair",
-    ] {
-        assert!(skill.contains(verb), "skill is missing forge verb `{verb}`");
+    for method in ForgeMethod::ALL {
+        assert!(
+            skill.contains(method.usage()),
+            "skill is missing Forge method `{}`",
+            method.name()
+        );
+        assert!(
+            skill.contains(method.purpose()),
+            "skill is missing the purpose for Forge method `{}`",
+            method.name()
+        );
     }
     for field in ["reason", "owner", "review"] {
         assert!(
@@ -256,6 +257,32 @@ fn forge_slag_grammar_markers_present() {
     for kw in ["req", "ens", "fx", "inv", "dec", "spec fn", "#[slag]"] {
         assert!(skill.contains(kw), "skill is missing grammar marker `{kw}`");
     }
+}
+
+#[test]
+fn forge_registry_drives_usage_and_has_unique_names() {
+    let usage = forge_usage();
+    let mut names = std::collections::BTreeSet::new();
+    for method in ForgeMethod::ALL {
+        assert!(
+            names.insert(method.name()),
+            "duplicate Forge method `{}`",
+            method.name()
+        );
+        assert!(
+            usage.contains(method.usage()),
+            "usage is missing `{}`",
+            method.usage()
+        );
+    }
+}
+
+#[test]
+fn claude_format_wraps_the_canonical_skill() {
+    let claude = generate_claude();
+    assert!(claude.starts_with("---\nname: thermite\ndescription: "));
+    assert!(claude.contains("\n---\n\n# Thermite language and Forge reference\n"));
+    assert!(claude.ends_with(&generate()));
 }
 
 /// AC-5 — the committed repo-root `THERMITE.skill.md` is byte-identical to
@@ -272,7 +299,7 @@ fn committed_skill_is_fresh() {
         committed,
         generate(),
         "committed THERMITE.skill.md is stale; regenerate with \
-         `cargo run -p thermite-skill -- --emit > THERMITE.skill.md`"
+         `cargo run -p forge -- skill --write THERMITE.skill.md`"
     );
 }
 

--- a/thermite2-semantics.md
+++ b/thermite2-semantics.md
@@ -9,6 +9,12 @@
 
 # Thermite 2 — Stage-1 normative semantics
 
+> This document freezes the Stage-1 increment. Later stages add checked QF_BV
+> and finite EPR relation/array reconstruction at L4 and make eligible routes
+> automatic; see [thermite-design.md §6](thermite-design.md#6-the-verification-ladder)
+> and [the Stage 4 design](.design/stage4-epr-reconstruction.md) for the live
+> ladder.
+
 This document is the one authoritative place the shipped Stage-1 forge-tier
 semantics live. It consolidates the conventions that were stated across module
 headers in `forge/src/`, `lean/Thermite/`, and `thermite-lower/src/` into one


### PR DESCRIPTION
## What changed

- rewrote the README into a shorter, task-oriented guide with complete installation instructions for the Rust-only build and the full Verus, Lean, solver, G4, and optional Kani proof stack
- implemented `forge skill` with print, write, freshness-check, and Claude Code output modes
- introduced a shared Forge method registry that drives top-level parsing, usage text, and the generated skill command reference
- regenerated `THERMITE.skill.md`, reduced it to 5,385 of the 6,000 estimated-token budget, and added a generated Claude Code form
- updated the rationale, overview, language design, semantics scope notes, code comments, and governed design documents to reflect current automatic BV/EPR routing and L4 reconstruction
- repinned every affected documentation-drift tripwire

## Why

The README had become difficult to scan and did not explain how to install the complete proof-bearing toolchain. The generated skill also advertised a `forge skill` command that did not exist, while its hand-maintained Forge method list had drifted behind the CLI. This makes installation reproducible and gives the CLI and generated reference one command inventory.

Crosslink remains optional issue/session infrastructure and is explicitly not a Thermite build dependency.

## Validation

- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `lake build` — 1,153 jobs, no `sorry` warnings
- `bash scripts/g4-gate.sh` — all six stages passed
- documentation drift, requirement registry, control-plane, README link, skill freshness, and token-budget checks
